### PR TITLE
Speech to text and Text to speech support

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmSpeechToText.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmSpeechToText.java
@@ -6,40 +6,48 @@ import android.os.Bundle;
 import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
-import android.widget.Toast;
 
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmRecordButton;
-import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmRecordView;
 import com.applozic.mobicommons.commons.core.utils.Utils;
-import com.applozic.mobicommons.json.GsonUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
 
 public class KmSpeechToText implements RecognitionListener {
     private static final String TAG = "KmSpeechToText";
-    private KmRecordView recordView;
     private KmRecordButton recordButton;
     private Context context;
     private KmTextListener listener;
+    private SpeechRecognizer speechRecognizer;
+    private boolean isStopped;
 
-    public KmSpeechToText(Context context, KmRecordView recordView, KmRecordButton recordButton, KmTextListener listener) {
+    public KmSpeechToText(Context context, KmRecordButton recordButton, KmTextListener listener) {
         this.context = context;
         this.listener = listener;
+        this.recordButton = recordButton;
     }
 
     public void startListening() {
+        isStopped = false;
         Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
 
         intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
         intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault());
+        intent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true);
         intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 5);
         intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.getPackageName());
 
-        SpeechRecognizer speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context);
+        speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context);
         speechRecognizer.setRecognitionListener(this);
         speechRecognizer.startListening(intent);
+    }
+
+    public void stopListening() {
+        isStopped = true;
+        if (speechRecognizer != null) {
+            speechRecognizer.stopListening();
+        }
     }
 
     @Override
@@ -55,43 +63,60 @@ public class KmSpeechToText implements RecognitionListener {
     @Override
     public void onRmsChanged(float rmsdB) {
         //Utils.printLog(context, TAG, "RMS changed : " + rmsdB);
+        if (rmsdB >= 1.0f) {
+            recordButton.startScaleWithValue(1.0f + rmsdB / 15);
+        }
     }
 
     @Override
     public void onBufferReceived(byte[] buffer) {
-        //Utils.printLog(context, TAG, "Buffer received");
+       // Utils.printLog(context, TAG, "Buffer received");
     }
 
     @Override
     public void onEndOfSpeech() {
+        if (listener != null) {
+            listener.onSpeechEnd(-1);
+        }
         Utils.printLog(context, TAG, "End of speech");
     }
 
     @Override
     public void onError(int error) {
-        Toast.makeText(context, "Some error occurred : " + error, Toast.LENGTH_SHORT).show();
-        Utils.printLog(context, TAG, "Error : " + error);
+        if (listener != null) {
+            listener.onSpeechEnd(error);
+        }
+        //Utils.printLog(context, TAG, "Error : " + error);
     }
 
     @Override
     public void onResults(Bundle results) {
         ArrayList<String> matches = results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
-        if(listener != null) {
+        if (listener != null && !isStopped) {
             listener.onSpeechToTextResult(matches != null ? matches.get(0) : "");
         }
+        //Utils.printLog(context, TAG, "Received result : " + results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION));
     }
 
     @Override
     public void onPartialResults(Bundle partialResults) {
-        //Utils.printLog(context, TAG, "Received partial result : " + GsonUtils.getJsonFromObject(partialResults, Bundle.class));
+        ArrayList<String> result = partialResults.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
+        if (listener != null && result != null && !result.isEmpty()) {
+            listener.onSpeechToTextPartialResult(result.get(0));
+        }
+        //Utils.printLog(context, TAG, "Received partial result : " + partialResults.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION));
     }
 
     @Override
     public void onEvent(int eventType, Bundle params) {
-        Utils.printLog(context, TAG, "Received event : " + eventType);
+       // Utils.printLog(context, TAG, "Received event : " + eventType);
     }
 
     public interface KmTextListener {
         void onSpeechToTextResult(String text);
+
+        void onSpeechToTextPartialResult(String text);
+
+        void onSpeechEnd(int errorCode);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmSpeechToText.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/KmSpeechToText.java
@@ -1,0 +1,97 @@
+package com.applozic.mobicomkit.uiwidgets;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.speech.RecognitionListener;
+import android.speech.RecognizerIntent;
+import android.speech.SpeechRecognizer;
+import android.widget.Toast;
+
+import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmRecordButton;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmRecordView;
+import com.applozic.mobicommons.commons.core.utils.Utils;
+import com.applozic.mobicommons.json.GsonUtils;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+public class KmSpeechToText implements RecognitionListener {
+    private static final String TAG = "KmSpeechToText";
+    private KmRecordView recordView;
+    private KmRecordButton recordButton;
+    private Context context;
+    private KmTextListener listener;
+
+    public KmSpeechToText(Context context, KmRecordView recordView, KmRecordButton recordButton, KmTextListener listener) {
+        this.context = context;
+        this.listener = listener;
+    }
+
+    public void startListening() {
+        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault());
+        intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 5);
+        intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.getPackageName());
+
+        SpeechRecognizer speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context);
+        speechRecognizer.setRecognitionListener(this);
+        speechRecognizer.startListening(intent);
+    }
+
+    @Override
+    public void onReadyForSpeech(Bundle params) {
+        Utils.printLog(context, TAG, "Ready for speech");
+    }
+
+    @Override
+    public void onBeginningOfSpeech() {
+        Utils.printLog(context, TAG, "Beginning of speech");
+    }
+
+    @Override
+    public void onRmsChanged(float rmsdB) {
+        //Utils.printLog(context, TAG, "RMS changed : " + rmsdB);
+    }
+
+    @Override
+    public void onBufferReceived(byte[] buffer) {
+        //Utils.printLog(context, TAG, "Buffer received");
+    }
+
+    @Override
+    public void onEndOfSpeech() {
+        Utils.printLog(context, TAG, "End of speech");
+    }
+
+    @Override
+    public void onError(int error) {
+        Toast.makeText(context, "Some error occurred : " + error, Toast.LENGTH_SHORT).show();
+        Utils.printLog(context, TAG, "Error : " + error);
+    }
+
+    @Override
+    public void onResults(Bundle results) {
+        ArrayList<String> matches = results.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION);
+        if(listener != null) {
+            listener.onSpeechToTextResult(matches != null ? matches.get(0) : "");
+        }
+    }
+
+    @Override
+    public void onPartialResults(Bundle partialResults) {
+        //Utils.printLog(context, TAG, "Received partial result : " + GsonUtils.getJsonFromObject(partialResults, Bundle.class));
+    }
+
+    @Override
+    public void onEvent(int eventType, Bundle params) {
+        Utils.printLog(context, TAG, "Received event : " + eventType);
+    }
+
+    public interface KmTextListener {
+        void onSpeechToTextResult(String text);
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/KmTextToSpeech.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/KmTextToSpeech.java
@@ -1,0 +1,57 @@
+package com.applozic.mobicomkit.uiwidgets.conversation;
+
+import android.content.Context;
+import android.speech.tts.TextToSpeech;
+import android.widget.Toast;
+
+import com.applozic.mobicommons.commons.core.utils.Utils;
+
+import java.util.Locale;
+
+public class KmTextToSpeech implements TextToSpeech.OnInitListener {
+
+    private Context context;
+    private TextToSpeech textToSpeech;
+    private static final String TAG = "KmSpeechToText";
+
+    public KmTextToSpeech(Context context) {
+        this.context = context;
+    }
+
+    public void initialize() {
+        this.textToSpeech = new TextToSpeech(context, this);
+    }
+
+    @Override
+    public void onInit(int status) {
+        if (status == TextToSpeech.SUCCESS) {
+            int ttsLang = textToSpeech.setLanguage(Locale.US);
+
+            if (ttsLang == TextToSpeech.LANG_MISSING_DATA || ttsLang == TextToSpeech.LANG_NOT_SUPPORTED) {
+                Toast.makeText(context, "The Language is not supported", Toast.LENGTH_SHORT).show();
+                Utils.printLog(context, TAG, "The Language is not supported");
+            } else {
+                Utils.printLog(context, TAG, "Language Supported");
+            }
+            Utils.printLog(context, TAG, "Text to Speech initialization successfull");
+        } else {
+            Toast.makeText(context, "Text to Speech initialization failed!", Toast.LENGTH_SHORT).show();
+            Utils.printLog(context, TAG, "Text to Speech initialization failed!");
+        }
+    }
+
+    public void speak(String text) {
+        int speechStatus = textToSpeech.speak(text, TextToSpeech.QUEUE_ADD, null);
+
+        if (speechStatus == TextToSpeech.ERROR) {
+            Utils.printLog(context, TAG, "Failed to convert the Text to Speech");
+        }
+    }
+
+    public void destroy() {
+        if (textToSpeech != null) {
+            textToSpeech.stop();
+            textToSpeech.shutdown();
+        }
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/animators/KmScaleAnimation.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/animators/KmScaleAnimation.java
@@ -15,6 +15,15 @@ public class KmScaleAnimation {
     }
 
 
+    public void startWithValue(float scale) {
+        AnimatorSet set = new AnimatorSet();
+        ObjectAnimator scaleY = ObjectAnimator.ofFloat(view, SCALE_Y, scale);
+        ObjectAnimator scaleX = ObjectAnimator.ofFloat(view, SCALE_X, scale);
+        set.setInterpolator(new AccelerateDecelerateInterpolator());
+        set.playTogether(scaleY, scaleX);
+        set.start();
+    }
+
     public void start() {
         AnimatorSet set = new AnimatorSet();
         ObjectAnimator scaleY = ObjectAnimator.ofFloat(view, SCALE_Y, 2.0f);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordButton.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordButton.java
@@ -3,8 +3,10 @@ package com.applozic.mobicomkit.uiwidgets.kommunicate.views;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.appcompat.widget.AppCompatImageView;
+
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -114,6 +116,10 @@ public class KmRecordButton extends AppCompatImageView implements View.OnTouchLi
 
     public void stopScale() {
         scaleAnim.stop();
+    }
+
+    public void startScaleWithValue(float value) {
+        scaleAnim.startWithValue(value);
     }
 
     public void setListenForRecord(boolean listenForRecord) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
@@ -6,8 +6,11 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.media.MediaPlayer;
 import android.os.SystemClock;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
+
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -42,6 +45,8 @@ public class KmRecordView extends FrameLayout {
     private KmOnRecordListener recordListener;
     private boolean isSwiped, isLessThanSecondAllowed = false;
     private boolean isSoundEnabled = true;
+    private boolean hideTimer = false;
+    private String recordingTextString;
     private MediaPlayer player;
     private KmAnimationHelper animationHelper;
 
@@ -135,8 +140,15 @@ public class KmRecordView extends FrameLayout {
     private void showViews() {
         slideToCancelLayout.setVisibility(VISIBLE);
         smallBlinkingDot.setVisibility(VISIBLE);
-        counterTime.setVisibility(VISIBLE);
+
+        if (!hideTimer) {
+            counterTime.setVisibility(VISIBLE);
+        }
         recordingText.setVisibility(VISIBLE);
+
+        if (!TextUtils.isEmpty(recordingTextString)) {
+            recordingText.setText(recordingTextString);
+        }
     }
 
     private boolean isLessThanOneSecond(long time) {
@@ -199,11 +211,10 @@ public class KmRecordView extends FrameLayout {
         long time = System.currentTimeMillis() - startTime;
 
 
-
-        if(context.getResources().getConfiguration().getLayoutDirection()==View.LAYOUT_DIRECTION_RTL) {
+        if (context.getResources().getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
 
             if (!isSwiped && time >= 150) {
-                if (slideToCancelLayout.getX() != 0 && (slideToCancelLayout.getX()+slideToCancelLayout.getWidth()) >= counterTime.getX() - cancelBounds) {
+                if (slideToCancelLayout.getX() != 0 && (slideToCancelLayout.getX() + slideToCancelLayout.getWidth()) >= counterTime.getX() - cancelBounds) {
                     if (isLessThanOneSecond(time)) {
                         hideViews(true);
                         animationHelper.clearAlphaAnimation(false);
@@ -352,6 +363,14 @@ public class KmRecordView extends FrameLayout {
 
     public void setCancelBounds(float cancelBounds) {
         setCancelBounds(cancelBounds, true);
+    }
+
+    public void hideTimer(boolean hide) {
+        hideTimer = hide;
+    }
+
+    public void setRecordingText(String recordingText) {
+        this.recordingTextString = recordingText;
     }
 
     public void setCounterTimeColor(int color) {

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -263,4 +263,5 @@
     <string name="description_unavailable">Description unavailable</string>
     <string name="room_night_detail">(1 Room for %1$d Nights)</string>
     <string name="room_name_unavailable">Room name unavailable</string>
+    <string name="km_speech_listening_text">Listening...</string>
 </resources>


### PR DESCRIPTION
* The settings are currently hardcoded in MobiomConversationFragment.java class:
    
```
    private boolean isTextToSpeechEnabled = true;   //Enables text to speech.
    private boolean isSpeechToTextEnabled = true;  // Enabled speech to text.
    private boolean isSendOnSpeechEnd = true;  //Will automatically send a message when speech 
   to text conversation is complete.
```
* Text to speech:  Works only when the conversation is open and a new message is received within the conversation. 

* Speech to text: The mic button used to record and send audio will function as STT starter. Just click the button once and the device will start listening. To cancel an ongoing listening, click on the button again. The audio button will scale animate depending on the input voice amplitude. The partial results will be set on the message edit text but the send message button will only be enabled once the complete speech is received. When `isSendOnSpeechEnd = true` , the message will be sent automatically once the text is received.

* To Integrate your own STT or TTS service, replace the KmSpeechToText and KmTextToSpeech implementation with your service.

