### PR TITLE
remove collectEmail field from away message response

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/models/KmAwayMessageResponse.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/models/KmAwayMessageResponse.java
@@ -30,16 +30,7 @@ public class KmAwayMessageResponse extends JsonMarker {
     }
 
     public class KmDataResposne extends JsonMarker {
-        private boolean collectEmail;
         private List<KmMessageResponse> messageList;
-
-        public boolean isCollectEmail() {
-            return collectEmail;
-        }
-
-        public void setCollectEmail(boolean collectEmail) {
-            this.collectEmail = collectEmail;
-        }
 
         public List<KmMessageResponse> getMessageList() {
             return messageList;


### PR DESCRIPTION
* The collectEmail Field used to be boolean earlier, now it is coming as number. Due to this the away message is broken. Adding this commit will fix the away message for android only for this update and above. The previous version will still have the away message broken.

* This was tested on the local device
