### PR TITLE
remove popup and imageIndex field from chat widget model

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -71,29 +71,11 @@ public class KmAppSettingModel extends JsonMarker {
     }
 
     public class KmChatWidget extends JsonMarker {
-        private boolean popup;
-        private Short iconIndex;
         private String primaryColor;
         private String secondaryColor;
         private boolean showPoweredBy;
         private long sessionTimeout;
         private int botMessageDelayInterval;
-
-        public boolean isPopup() {
-            return popup;
-        }
-
-        public void setPopup(boolean popup) {
-            this.popup = popup;
-        }
-
-        public Short getIconIndex() {
-            return iconIndex;
-        }
-
-        public void setIconIndex(Short iconIndex) {
-            this.iconIndex = iconIndex;
-        }
 
         public String getPrimaryColor() {
             return primaryColor;


### PR DESCRIPTION
This is failing in mobile if someone is uploading their own icon instead of using the pre exisitng ones. In that case the iconIndex field is sending the image name string instead of the index.