### PR TITLE
CM-93 Optimised push notification setup steps

### DIFF
--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -181,18 +181,6 @@ public class MainActivity extends AppCompatActivity {
                     ApplozicClient.getInstance(context).hideActionMessages(false).setMessageMetaData(metadata);
                 }
 
-                Kommunicate.registerForPushNotification(context, new KmPushNotificationHandler() {
-                    @Override
-                    public void onSuccess(RegistrationResponse registrationResponse) {
-
-                    }
-
-                    @Override
-                    public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-
-                    }
-                });
-
                 try {
                     KmConversationHelper.openConversation(context, true, null, new KmCallback() {
                         @Override

--- a/app/src/main/java/kommunicate/io/sample/pushnotification/FcmListenerService.java
+++ b/app/src/main/java/kommunicate/io/sample/pushnotification/FcmListenerService.java
@@ -2,7 +2,7 @@ package kommunicate.io.sample.pushnotification;
 
 
 import android.util.Log;
-import com.applozic.mobicomkit.api.notification.MobiComPushReceiver;
+
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 
@@ -11,21 +11,16 @@ import io.kommunicate.Kommunicate;
 
 public class FcmListenerService extends FirebaseMessagingService {
 
-    private static final String TAG = "KommunicatePushReceiver";
+    private static final String TAG = "KmSampleFCMService";
 
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
+        Log.i(TAG, "FCM notification processing...");
 
-        Log.i(TAG, "Message data:" + remoteMessage.getData());
-
-        if (remoteMessage.getData().size() > 0) {
-            if (MobiComPushReceiver.isMobiComPushNotification(remoteMessage.getData())) {
-                Log.i(TAG, "Kommunicate notification processing...");
-                MobiComPushReceiver.processMessageAsync(this, remoteMessage.getData());
-                return;
-            }
+        if (Kommunicate.isKmNotification(this, remoteMessage.getData())) {
+            return;
         }
-
+        super.onMessageReceived(remoteMessage);
     }
 
     @Override

--- a/app/src/main/java/kommunicate/io/sample/pushnotification/FcmListenerService.java
+++ b/app/src/main/java/kommunicate/io/sample/pushnotification/FcmListenerService.java
@@ -2,14 +2,11 @@ package kommunicate.io.sample.pushnotification;
 
 
 import android.util.Log;
-
-import com.applozic.mobicomkit.Applozic;
-import com.applozic.mobicomkit.api.account.register.RegisterUserClientService;
-import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
-import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
 import com.applozic.mobicomkit.api.notification.MobiComPushReceiver;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+
+import io.kommunicate.Kommunicate;
 
 
 public class FcmListenerService extends FirebaseMessagingService {
@@ -36,13 +33,7 @@ public class FcmListenerService extends FirebaseMessagingService {
         super.onNewToken(registrationId);
 
         Log.i(TAG, "Found Registration Id:" + registrationId);
-        Applozic.getInstance(this).setDeviceRegistrationId(registrationId);
-        if (MobiComUserPreference.getInstance(this).isRegistered()) {
-            try {
-                RegistrationResponse registrationResponse = new RegisterUserClientService(this).updatePushNotificationId(registrationId);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+
+        Kommunicate.updateDeviceToken(this, registrationId);
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/KmPreference.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmPreference.java
@@ -15,6 +15,7 @@ public class KmPreference {
     private static KmPreference kmPreference;
     private static final String KM_USER_PREFERENCES = "KOMMUNICATE_USER_PREFS";
     private static final String KM_CONVERSATION_BUILDER = "KM_CONVERSATION_BUILDER";
+    private static final String IS_FCM_REGISTRATION_CALL_DONE = "IS_FCM_REGISTRATION_CALL_DONE";
 
     private String HELPDOCS_ACCESS_KEY = "HELPDOCS_ACCESS_KEY";
 
@@ -47,5 +48,16 @@ public class KmPreference {
 
     public KmConversationBuilder getKmConversationBuilder() {
         return (KmConversationBuilder) GsonUtils.getObjectFromJson(preferences.getString(KM_CONVERSATION_BUILDER, null), KmConversationBuilder.class);
+    }
+
+    public KmPreference setFcmRegistrationCallDone(boolean callDone) {
+        if (preferences != null) {
+            preferences.edit().putBoolean(IS_FCM_REGISTRATION_CALL_DONE, callDone).commit();
+        }
+        return this;
+    }
+
+    public boolean isFcmRegistrationCallDone() {
+        return preferences != null && preferences.getBoolean(IS_FCM_REGISTRATION_CALL_DONE, false);
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -10,6 +10,7 @@ import android.text.TextUtils;
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitClientService;
+import com.applozic.mobicomkit.api.account.register.RegisterUserClientService;
 import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
 import com.applozic.mobicomkit.api.account.user.PushNotificationTask;
@@ -465,6 +466,20 @@ public class Kommunicate {
         }
 
         setDeviceToken(context, token);
+    }
+
+    public static void updateDeviceToken(Context context, String deviceToken) {
+        if (TextUtils.isEmpty(deviceToken)) {
+            return;
+        }
+        if (MobiComUserPreference.getInstance(context).isRegistered() && !deviceToken.equals(getDeviceToken(context))) {
+            try {
+                new RegisterUserClientService(context).updatePushNotificationId(deviceToken);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        setDeviceToken(context, deviceToken);
     }
 
     public static void registerForPushNotification(Context context, KmPushNotificationHandler listener) {

--- a/kommunicateui/src/main/AndroidManifest.xml
+++ b/kommunicateui/src/main/AndroidManifest.xml
@@ -18,6 +18,14 @@
                 android:resource="@xml/applozic_provider_paths" />
         </provider>
 
+        <service
+            android:name="com.applozic.mobicomkit.uiwidgets.KmFirebaseMessagingService"
+            android:stopWithTask="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name="com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity"
             android:configChanges="keyboardHidden|screenSize|locale|smallestScreenSize|screenLayout|orientation"

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmFirebaseMessagingService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmFirebaseMessagingService.java
@@ -1,0 +1,28 @@
+package com.applozic.mobicomkit.uiwidgets;
+
+import com.applozic.mobicommons.commons.core.utils.Utils;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import io.kommunicate.Kommunicate;
+
+public class KmFirebaseMessagingService extends FirebaseMessagingService {
+
+    private static final String TAG = "KmFCMService";
+
+    @Override
+    public void onNewToken(String s) {
+        Utils.printLog(this, TAG, "Found deviceToken in KM : " + s);
+        super.onNewToken(s);
+        Kommunicate.updateDeviceToken(this, s);
+    }
+
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        Utils.printLog(this, TAG, "Kommunicate notification processing...");
+        if (Kommunicate.isKmNotification(this, remoteMessage.getData())) {
+            return;
+        }
+        super.onMessageReceived(remoteMessage);
+    }
+}


### PR DESCRIPTION
1) Added the push notification service within the SDK. So if someone doesn't have the setup, they do not need to do anything. 
2) If someone already has the setup for push notification, then only 2 steps are required:
     **a)** Add the below code in `onNewToken(String s)` method of the Fcm Service:
        ```
          Kommunicate.updateDeviceToken(this, s);
        ```
      **b)** Add the below code in `onMessageReceived(RemoteMessage remoteMessage)` method of the Fcm Service:
        ```
           if (Kommunicate.isKmNotification(this, remoteMessage.getData())) {
              return;
            }
        ```
3) No need to call the `registerForPushNotification` method now. Kommunicate will internally check if the deviceToken exists or not, if the tokenExists, push registration will automatically be called.
4) Push registeration will also be called when firebase updates the token.