### PR TITLE
fix crashes, issues and add metadata merge, delete group features

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -78,7 +78,10 @@
   "enableAwayMessage": true,
   "awayMessageTextColor": "#A9A4A4",
   "hideGroupSubtitle": false,
-  "isFaqOptionEnabled": true,
+  "enableFaqOption": [
+    true,
+    false
+  ],
   "sentMessageCornerRadii": [
     10,
     10,

--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -231,6 +231,6 @@
         <meta-data
             android:name="main_folder_name"
             android:value="@string/app_name"
-            tools:node="merge"/>
+            tools:node="replace"/>
     </application>
 </manifest>

--- a/kommunicate/src/main/java/io/kommunicate/KmChatBuilder.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmChatBuilder.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.applozic.mobicommons.json.JsonMarker;
 
 import java.util.List;
+import java.util.Map;
 
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.users.KMUser;
@@ -25,6 +26,7 @@ public class KmChatBuilder extends JsonMarker {
     private String chatId;
     private String chatName;
     private String deviceToken;
+    private Map<String, String> metadata;
 
     public KmChatBuilder(Context context) {
         this.context = context;
@@ -157,6 +159,15 @@ public class KmChatBuilder extends JsonMarker {
 
     public KmChatBuilder setDeviceToken(String deviceToken) {
         this.deviceToken = deviceToken;
+        return this;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public KmChatBuilder setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
         return this;
     }
 

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.Applozic;
+import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
 import com.applozic.mobicomkit.api.conversation.ApplozicConversation;
 import com.applozic.mobicomkit.api.conversation.Message;
@@ -271,6 +272,10 @@ public class KmConversationHelper {
                 String deviceToken = launchChat.getDeviceToken() != null ? launchChat.getDeviceToken() : Kommunicate.getDeviceToken(context);
                 if (!TextUtils.isEmpty(deviceToken)) {
                     Kommunicate.registerForPushNotification(context, deviceToken, null);
+                }
+
+                if (launchChat.getMetadata() != null) {
+                    ApplozicClient.getInstance(context).setMessageMetaData(launchChat.getMetadata());
                 }
 
                 try {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 
 
 import com.applozic.mobicomkit.Applozic;
+import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitClientService;
 import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -315,6 +316,13 @@ public class Kommunicate {
         metadata.put("GROUP_USER_ROLE_UPDATED_MESSAGE", "");
         metadata.put("GROUP_META_DATA_UPDATED_MESSAGE", "");
         metadata.put("HIDE", "true");
+
+        if (!TextUtils.isEmpty(ApplozicClient.getInstance(context).getMessageMetaData())) {
+            Map<String, String> defaultMetadata = (Map<String, String>) GsonUtils.getObjectFromJson(ApplozicClient.getInstance(context).getMessageMetaData(), Map.class);
+            if (defaultMetadata != null) {
+                metadata.putAll(defaultMetadata);
+            }
+        }
 
         channelInfo.setMetadata(metadata);
 

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
@@ -14,7 +14,6 @@ import com.applozic.mobicomkit.listners.AlLoginHandler;
 import java.lang.ref.WeakReference;
 
 import io.kommunicate.services.KmUserClientService;
-import io.kommunicate.services.KmUserService;
 import io.kommunicate.users.KMUser;
 
 /**
@@ -28,7 +27,6 @@ public class KmUserLoginTask extends UserLoginTask {
     private WeakReference<Context> context;
     private RegistrationResponse response;
     private KmUserClientService userClientService;
-    private KmUserService userService;
     private boolean isAgent;
 
 
@@ -38,7 +36,6 @@ public class KmUserLoginTask extends UserLoginTask {
         this.context = new WeakReference<Context>(context);
         handler = listener;
         userClientService = new KmUserClientService(this.context.get());
-        userService = new KmUserService(this.context.get());
         this.isAgent = isAgent;
     }
 

--- a/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.Applozic;
+import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.HttpRequestUtils;
 import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -372,6 +373,7 @@ public class KmUserClientService extends UserClientService {
         mobiComUserPreference.setPricingPackage(registrationResponse.getPricingPackage());
         mobiComUserPreference.setAuthenticationType(String.valueOf(user.getAuthenticationTypeId()));
         mobiComUserPreference.setUserRoleType(registrationResponse.getRoleType());
+        ApplozicClient.getInstance(context).skipDeletedGroups(user.isSkipDeletedGroups());
 
         if (user.getUserTypeId() != null) {
             mobiComUserPreference.setUserTypeId(String.valueOf(user.getUserTypeId()));
@@ -379,6 +381,7 @@ public class KmUserClientService extends UserClientService {
         if (!TextUtils.isEmpty(user.getNotificationSoundFilePath())) {
             Applozic.getInstance(context).setCustomNotificationSound(user.getNotificationSoundFilePath());
         }
+
         Contact contact = new Contact();
         contact.setUserId(user.getUserId());
         contact.setFullName(registrationResponse.getDisplayName());

--- a/kommunicate/src/main/java/io/kommunicate/users/KMUser.java
+++ b/kommunicate/src/main/java/io/kommunicate/users/KMUser.java
@@ -19,6 +19,14 @@ public class KMUser extends User {
         return MobiComUserPreference.getInstance(context).isLoggedIn();
     }
 
+    public KMUser() {
+        setSkipDeletedGroups(true);
+    }
+
+    public KMUser(boolean skipDeletedGroups) {
+        setSkipDeletedGroups(skipDeletedGroups);
+    }
+
     public static KMUser getLoggedInUser(Context context) {
         KMUser user = new KMUser();
         user.setRoleType(MobiComUserPreference.getInstance(context).getUserRoleType());

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'com.applozic.communication.message:mobicomkit:5.34'
+    api 'com.applozic.communication.message:mobicomkit:5.43'
     api 'com.google.firebase:firebase-messaging:17.1.0'
     api 'com.google.android.gms:play-services-maps:15.0.1'
     api 'com.google.android.gms:play-services-location:15.0.1'

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -115,6 +115,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private float[] receivedMessageCornerRadii;
     private KmFontModel fontModel;
     private boolean isFaqOptionEnabled = false;
+    private boolean[] enableFaqOption = {true, false};
 
     private Map<String, Boolean> attachmentOptions;
 
@@ -619,6 +620,10 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public boolean isFaqOptionEnabled() {
         return isFaqOptionEnabled;
+    }
+
+    public boolean isFaqOptionEnabled(int screen) {
+        return enableFaqOption[screen - 1];
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -88,6 +88,7 @@ import com.applozic.mobicomkit.uiwidgets.uilistener.KmActionCallback;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmStoragePermission;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmStoragePermissionListener;
 import com.applozic.mobicomkit.uiwidgets.uilistener.MobicomkitUriListener;
+import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.commons.core.utils.PermissionsUtils;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.file.FileUtils;
@@ -332,6 +333,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ApplozicService.initWithContext(this);
         String jsonString = FileUtils.loadSettingsJsonFile(getApplicationContext());
         if (!TextUtils.isEmpty(jsonString)) {
             alCustomizationSettings = (AlCustomizationSettings) GsonUtils.getObjectFromJson(jsonString, AlCustomizationSettings.class);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -1,6 +1,7 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.activity;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.ClipData;
 import android.content.Context;
@@ -8,7 +9,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.IntentSender;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Color;
@@ -77,8 +77,10 @@ import com.applozic.mobicomkit.uiwidgets.conversation.fragment.AudioMessageFragm
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.ConversationFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MobiComQuickConversationFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MultimediaOptionFragment;
+import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.payment.PaymentActivity;
 import com.applozic.mobicomkit.uiwidgets.instruction.ApplozicPermissions;
 import com.applozic.mobicomkit.uiwidgets.instruction.InstructionUtil;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.KommunicateUI;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmUtils;
 import com.applozic.mobicomkit.uiwidgets.people.activity.MobiComKitPeopleActivity;
 import com.applozic.mobicomkit.uiwidgets.people.fragment.ProfileFragment;
@@ -457,7 +459,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
             return;
         }
 
-        if(customToolbarLayout != null){
+        if (customToolbarLayout != null) {
             customToolbarLayout.setVisibility(View.GONE);
         }
 
@@ -1356,5 +1358,11 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
                 }
             }
         }
+    }
+
+    public static void openFaq(Activity activity, String url) {
+        Intent faqIntent = new Intent(activity, PaymentActivity.class);
+        faqIntent.putExtra(KommunicateUI.KM_HELPCENTER_URL, url);
+        activity.startActivity(faqIntent);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -549,7 +549,13 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         private final MenuItem.OnMenuItemClickListener onEditMenu = new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                Message message = messageList.get(getLayoutPosition());
+                int position = getLayoutPosition();
+
+                if (messageList.size() <= position || position == -1) {
+                    return true;
+                }
+
+                Message message = messageList.get(position);
 
                 Channel channel = null;
                 Contact contact = null;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -88,6 +88,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
     private View view;
     private ConversationUIService conversationUIService;
     private int loggedInUserRoleType;
+    private String loggedInUserId;
 
     public void setAlCustomizationSettings(AlCustomizationSettings alCustomizationSettings) {
         this.alCustomizationSettings = alCustomizationSettings;
@@ -101,6 +102,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         this.messageList = messageList;
         conversationUIService = new ConversationUIService((FragmentActivity) context);
         loggedInUserRoleType = MobiComUserPreference.getInstance(context).getUserRoleType();
+        loggedInUserId = MobiComUserPreference.getInstance(context).getUserId();
         contactImageLoader = new ImageLoader(context, ImageUtils.getLargestScreenDimension((Activity) context)) {
             @Override
             protected Bitmap processBitmap(Object data) {
@@ -187,7 +189,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                             myholder.smReceivers.setText(supportGroupContact.getDisplayName());
                             loadSupportGroupImage(supportGroupContact.getImageURL(), supportGroupContact.getDisplayName(), myholder.alphabeticTextView, myholder.contactImage);
                         } else {
-                            myholder.smReceivers.setText(ChannelUtils.getChannelTitleName(channel, MobiComUserPreference.getInstance(context).getUserId()));
+                            myholder.smReceivers.setText(ChannelUtils.getChannelTitleName(channel, loggedInUserId));
                             loadSupportGroupImage(channel.getImageUrl(), channel.getName(), myholder.alphabeticTextView, myholder.contactImage);
                         }
                     } else {
@@ -197,6 +199,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                         myholder.alphabeticTextView.setVisibility(View.GONE);
                         myholder.contactImage.setImageResource(R.drawable.applozic_group_icon);
                         myholder.contactImage.setVisibility(View.VISIBLE);
+                        myholder.smReceivers.setText(ChannelUtils.getChannelTitleName(channel, loggedInUserId));
 
                         if (channel != null && !TextUtils.isEmpty(channel.getImageUrl())) {
                             channelImageLoader.loadImage(channel, myholder.contactImage);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -119,7 +119,6 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         };
         channelImageLoader.addImageCache(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         channelImageLoader.setImageFadeIn(false);
-        final String alphabet = context.getString(R.string.alphabet);
         highlightTextSpan = new TextAppearanceSpan(context, R.style.searchTextHiglight);
     }
 
@@ -139,7 +138,6 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         if (getItemViewType(position) == 2) {
             FooterViewHolder myHolder = (FooterViewHolder) holder;
-            //myHolder.loadMoreProgressBar.setVisibility(View.GONE);
             myHolder.infoBroadCast.setVisibility(View.GONE);
         } else {
             Myholder myholder = (Myholder) holder;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1318,6 +1318,7 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
         if (userNotAbleToChatLayout != null) {
             if (contact != null && contact.isDeleted()) {
                 userNotAbleToChatLayout.setVisibility(VISIBLE);
+                recordButton.setVisibility(View.GONE);
                 individualMessageSendLayout.setVisibility(View.GONE);
             } else {
                 userNotAbleToChatLayout.setVisibility(View.GONE);
@@ -1489,6 +1490,9 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
                 if (userNotAbleToChatLayout != null && individualMessageSendLayout != null) {
                     userNotAbleToChatLayout.setVisibility(withUserContact.isDeleted() ? VISIBLE : View.GONE);
                     individualMessageSendLayout.setVisibility(withUserContact.isDeleted() ? View.GONE : VISIBLE);
+                    if (recordButton != null) {
+                        recordButton.setVisibility(withUserContact.isDeleted() ? View.GONE : VISIBLE);
+                    }
                     bottomlayoutTextView.setText(R.string.user_has_been_deleted_text);
                 }
 
@@ -2670,9 +2674,10 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
         if (hide) {
             individualMessageSendLayout.setVisibility(View.GONE);
             userNotAbleToChatLayout.setVisibility(VISIBLE);
+            recordButton.setVisibility(View.GONE);
         } else {
             userNotAbleToChatLayout.setVisibility(View.GONE);
-
+            recordButton.setVisibility(View.VISIBLE);
         }
 
     }
@@ -2825,6 +2830,7 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
                 channel.setDeletedAtTime(channelInfo.getDeletedAtTime());
                 individualMessageSendLayout.setVisibility(View.GONE);
                 userNotAbleToChatLayout.setVisibility(VISIBLE);
+                recordButton.setVisibility(View.GONE);
                 userNotAbleToChatTextView.setText(ApplozicService.getContext(getContext()).getString(R.string.group_has_been_deleted_text));
                 if (channel != null && !ChannelService.getInstance(getContext()).isUserAlreadyPresentInChannel(channel.getKey(), MobiComUserPreference.getInstance(getContext()).getUserId())
                         && messageTemplate != null && messageTemplate.isEnabled() && templateAdapter != null) {
@@ -2837,6 +2843,7 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
                         && (!Channel.GroupType.OPEN.getValue().equals(channel.getType())) && !Channel.GroupType.SUPPORT_GROUP.getValue().equals(channel.getType()))) {
                     individualMessageSendLayout.setVisibility(View.GONE);
                     userNotAbleToChatLayout.setVisibility(VISIBLE);
+                    recordButton.setVisibility(View.GONE);
                     if (channel != null && !ChannelService.getInstance(getContext()).isUserAlreadyPresentInChannel(channel.getKey(), MobiComUserPreference.getInstance(getContext()).getUserId())
                             && messageTemplate != null && messageTemplate.isEnabled() && templateAdapter != null) {
                         templateAdapter.setMessageList(new HashMap<String, String>());

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -2062,10 +2062,9 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
                             if (existingMetadataValueMap != null) {
                                 Map<String, String> newMetadataValueMap = getDataMap(newMetadata.get(key));
                                 if (newMetadataValueMap != null) {
-                                    newMetadataValueMap.putAll(existingMetadataValueMap);
-                                    mergedMetaData.put(key, GsonUtils.getJsonFromObject(newMetadataValueMap, Map.class));
+                                    existingMetadataValueMap.putAll(newMetadataValueMap);
+                                    mergedMetaData.put(key, GsonUtils.getJsonFromObject(existingMetadataValueMap, Map.class));
                                     newMetadata.remove(key);
-                                    existingMetadataValueMap.clear();
                                 }
                             }
                         } catch (Exception e) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -119,6 +119,7 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.AlHotelBooki
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.AlRichMessage;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.payment.PaymentActivity;
 import com.applozic.mobicomkit.uiwidgets.instruction.InstructionUtil;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.KmSettings;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.KommunicateUI;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.animators.OnBasketAnimationEndListener;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.KmAwayMessageHandler;
@@ -382,6 +383,22 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
             toolbarOnlineTv = customToolbarLayout.findViewById(R.id.onlineTextView);
             toolbarOfflineTv = customToolbarLayout.findViewById(R.id.offlineTextView);
             toolbarAlphabeticImage = customToolbarLayout.findViewById(R.id.toolbarAlphabeticImage);
+
+            TextView faqOption = customToolbarLayout.findViewById(R.id.kmFaqOption);
+
+            if (KmSettings.getInstance(getContext()).isFaqOptionEnabled() || alCustomizationSettings.isFaqOptionEnabled(2)) {
+                faqOption.setVisibility(View.VISIBLE);
+                if (faqOption != null) {
+                    faqOption.setOnClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            ConversationActivity.openFaq(getActivity(), new KmClientService(getContext()).getHelpCenterUrl());
+                        }
+                    });
+                }
+            } else {
+                faqOption.setVisibility(View.GONE);
+            }
         }
 
         mainEditTextLinearLayout = (LinearLayout) list.findViewById(R.id.main_edit_text_linear_layout);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
@@ -42,12 +42,11 @@ import android.support.v7.widget.LinearLayoutManager;
 import com.applozic.mobicomkit.uiwidgets.DimensionsUtils;
 import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.conversation.ConversationUIService;
+import com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity;
 import com.applozic.mobicomkit.uiwidgets.conversation.activity.MobiComKitActivityInterface;
 import com.applozic.mobicomkit.uiwidgets.conversation.activity.RecyclerViewPositionHelper;
 import com.applozic.mobicomkit.uiwidgets.conversation.adapter.QuickConversationAdapter;
-import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.payment.PaymentActivity;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.KmSettings;
-import com.applozic.mobicomkit.uiwidgets.kommunicate.KommunicateUI;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.services.KmClientService;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmActionCallback;
 import com.applozic.mobicommons.commons.core.utils.DateUtils;
@@ -153,7 +152,7 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
 
         faqButtonLayout = getActivity().findViewById(R.id.faqButtonLayout);
 
-        if (alCustomizationSettings.isFaqOptionEnabled() || KmSettings.getInstance(getContext()).isFaqOptionEnabled()) {
+        if (alCustomizationSettings.isFaqOptionEnabled() || KmSettings.getInstance(getContext()).isFaqOptionEnabled() || alCustomizationSettings.isFaqOptionEnabled(1)) {
             faqButtonLayout.setVisibility(View.VISIBLE);
             TextView textView = faqButtonLayout.findViewById(R.id.kmFaqOption);
 
@@ -161,7 +160,7 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
                 textView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        openFaq(new KmClientService(getContext()).getHelpCenterUrl());
+                        ConversationActivity.openFaq(getActivity(), new KmClientService(getContext()).getHelpCenterUrl());
                     }
                 });
             }
@@ -235,12 +234,6 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
                 ((MobiComKitActivityInterface) getActivity()).startContactActivityForResult();
             }
         };
-    }
-
-    public void openFaq(String url) {
-        Intent faqIntent = new Intent(getActivity(), PaymentActivity.class);
-        faqIntent.putExtra(KommunicateUI.KM_HELPCENTER_URL, url);
-        startActivity(faqIntent);
     }
 
     @Override

--- a/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
@@ -3,8 +3,6 @@
     android:id="@+id/custom_toolbar_root_layout"
     android:layout_width="fill_parent"
     android:layout_height="?actionBarSize"
-    android:layout_marginEnd="70dp"
-    android:layout_marginRight="70dp"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:visibility="visible">
 
@@ -71,6 +69,8 @@
         android:layout_centerVertical="true"
         android:layout_marginStart="9dp"
         android:layout_marginLeft="9dp"
+        android:layout_marginRight="50dp"
+        android:layout_marginEnd="50dp"
         android:layout_toEndOf="@+id/profile_image_layout"
         android:layout_toRightOf="@+id/profile_image_layout"
         android:gravity="center_vertical"
@@ -101,4 +101,25 @@
             android:textSize="12sp"
             android:textStyle="normal" />
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/kmFaqOption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:layout_marginEnd="10dp"
+        android:layout_marginRight="10dp"
+        android:background="@drawable/km_faq_button_background"
+        android:paddingStart="7dp"
+        android:paddingLeft="7dp"
+        android:paddingTop="5dp"
+        android:paddingEnd="7dp"
+        android:paddingRight="7dp"
+        android:paddingBottom="5dp"
+        android:text="@string/faq_option"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        android:textStyle="bold" />
 </RelativeLayout>

--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -487,26 +487,26 @@
                     android:src="@drawable/noun_mic_1057615"
                     android:visibility="visible" />
             </FrameLayout>
+
+            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:id="@+id/user_not_able_to_chat_layout"
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:layout_gravity="bottom"
+                android:minHeight="50dp"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <TextView
+                    android:id="@+id/user_not_able_to_chat_textView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:text="@string/user_not_in_this_group_text"
+                    android:textSize="18sp" />
+            </LinearLayout>
         </FrameLayout>
-    </LinearLayout>
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/user_not_able_to_chat_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        android:minHeight="50dp"
-        android:orientation="horizontal"
-        android:visibility="gone">
-
-        <TextView
-            android:id="@+id/user_not_able_to_chat_textView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:text="@string/user_not_in_this_group_text"
-            android:textSize="18sp" />
     </LinearLayout>
 
     <FrameLayout

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -167,7 +167,7 @@
     <string name="channel_edit_alert">Unable to change the group name because you are not a participant</string>
     <string name="admin_text">Group admin</string>
     <string name="user_not_in_this_group_text">You are no longer a participant of this group</string>
-    <string name="group_has_been_deleted_text">This group has been deleted</string>
+    <string name="group_has_been_deleted_text">This conversation has been deleted</string>
     <string name="update_channel_title_name">Enter group name</string>
     <string name="new_channel_name_hint">Group name…</string>
     <string name="user_block_info">Block [name]? A blocked user will no longer be able to send you messages</string>


### PR DESCRIPTION
This PR contains the commits for:
1) setting to enable/disable faq option on both screens
2) set default metadata in the new conversation
3) fixed issue where the normal group name is not displaying in conversation screen
4) option to add default metadata in KmChatBuilder
5) The option to merge the message metadata if the keys are similar
6) Delete group functionality
7) Crash fixes and optimisations

This was tested on local device.