### PR TITLE
fix duplicate message issue when creating a new conversation

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3363,15 +3363,13 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
             }
 
             for (Message message : nextMessageList) {
+                if (initial && !messageList.contains(message)) {
+                    messageList.add(message);
+                }
                 selfDestructMessage(message);
             }
 
             if (initial) {
-                for (Message message : nextMessageList) {
-                    if (!messageList.contains(message)) {
-                        messageList.add(message);
-                    }
-                }
                 recyclerDetailConversationAdapter.searchString = searchString;
                 emptyTextView.setVisibility(messageList.isEmpty() ? VISIBLE : View.GONE);
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3367,7 +3367,11 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
             }
 
             if (initial) {
-                messageList.addAll(nextMessageList);
+                for (Message message : nextMessageList) {
+                    if (!messageList.contains(message)) {
+                        messageList.add(message);
+                    }
+                }
                 recyclerDetailConversationAdapter.searchString = searchString;
                 emptyTextView.setVisibility(messageList.isEmpty() ? VISIBLE : View.GONE);
 


### PR DESCRIPTION
* When the message is already present through MQTT/ FCM, and the sync call goes simultaneously for the same message, the list contains duplicate entries for that message. This happens when creating and launching the conversation simultaneously.
* This is tested on local device with several conversations.