### PR TITLE
fix file provider issue in case of multiple authorities

### DIFF
--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -37,8 +37,7 @@
         tools:node="merge" />
 
     <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
         <service
             android:name="com.applozic.mobicomkit.api.conversation.MessageIntentService"

--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
         tools:node="merge" />
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 

--- a/kommunicateui/src/main/AndroidManifest.xml
+++ b/kommunicateui/src/main/AndroidManifest.xml
@@ -4,8 +4,7 @@
     package="com.applozic.mobicomkit.uiwidgets">
 
     <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
         <activity
             android:name="com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity"

--- a/kommunicateui/src/main/AndroidManifest.xml
+++ b/kommunicateui/src/main/AndroidManifest.xml
@@ -4,19 +4,8 @@
     package="com.applozic.mobicomkit.uiwidgets">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
-        <provider
-            android:name="com.applozic.mobicomkit.uiwidgets.ALFileProvider"
-            android:authorities="${applicationId}.provider"
-            android:exported="false"
-            android:grantUriPermissions="true"
-            tools:node="merge">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/applozic_provider_paths" />
-        </provider>
 
         <activity
             android:name="com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity"

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/ApplozicDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/ApplozicDocumentView.java
@@ -350,7 +350,7 @@ public class ApplozicDocumentView {
     public void playAudio() {
         final String mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
         if (Utils.hasNougat()) {
-            uri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+            uri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
         } else {
             uri = Uri.fromFile(new File(message.getFilePaths().get(0)));
             Log.i(TAG, uri.toString());

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ChannelCreateActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ChannelCreateActivity.java
@@ -381,7 +381,7 @@ public class ChannelCreateActivity extends AppCompatActivity implements Activity
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_" + ".jpeg";
         profilePhotoFile = FileClientService.getFilePath(imageFileName, getApplicationContext(), "image/jpeg");
-        imageChangeUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", profilePhotoFile);
+        imageChangeUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", profilePhotoFile);
         return imageChangeUri;
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ChannelNameActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ChannelNameActivity.java
@@ -263,7 +263,7 @@ public class ChannelNameActivity extends AppCompatActivity implements ActivityCo
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_" + ".jpeg";
         profilePhotoFile = FileClientService.getFilePath(imageFileName, getApplicationContext(), "image/jpeg");
-        imageChangeUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", profilePhotoFile);
+        imageChangeUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", profilePhotoFile);
         return imageChangeUri;
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -1238,7 +1238,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
             mediaFile = FileClientService.getFilePath(imageFileName, getApplicationContext(), "image/jpeg");
 
-            capturedImageUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", mediaFile);
+            capturedImageUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", mediaFile);
 
             Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 
@@ -1309,7 +1309,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
             mediaFile = FileClientService.getFilePath(imageFileName, getApplicationContext(), "video/mp4");
 
-            videoFileUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", mediaFile);
+            videoFileUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", mediaFile);
 
             videoIntent.putExtra(MediaStore.EXTRA_OUTPUT, videoFileUri);
 
@@ -1357,7 +1357,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "JPEG_" + timeStamp + "_" + ".jpeg";
         profilePhotoFile = FileClientService.getFilePath(imageFileName, getApplicationContext(), "image/jpeg");
-        imageUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", profilePhotoFile);
+        imageUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", profilePhotoFile);
         return imageUri;
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
@@ -203,7 +203,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
             Intent shareIntent = new Intent();
             shareIntent.setAction(Intent.ACTION_SEND);
 
-            Uri uri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+            Uri uri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1119,7 +1119,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                         Uri outputUri = null;
                         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         if (Utils.hasNougat()) {
-                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
                         } else {
                             outputUri = Uri.fromFile(new File(message.getFilePaths().get(0)));
                         }
@@ -1138,7 +1138,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                                 Uri outputUri = null;
                                 intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                                 if (Utils.hasNougat()) {
-                                    outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+                                    outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
                                 } else {
                                     outputUri = Uri.fromFile(new File(message.getFilePaths().get(0)));
                                 }
@@ -1251,7 +1251,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                         intent.setAction(Intent.ACTION_VIEW);
                         Uri outputUri;
                         if (Utils.hasNougat()) {
-                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
                         } else {
                             outputUri = Uri.fromFile(new File(message.getFilePaths().get(0)));
                         }
@@ -1301,7 +1301,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                         intentVideo.setAction(Intent.ACTION_VIEW);
                         Uri outputUri;
                         if (Utils.hasNougat()) {
-                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(smListItem.getFilePaths().get(0)));
+                            outputUri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(smListItem.getFilePaths().get(0)));
                         } else {
                             outputUri = Uri.fromFile(new File(smListItem.getFilePaths().get(0)));
                         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3913,7 +3913,7 @@ abstract public class MobiComConversationFragment extends Fragment implements Vi
                 if (message.getFilePaths() != null) {
                     Uri shareUri = null;
                     if (Utils.hasNougat()) {
-                        shareUri = FileProvider.getUriForFile(ApplozicService.getContext(getContext()), Utils.getMetaDataValue(getActivity(), MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
+                        shareUri = FileProvider.getUriForFile(ApplozicService.getContext(getContext()), Utils.getMetaDataValue(getActivity(), MobiComKitConstants.PACKAGE_NAME) + ".applozic.provider", new File(message.getFilePaths().get(0)));
                     } else {
                         shareUri = Uri.fromFile(new File(message.getFilePaths().get(0)));
                     }


### PR DESCRIPTION
Fixed the issue with file provider in case someone uses the same authority as we are using.
This would result in conflict and they will have to change their authority. 
Have appended 'applozic' to the authority to recognize it as our FileProvider