### PR TITLE
[CM-227] add setting to change message status icon color

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -9,6 +9,7 @@
   "channelCustomMessageBgColor": "#cccccc",
   "sentContactMessageTextColor:": "#5fba7d",
   "receivedContactMessageTextColor": "#646262",
+  "messageStatusIconColor": "#5c5aa7",
   "sentMessageTextColor": "#FFFFFFFF",
   "receivedMessageTextColor": "#646262",
   "messageEditTextTextColor": "#000000",

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -111,6 +111,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean launchChatFromProfilePicOrName = false;
     private Map<String, Boolean> filterGallery;
     private boolean enableShareConversation = false;
+    private String messageStatusIconColor = "";
     private float[] sentMessageCornerRadii;
     private float[] receivedMessageCornerRadii;
     private KmFontModel fontModel;
@@ -624,6 +625,14 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public boolean isFaqOptionEnabled(int screen) {
         return enableFaqOption[screen - 1];
+    }
+
+    public String getMessageStatusIconColor() {
+        return messageStatusIconColor;
+    }
+
+    public void setMessageStatusIconColor(String messageStatusIconColor) {
+        this.messageStatusIconColor = messageStatusIconColor;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1532,7 +1532,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
             statusIconBackground = customView.findViewById(R.id.statusIconBackground);
 
             if (statusIconBackground != null) {
-                KmUtils.setGradientSolidColor(statusIconBackground, themeHelper.getSentMessageBackgroundColor());
+                KmUtils.setGradientSolidColor(statusIconBackground, themeHelper.getMessageStatusIconColor());
             }
 
             shareContactImage = (ImageView) mainContactShareLayout.findViewById(R.id.contact_share_image);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -22,6 +22,7 @@ public class KmThemeHelper implements KmCallback {
     private int sentMessageBackgroundColor = -1;
     private int sendButtonBackgroundColor = -1;
     private int sentMessageBorderColor = -1;
+    private int messageStatusIconColor = -1;
 
     public static KmThemeHelper getInstance(Context context, AlCustomizationSettings alCustomizationSettings) {
         if (kmThemeHelper == null) {
@@ -79,6 +80,19 @@ public class KmThemeHelper implements KmCallback {
             sendButtonBackgroundColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary);
         }
         return sendButtonBackgroundColor;
+    }
+
+    public int getMessageStatusIconColor() {
+        if (messageStatusIconColor == -1) {
+            String colorStr = alCustomizationSettings.getMessageStatusIconColor();
+
+            if (TextUtils.isEmpty(colorStr)) {
+                colorStr = appSettingPreferences.getPrimaryColor();
+            }
+
+            messageStatusIconColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.message_status_icon_colors);
+        }
+        return messageStatusIconColor;
     }
 
     public int getSecondaryColor() {


### PR DESCRIPTION
Added static setting to set custom message status icon color. This will override the primary color received from the server.