### PR TITLE
Fix rich message repeating issue

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1064,11 +1064,11 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     }
 
     public static boolean isEmailTypeMessage(Message message) {
-        return isHtmlTypeMessage(message) && message.getSource() == 7;
+        return message.getSource() == 7;
     }
 
     public static boolean isHtmlTypeMessage(Message message) {
-        return Message.ContentType.TEXT_HTML.getValue().equals(message.getContentType());
+        return Message.ContentType.TEXT_HTML.getValue().equals(message.getContentType()) || isEmailTypeMessage(message);
     }
 
     private void setupContactShareView(final Message message, MyViewHolder myViewHolder) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -591,6 +591,12 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                     if (isHtmlTypeMessage(message)) {
                         if (myHolder.viaEmailView != null) {
                             myHolder.viaEmailView.setVisibility(isEmailTypeMessage(message) ? View.VISIBLE : GONE);
+
+                            if (message.isTypeOutbox()) {
+                                myHolder.viaEmailView.setTextColor(context.getResources().getColor(R.color.white));
+                            } else {
+                                myHolder.viaEmailView.setTextColor(context.getResources().getColor(R.color.km_via_email_text_color));
+                            }
                         }
                         if (myHolder.emailLayout != null) {
                             myHolder.emailLayout.setVisibility(View.VISIBLE);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/AlRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/AlRichMessage.java
@@ -102,7 +102,7 @@ public class AlRichMessage {
             faqReplyLayout.setVisibility(View.GONE);
             quickRepliesRecycler.setVisibility(View.VISIBLE);
             setUpGridView(quickRepliesRecycler, model);
-        } else {
+        } else if (model.getTemplateId() > 0) {
             listItemlayout.setVisibility(View.GONE);
             recyclerView.setVisibility(View.VISIBLE);
             faqLayout.setVisibility(View.GONE);
@@ -113,6 +113,8 @@ public class AlRichMessage {
             recyclerView.setLayoutManager(layoutManager);
             ALRichMessageAdapter adapter = new ALRichMessageAdapter(context, model, listener, message);
             recyclerView.setAdapter(adapter);
+        } else {
+            containerView.setVisibility(View.GONE);
         }
     }
 

--- a/kommunicateui/src/main/res/layout/mobicom_sent_message_list_view.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_sent_message_list_view.xml
@@ -34,6 +34,21 @@
             <include layout="@layout/reply_message_layout" />
 
             <TextView
+                android:id="@+id/via_email_text_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:drawableStart="@drawable/forward"
+                android:drawableLeft="@drawable/forward"
+                android:drawablePadding="7dp"
+                android:fontFamily="sans-serif-light"
+                android:letterSpacing="0.04"
+                android:text="@string/via_email_text"
+                android:textColor="@color/km_via_email_text_color"
+                android:textSize="13sp"
+                android:textStyle="italic" />
+
+            <TextView
                 android:id="@+id/attached_file"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -69,6 +84,18 @@
                 android:textDirection="locale"
                 android:textSize="14sp"
                 android:visibility="visible" />
+
+            <FrameLayout
+                android:id="@+id/emailLayout"
+                android:layout_width="240dp"
+                android:layout_height="match_parent"
+                android:visibility="gone">
+
+                <WebView
+                    android:id="@+id/emailWebView"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </FrameLayout>
 
             <TextView
                 android:id="@+id/createdAtTime"


### PR DESCRIPTION
**Description**
Fix Rich message - Whenever an invalid json in a chat after a valid JSON then the rich message was repeating itself from the previous one. This has been fixed by hiding the rich message view when no template ID is received in the JSON.

Email Source check - Earlier the email type message had a check for HTML contentType and source == 7. Now the email type message just has check for source == 7. This is because for sent email messages the source 