### PR TITLE
Update glide version to 4.9.0 and release v1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# CHANGELOG
+
+The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
+[releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
+
+
+Kommunicate Android SDK 1.8.3
+
+### Features
+
+* FAQ option added in the toolbar. Enable it by setting the below property true in applozic-settings.json file:
+"isFaqOptionEnabled": true
+* Login as visitor option in sample app
+* Option to set APP_ID in build.gradle file for the sample app. In App level build.gradle file add the below property inside defaultConfig:
+buildConfigField "String", "APP_ID", '"<Your-APP_ID>"'
+* Added APP_ID missing error dialog incase user forgets to set the APP_ID in build.gradle file in the sample app.
+
+### Bug fixes and optimisation
+
+* Fixed UI issues for pre lollipop devices
+* Fixed crash for rendering broadcast type groups(For agent app)
+* Fixed duplicate message issue when creating a new conversation
+* Fixed 'email/html type message not getting displayed to the sender'
+* Fixed 'carousels displaying even incase of invalid JSON'
+
+
+
+Kommunicate Android SDK 1.8.2
+
+### New Features
+
+* Setting to change the corner radius of message bubbles.
+Add the below properties in applozic-settings.json file:
+```
+"sentMessageCornerRadii": [
+10,
+10,
+10,
+10
+],
+"receivedMessageCornerRadii": [
+10,
+10,
+10,
+10
+]
+```
+The order is topLeft, topRight, bottomRight, bottomLeft
+
+* Setting to change the fonts for some TextViews. You can set some external fonts using ttf files or select one from the default android fonts.
+Below are the TextViews which support changing the fonts. Add the below property in applozic-settings.json file:
+```
+"fontModel": {
+    "messageTextFont": "",
+    "messageDisplayNameFont": "",
+    "createdAtTimeFont": "",
+    "toolbarTitleFont": "",
+    "toolbarSubtitleFont": "",
+    "messageEditTextFont": ""
+  }
+ ```
+* Support for Rich message carousels has been added(Template ID - 10).
+
+### Bug Fixes
+
+* Fixed crash when updating to version 1.8.1 and audio option is missing in applozic-settings.json file
+* Fixed crash on pre lollipop devices
+* Fixed the conversation name not being displayed if CONVERSATION_ASIGNEE is missing in the conversation(In case of older conversations)
+* Fixed issue related to external audio is being stopped when user navigates back from the chat thread.
+
+Kommunicate Android SDK 1.8.0
+
+###  Features
+
+* Audio recording functionality added.
+* Full HTML support for ContentType 3 messages.
+* Image type rich messages added.
+
+###  Bug fixes
+
+* Fixed issue related to unread count not resetting after opening the conversation.
+* Fixed NPE in createSingleChat and ContactActivity for users that are not logged in
+* Fixed few other crashes.
+
+
+Kommunicate Android SDK 1.7.2
+
+### New Features
+
+* In app web link support
+* Custom click listener for rich message action clicks
+* Conversation assignee name and image in conversation list
+* Reply metadata feature in Rich messages
+
+# Bug Fixes
+
+* Html formatting issue in rich messages
+* Rich message Custom Click fixed
+* Group title was being displayed for a brief time after opening a conversation - fixed
+
+
+Kommunicate Android SDK 1.7.1
+
+### Bug Fixes
+* Fixed issue related to creating new conversation
+* Fixed issue related to online/offline status not visible to users in some cases
+
+
+
+### New Features
+
+* Online/Offline status for agents
+* Current conversation Assignee image will be displayed on toolbar
+* Typing indicator for agents/bots
+* Chat builder for building conversation
+* Now you can set attachment type in the settings. Only those attachment types would be supported for the user.
+* Full HTML/CSS email type support in the chat
+* Now you can pass agentList as null/empty when starting a conversation - In this case the conversation would be created using the default agent
+* New Staggered layout for quick replies/web links
+
+### Fixes/Improvements
+
+* Html message not displaying in notification - Fixed
+* Fixed crash related to invalid payload being sent for Rich Lists
+* Fixed static map not loading issue
+* The Web links/Quick replies click was not being received outside the SDK - Fixed
+
+
+Kommunicate Android SDK 1.6.3
+
+### Fixes/Improvements
+
+* Method to launch chat directly without calling login -> createChat -> launchChat
+* Fixed image loading issues in conversation screen
+* Fixed back button issue in Message info screen
+* Fixed issue in which some attachments were not getting loaded from storage
+
+
+Kommunicate Android SDK Version 1.6.1
+
+### Features
+
+* Templates for FAQ now available
+* Improvements in list templates, addition of header and item images
+* Push notification fix for Oreo devices
+* Custom sound can be set for notifications
+
+
+Kommunicate Android SDK 1.5
+
+### Features
+
+* Added setting to hide Attachment options
+* Added setting to hide conversation subtitle
+* Added visitor login option
+* Added Message status icon and theme customisation capability
+
+### Bug Fixes
+
+* Away message crash fixed
+* Localisation issues fixed
+* Sent messages not visible without adding settings file fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Kommunicate Android SDK 1.8.3
 
-Kommunicate Android SDK 1.8.3
+### Bug fixes and improvement
+
+* Update glide to version 4.9.0.
+* Fixed issue for group name was not showing  in chat list for  public,private and broadcast groups.
+
+## Kommunicate Android SDK 1.8.3
 
 ### Features
 
@@ -23,9 +29,7 @@ buildConfigField "String", "APP_ID", '"<Your-APP_ID>"'
 * Fixed 'email/html type message not getting displayed to the sender'
 * Fixed 'carousels displaying even incase of invalid JSON'
 
-
-
-Kommunicate Android SDK 1.8.2
+## Kommunicate Android SDK 1.8.2
 
 ### New Features
 
@@ -68,7 +72,7 @@ Below are the TextViews which support changing the fonts. Add the below property
 * Fixed the conversation name not being displayed if CONVERSATION_ASIGNEE is missing in the conversation(In case of older conversations)
 * Fixed issue related to external audio is being stopped when user navigates back from the chat thread.
 
-Kommunicate Android SDK 1.8.0
+## Kommunicate Android SDK 1.8.0
 
 ###  Features
 
@@ -76,14 +80,14 @@ Kommunicate Android SDK 1.8.0
 * Full HTML support for ContentType 3 messages.
 * Image type rich messages added.
 
-###  Bug fixes
+### Bug fixes
 
 * Fixed issue related to unread count not resetting after opening the conversation.
 * Fixed NPE in createSingleChat and ContactActivity for users that are not logged in
 * Fixed few other crashes.
 
 
-Kommunicate Android SDK 1.7.2
+## Kommunicate Android SDK 1.7.2
 
 ### New Features
 
@@ -92,19 +96,18 @@ Kommunicate Android SDK 1.7.2
 * Conversation assignee name and image in conversation list
 * Reply metadata feature in Rich messages
 
-# Bug Fixes
+### Bug Fixes
 
 * Html formatting issue in rich messages
 * Rich message Custom Click fixed
 * Group title was being displayed for a brief time after opening a conversation - fixed
 
 
-Kommunicate Android SDK 1.7.1
+## Kommunicate Android SDK 1.7.1
 
 ### Bug Fixes
 * Fixed issue related to creating new conversation
 * Fixed issue related to online/offline status not visible to users in some cases
-
 
 
 ### New Features
@@ -126,7 +129,7 @@ Kommunicate Android SDK 1.7.1
 * The Web links/Quick replies click was not being received outside the SDK - Fixed
 
 
-Kommunicate Android SDK 1.6.3
+## Kommunicate Android SDK 1.6.3
 
 ### Fixes/Improvements
 
@@ -136,7 +139,7 @@ Kommunicate Android SDK 1.6.3
 * Fixed issue in which some attachments were not getting loaded from storage
 
 
-Kommunicate Android SDK Version 1.6.1
+## Kommunicate Android SDK Version 1.6.1
 
 ### Features
 
@@ -146,7 +149,7 @@ Kommunicate Android SDK Version 1.6.1
 * Custom sound can be set for notifications
 
 
-Kommunicate Android SDK 1.5
+## Kommunicate Android SDK 1.5
 
 ### Features
 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 27
         versionCode 1
-        versionName "1.8.3"
+        versionName "1.8.4"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -39,7 +39,7 @@ dependencies {
     // module. The artifact name needs to match the name of the library.
     artifact = 'kommunicate'
     libraryDescription = 'Kommunicate android chat SDK for cutomer support'
-    libraryVersion = '1.8.3'
+    libraryVersion = '1.8.4'
     developerId = 'devashish'
     developerName = 'Applozic'
     developerEmail = 'devashish.mamgain@gmail.com'

--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -125,6 +125,7 @@
             android:name="com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.payment.PaymentActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="Image"
+            android:launchMode="singleTop"
             android:parentActivityName="io.kommunicate.activities.KMConversationActivity"
             android:theme="@style/ApplozicTheme"
             tools:node="merge" />

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 1
-        versionName "1.8.3"
+        versionName "1.8.4"
         vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
@@ -47,7 +47,7 @@ dependencies {
     artifact = 'kommunicateui'
 
     libraryDescription = 'Kommunicate android chat SDK for cutomer support'
-    libraryVersion = '1.8.3'
+    libraryVersion = '1.8.4'
     developerId = 'devashish'
     developerName = 'Applozic'
     developerEmail = 'devashish.mamgain@gmail.com'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api 'de.hdodenhof:circleimageview:2.2.0'
     api 'com.android.support:design:27.1.1'
     api 'com.theartofdev.edmodo:android-image-cropper:2.7.0'
-    api 'com.github.bumptech.glide:glide:4.7.1'
+    api 'com.github.bumptech.glide:glide:4.9.0'
     api 'com.android.support:cardview-v7:27.1.1'
     //compile project(':mobicomkit')//Note: use this for customization
     //Note: use this in case customization is not required

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -171,15 +171,15 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                     myholder.smReceivers.setText(contactInfo);
                     contactImageLoader.setLoadingImage(R.drawable.applozic_ic_contact_picture_holo_light);
                     processContactImage(contactReceiver, myholder.onlineTextView, myholder.offlineTextView, myholder.alphabeticTextView, myholder.contactImage);
-                } else if (message.getGroupId() != null) {
-                    if (channel != null && Channel.GroupType.GROUPOFTWO.getValue().equals(channel.getType())) {
+                } else if (message.getGroupId() != null && channel != null) {
+                    if (Channel.GroupType.GROUPOFTWO.getValue().equals(channel.getType())) {
                         contactImageLoader.setLoadingImage(R.drawable.applozic_ic_contact_picture_holo_light);
                         Contact withUserContact = contactService.getContactById(ChannelService.getInstance(context).getGroupOfTwoReceiverUserId(channel.getKey()));
                         if (withUserContact != null) {
                             myholder.smReceivers.setText(withUserContact.getDisplayName());
                             processContactImage(withUserContact, myholder.onlineTextView, myholder.offlineTextView, myholder.alphabeticTextView, myholder.contactImage);
                         }
-                    } else if (channel != null && Channel.GroupType.SUPPORT_GROUP.getValue().equals(channel.getType())) {
+                    } else if (Channel.GroupType.SUPPORT_GROUP.getValue().equals(channel.getType())) {
                         channelImageLoader.setLoadingImage(R.drawable.applozic_ic_contact_picture_holo_light);
                         myholder.contactImage.setImageResource(R.drawable.applozic_ic_contact_picture_holo_light);
                         Contact supportGroupContact = KmService.getSupportGroupContact(context, channel, contactService, loggedInUserRoleType);
@@ -191,6 +191,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                             loadSupportGroupImage(channel.getImageUrl(), channel.getName(), myholder.alphabeticTextView, myholder.contactImage);
                         }
                     } else {
+                        myholder.smReceivers.setText(channel.getName() != null ? channel.getName(): "");
                         channelImageLoader.setLoadingImage(R.drawable.applozic_group_icon);
                         myholder.contactImage.setImageResource(R.drawable.applozic_group_icon);
 

--- a/kommunicateui/src/main/res/layout/mobicom_message_row_view.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_row_view.xml
@@ -58,7 +58,6 @@
             android:ellipsize="end"
             android:layout_weight="10"
             android:singleLine="true"
-            android:text="James Drake"
             android:textAlignment="gravity"
             android:textColor="#565658"
             android:letterSpacing="0.06"


### PR DESCRIPTION
* Update glide version to the latest
* Fixed the group name not displaying for another group types like the public, private and   broadcast 