### PR TITLE
Added way to sending usersIds from builder.

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
@@ -20,6 +20,7 @@ public class KmConversationBuilder extends JsonMarker {
     private String appId;
     private List<String> agentIds;
     private List<String> botIds;
+    private List<String> userIds;
     private boolean skipConversationList = true;
     private String conversationId;
     private String fcmDeviceToken;
@@ -196,6 +197,15 @@ public class KmConversationBuilder extends JsonMarker {
 
     public KmConversationBuilder setConversationTitle(String conversationTitle) {
         this.conversationTitle = conversationTitle;
+        return this;
+    }
+
+    public List<String> getUserIds() {
+        return userIds;
+    }
+
+    public KmConversationBuilder setUserIds(List<String> userIds) {
+        this.userIds = userIds;
         return this;
     }
 

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -542,6 +542,7 @@ public class KmConversationHelper {
 
     private static void createConversation(KmConversationBuilder conversationBuilder, KmStartConversationHandler handler) throws KmException {
         List<KMGroupInfo.GroupUser> users = new ArrayList<>();
+        String loginUserId = MobiComUserPreference.getInstance(conversationBuilder.getContext()).getUserId();
 
         KMGroupInfo channelInfo = new KMGroupInfo(Utils.getString(conversationBuilder.getContext(), R.string.km_default_support_group_name), new ArrayList<String>());
 
@@ -553,7 +554,18 @@ public class KmConversationHelper {
         }
 
         users.add(channelInfo.new GroupUser().setUserId(KM_BOT).setGroupRole(2));
-        users.add(channelInfo.new GroupUser().setUserId(MobiComUserPreference.getInstance(conversationBuilder.getContext()).getUserId()).setGroupRole(3));
+
+        if (conversationBuilder.getUserIds() == null || conversationBuilder.getUserIds().isEmpty()) {
+            List<String> userIds = new ArrayList<>();
+            userIds.add(loginUserId);
+            conversationBuilder.setUserIds(userIds);
+        } else if (!conversationBuilder.getUserIds().contains(loginUserId)) {
+            conversationBuilder.getUserIds().add(loginUserId);
+        }
+
+        for (String userId : conversationBuilder.getUserIds()) {
+            users.add(channelInfo.new GroupUser().setUserId(userId).setGroupRole(3));
+        }
 
         if (conversationBuilder.getBotIds() != null) {
             for (String botId : conversationBuilder.getBotIds()) {
@@ -573,7 +585,7 @@ public class KmConversationHelper {
         if (!TextUtils.isEmpty(conversationBuilder.getClientConversationId())) {
             channelInfo.setClientGroupId(conversationBuilder.getClientConversationId());
         } else if (conversationBuilder.isSingleConversation()) {
-            channelInfo.setClientGroupId(getClientGroupId(MobiComUserPreference.getInstance(conversationBuilder.getContext()).getUserId(), conversationBuilder.getAgentIds(), conversationBuilder.getBotIds()));
+            channelInfo.setClientGroupId(getClientGroupId(conversationBuilder.getUserIds(), conversationBuilder.getAgentIds(), conversationBuilder.getBotIds(), conversationBuilder.getContext()));
         }
 
         Map<String, String> metadata = new HashMap<>();
@@ -655,7 +667,7 @@ public class KmConversationHelper {
                         agents.add(agent.getAgentId());
                         conversationBuilder.setAgentIds(agents);
                         try {
-                            final String clientChannelKey = !TextUtils.isEmpty(conversationBuilder.getClientConversationId()) ? conversationBuilder.getClientConversationId() : (conversationBuilder.isSingleConversation() ? getClientGroupId(MobiComUserPreference.getInstance(conversationBuilder.getContext()).getUserId(), agents, conversationBuilder.getBotIds()) : null);
+                            final String clientChannelKey = !TextUtils.isEmpty(conversationBuilder.getClientConversationId()) ? conversationBuilder.getClientConversationId() : (conversationBuilder.isSingleConversation() ? getClientGroupId(conversationBuilder.getUserIds(), agents, conversationBuilder.getBotIds(), conversationBuilder.getContext()) : null);
                             if (!TextUtils.isEmpty(clientChannelKey)) {
                                 conversationBuilder.setClientConversationId(clientChannelKey);
                                 startOrGetConversation(conversationBuilder, handler);
@@ -678,7 +690,7 @@ public class KmConversationHelper {
 
             new KmGetAgentListTask(conversationBuilder.getContext(), MobiComKitClientService.getApplicationKey(conversationBuilder.getContext()), callback).execute();
         } else {
-            final String clientChannelKey = !TextUtils.isEmpty(conversationBuilder.getClientConversationId()) ? conversationBuilder.getClientConversationId() : (conversationBuilder.isSingleConversation() ? getClientGroupId(MobiComUserPreference.getInstance(conversationBuilder.getContext()).getUserId(), conversationBuilder.getAgentIds(), conversationBuilder.getBotIds()) : null);
+            final String clientChannelKey = !TextUtils.isEmpty(conversationBuilder.getClientConversationId()) ? conversationBuilder.getClientConversationId() : (conversationBuilder.isSingleConversation() ? getClientGroupId(conversationBuilder.getUserIds(), conversationBuilder.getAgentIds(), conversationBuilder.getBotIds(), conversationBuilder.getContext()) : null);
             if (!TextUtils.isEmpty(clientChannelKey)) {
                 startOrGetConversation(conversationBuilder, handler);
             } else {
@@ -752,20 +764,27 @@ public class KmConversationHelper {
         new KmConversationInfoTask(context, conversationId, conversationInfoCallback).execute();
     }
 
-    private static String getClientGroupId(String userId, List<String> agentIds, List<String> botIds) throws KmException {
+    private static String getClientGroupId(List<String> userIds, List<String> agentIds, List<String> botIds, Context context) throws KmException {
 
         if (agentIds == null || agentIds.isEmpty()) {
             throw new KmException("Please add at-least one Agent");
         }
-
-        if (TextUtils.isEmpty(userId)) {
-            throw new KmException("UserId cannot be null");
+        if (userIds == null || userIds.isEmpty()) {
+            userIds = new ArrayList<>();
         }
 
         Collections.sort(agentIds);
 
         List<String> tempList = new ArrayList<>(agentIds);
-        tempList.add(userId);
+
+        String loginUserId = MobiComUserPreference.getInstance(context).getUserId();
+
+        if (!userIds.contains(loginUserId)) {
+            userIds.add(loginUserId);
+        }
+
+        Collections.sort(userIds);
+        tempList.addAll(userIds);
 
         if (botIds != null && !botIds.isEmpty()) {
             if (botIds.contains(KM_BOT)) {


### PR DESCRIPTION
* Added a way for adding more users in the group using the builder so that they can add users other than the agent Ids or bot ids.

* Tested with and without adding members in the group works fine.

Testing code: 
 ```
    List<String> agentIds = new ArrayList<>();
                    agentIds.add("<AGENT_ID>"); // Add AGENT_ID(s) to this list.
                    List<String> botIds = new ArrayList<>();
                    botIds.add("BOT_ID");// Add BOT_ID(s) to this list.

                    List<String> userIds = new ArrayList<>();
                    userIds.add("userId1");// Add USER id to this list.
                    userIds.add("userId2");// Add USER id  to this list.

                    new KmConversationBuilder(MainActivity.this)
                            .setAgentIds(agentIds)
                            .setBotIds(botIds)
                            .setUserIds(userIds)
                            .createConversation(new KmCallback() {
                                @Override
                                public void onSuccess(Object message) {

                                }

                                @Override
                                public void onFailure(Object error) {

                                }
                            });
```

1. Test without using  ```.setUserIds(userIds)``` if this is not added it should work as it was working before 
2. Test with using  ```.setUserIds(userIds)``` if this is added then users need be in that support group the user can chat in that support group as a group.


