### PR TITLE
Add support for date and time picker in form template

### DIFF
--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api 'com.applozic.communication.message:mobicomkit:5.80'
+    api 'com.applozic.communication.message:mobicomkit:5.80.1'
     //api project(':mobicomkit')
 }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -20,6 +20,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.TimePicker;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -31,6 +32,7 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.KmFor
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmFlowLayout;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmRadioGroup;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmToast;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.json.GsonUtils;
 
@@ -42,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class KmFormItemAdapter extends RecyclerView.Adapter {
 
@@ -339,15 +342,20 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                             enteredText = KmFormStateHelper.getFormState(messageKey).getTextFields().get(i);
                         }
 
-                        if (textField.getValidation() != null
-                                && !TextUtils.isEmpty(textField.getValidation().getRegex())
-                                && !Pattern.compile(textField.getValidation().getRegex()).matcher(enteredText).matches()) {
-                            validationArray.put(i, INVALID_DATA);
-                            formStateModel.setValidationArray(validationArray);
-                            KmFormStateHelper.addFormState(messageKey, formStateModel);
-                            isValid = false;
-                        } else {
-                            validationArray.put(i, VALID_DATA);
+                        try {
+                            if (textField.getValidation() != null
+                                    && !TextUtils.isEmpty(textField.getValidation().getRegex())
+                                    && !Pattern.compile(textField.getValidation().getRegex()).matcher(enteredText).matches()) {
+                                validationArray.put(i, INVALID_DATA);
+                                formStateModel.setValidationArray(validationArray);
+                                KmFormStateHelper.addFormState(messageKey, formStateModel);
+                                isValid = false;
+                            } else {
+                                validationArray.put(i, VALID_DATA);
+                            }
+                        } catch (PatternSyntaxException exception) {
+                            exception.printStackTrace();
+                            KmToast.error(context, R.string.invalid_regex_error, Toast.LENGTH_SHORT).show();
                         }
                     }
                 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -1,5 +1,6 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.adapters;
 
+import android.app.DatePickerDialog;
 import android.content.Context;
 import android.text.Editable;
 import android.text.InputType;
@@ -13,6 +14,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -29,6 +31,8 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmFlow
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmRadioGroup;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +47,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
     private SparseArray<String> textFieldArray;
     private SparseArray<HashSet<Integer>> checkBoxStateArray;
     private SparseIntArray radioButtonSelectedIndices;
+    private SparseArray<String> dateFieldArray;
     private Map<String, String> hiddenFields;
     private KmFormStateModel formStateModel;
     private String messageKey;
@@ -71,6 +76,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
         radioButtonSelectedIndices = formStateModel.getSelectedRadioButtonIndex();
         hiddenFields = formStateModel.getHiddenFields();
         validationArray = formStateModel.getValidationArray();
+        dateFieldArray = formStateModel.getDateFieldArray();
 
         if (textFieldArray == null) {
             textFieldArray = new SparseArray<>();
@@ -90,6 +96,10 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
 
         if (validationArray == null) {
             validationArray = new SparseIntArray();
+        }
+
+        if (dateFieldArray == null) {
+            dateFieldArray = new SparseArray<>();
         }
 
         formStateModel.setTextFields(textFieldArray);
@@ -215,13 +225,40 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                         } else {
                             formItemViewHolder.flowLayout.setVisibility(View.GONE);
                         }
-                    }
+                    } else if (KmFormPayloadModel.Type.DATE.getValue().equals(payloadModel.getType()) || KmFormPayloadModel.Type.TIME.getValue().equals(payloadModel.getType())) {
+                        KmFormPayloadModel.DateTimePicker dateTimePickerModel = payloadModel.getDatePickerModel();
+                        if (dateTimePickerModel != null) {
+                            formItemViewHolder.formLabel.setVisibility(!TextUtils.isEmpty(dateTimePickerModel.getLabel()) ? View.VISIBLE : View.GONE);
+                            formItemViewHolder.formEditText.setVisibility(View.GONE);
+                            formItemViewHolder.formLabel.setText(dateTimePickerModel.getLabel());
 
+                            if()
+                        }
+                    }
                 }
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
+    }
+
+    private void openDateTimePickerDialog(final int position, final EditText editText) {
+        new DatePickerDialog(context, new DatePickerDialog.OnDateSetListener() {
+            @Override
+            public void onDateSet(DatePicker view, int year, int month, int dayOfMonth) {
+                Date date = new Date();
+                date.setYear(year);
+                date.setMonth(month);
+                date.setDate(dayOfMonth);
+
+                editText.setText(new SimpleDateFormat("dd/mm/yyyy").format(date));
+                notifyItemChanged(position);
+            }
+        }, 0, 0, 0).show();
+    }
+
+    private String getFormattedDate(Date date) {
+
     }
 
     public boolean isFormDataValid() {
@@ -286,6 +323,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
         EditText formEditText;
         LinearLayout formItemLayout;
         KmFlowLayout flowLayout;
+        EditText formDatePicker;
 
         public KmFormItemViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -294,6 +332,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
             formEditText = itemView.findViewById(R.id.kmFormEditText);
             formItemLayout = itemView.findViewById(R.id.kmFormItemLayout);
             flowLayout = itemView.findViewById(R.id.kmFormSelectionItems);
+            formDatePicker = itemView.findViewById(R.id.kmFormDatePicker);
 
             if (formEditText != null) {
                 formEditText.addTextChangedListener(new TextWatcher() {
@@ -313,6 +352,15 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                             formStateModel.setTextFields(textFieldArray);
                             KmFormStateHelper.addFormState(messageKey, formStateModel);
                         }
+                    }
+                });
+            }
+
+            if (formDatePicker != null) {
+                formDatePicker.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        openDateTimePickerDialog(getAdapterPosition(), formEditText);
                     }
                 });
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -63,6 +63,12 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
     private static final int VIEW_TYPE_SELECTION = 2;
     private static final int VIEW_TYPE_DATETIME = 3;
 
+    public static final String DEFAULT_DATE_FORMAT = "dd-MM-yyyy";
+    public static final String DEFAULT_TIME_FORMAT_24 = "HH:mm";
+    public static final String DEFAULT_TIME_FORMAT_12 = "hh:mm aa";
+    public static final String DEFAULT_DATE_TIME_FORMAT_24 = "dd-MM-yyyy HH:mm";
+    public static final String DEFAULT_DATE_TIME_FORMAT_12 = "dd-MM-yyyy hh:mm aa";
+
     public KmFormItemAdapter(Context context, List<KmFormPayloadModel> payloadList, String messageKey) {
         this.context = context;
         this.payloadList = payloadList;
@@ -141,10 +147,6 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                             }
                         }
                         return;
-                    }
-
-                    if(payloadModel.getType().equals("datetime-local")) {
-                        payloadModel.setType("time");
                     }
 
                     formItemViewHolder.formItemLayout.setVisibility(View.VISIBLE);
@@ -240,11 +242,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                             formItemViewHolder.formLabel.setText(dateTimePickerModel.getLabel());
                             formItemViewHolder.formDatePicker.setVisibility(View.VISIBLE);
 
-                            if (dateFieldArray.get(position) != null) {
-                                formItemViewHolder.formDatePicker.setText(getFormattedDateByType(payloadModel.getType(), dateFieldArray.get(position), dateTimePickerModel.isAmPm()));
-                            } else {
-                                formItemViewHolder.formDatePicker.setText("dd-mm-yyyy");
-                            }
+                            formItemViewHolder.formDatePicker.setText(getFormattedDateByType(payloadModel.getType(), dateFieldArray.get(position), dateTimePickerModel.isAmPm()));
                         }
                     }
                 }
@@ -304,24 +302,24 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
     }
 
     private String getFormattedDate(Long timeInMillis) {
-        return new SimpleDateFormat("dd-MM-yyyy").format(new Date(timeInMillis));
+        return new SimpleDateFormat(DEFAULT_DATE_FORMAT).format(new Date(timeInMillis));
     }
 
     private String getFormattedTime(Long timeInMillis, boolean isAmPm) {
-        return new SimpleDateFormat("hh:mm" + (isAmPm ? " aa" : "")).format(new Date(timeInMillis));
+        return new SimpleDateFormat(isAmPm ? DEFAULT_TIME_FORMAT_12 : DEFAULT_TIME_FORMAT_24).format(new Date(timeInMillis));
     }
 
     private String getFormattedDateTime(Long timeInMillis, boolean isAmPm) {
-        return new SimpleDateFormat("dd-MM-yyyy hh:mm" + (isAmPm ? " aa" : "")).format(new Date(timeInMillis));
+        return new SimpleDateFormat(isAmPm ? DEFAULT_DATE_TIME_FORMAT_12 : DEFAULT_DATE_TIME_FORMAT_24).format(new Date(timeInMillis));
     }
 
     private String getFormattedDateByType(String type, Long timeInMillis, boolean isAmPm) {
         if (KmFormPayloadModel.Type.DATE.getValue().equals(type)) {
-            return getFormattedDate(timeInMillis);
+            return timeInMillis == null ? DEFAULT_DATE_FORMAT : getFormattedDate(timeInMillis);
         } else if (KmFormPayloadModel.Type.TIME.getValue().equals(type)) {
-            return getFormattedTime(timeInMillis, isAmPm);
+            return timeInMillis == null ? (isAmPm ? DEFAULT_TIME_FORMAT_12 : DEFAULT_TIME_FORMAT_24) : getFormattedTime(timeInMillis, isAmPm);
         } else if (KmFormPayloadModel.Type.DATE_TIME.getValue().equals(type)) {
-            return getFormattedDateTime(timeInMillis, isAmPm);
+            return timeInMillis == null ? (isAmPm ? DEFAULT_DATE_TIME_FORMAT_12 : DEFAULT_DATE_TIME_FORMAT_24) : getFormattedDateTime(timeInMillis, isAmPm);
         }
         return "";
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -154,7 +154,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
 
                     formItemViewHolder.formItemLayout.setVisibility(View.VISIBLE);
 
-                    if (isTypeText(payloadModel.getType())) {
+                    if (payloadModel.isTypeText()) {
                         KmFormPayloadModel.Text textModel = payloadModel.getTextModel();
 
                         formItemViewHolder.formLabel.setVisibility(!TextUtils.isEmpty(textModel.getLabel()) ? View.VISIBLE : View.GONE);
@@ -234,10 +234,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                         } else {
                             formItemViewHolder.flowLayout.setVisibility(View.GONE);
                         }
-                    } else if (KmFormPayloadModel.Type.DATE.getValue().equals(payloadModel.getType())
-                            || KmFormPayloadModel.Type.TIME.getValue().equals(payloadModel.getType())
-                            || KmFormPayloadModel.Type.DATE_TIME.getValue().equals(payloadModel.getType())) {
-
+                    } else if (payloadModel.isTypeDateTime()) {
                         KmFormPayloadModel.DateTimePicker dateTimePickerModel = payloadModel.getDatePickerModel();
                         if (dateTimePickerModel != null) {
                             formItemViewHolder.formLabel.setVisibility(!TextUtils.isEmpty(dateTimePickerModel.getLabel()) ? View.VISIBLE : View.GONE);
@@ -466,9 +463,5 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
             formEditText.setTransformationMethod(PasswordTransformationMethod.getInstance());
             return formEditText;
         }
-    }
-
-    private boolean isTypeText(String type) {
-        return KmFormPayloadModel.Type.TEXT.getValue().equals(type) || KmFormPayloadModel.Type.PASSWORD.getValue().equals(type);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
@@ -107,6 +107,14 @@ public class KmFormStateHelper {
             if (formStateModel.getHiddenFields() != null) {
                 formDataMap.putAll(formStateModel.getHiddenFields());
             }
+
+            if (formStateModel.getDateFieldArray() != null) {
+                for (int i = 0; i < formStateModel.getDateFieldArray().size(); i++) {
+                    int key = formStateModel.getDateFieldArray().keyAt(i);
+                    KmFormPayloadModel.DateTimePicker dateTimePicker = formPayloadModelList.get(key).getDatePickerModel();
+                    formDataMap.put(dateTimePicker.getLabel(), formStateModel.getDateFieldArray().get(key).toString());  //Might need to convert to formatted date
+                }
+            }
         }
 
         return formDataMap;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
@@ -15,7 +15,7 @@ public class KmFormStateModel extends JsonMarker {
     private SparseArray<HashSet<Integer>> checkBoxStates;
     private Map<String, String> hiddenFields;
     private SparseIntArray validationArray;
-    private SparseArray<String> dateFieldArray;
+    private SparseArray<Long> dateFieldArray;
 
     public SparseArray<String> getTextFields() {
         return textFields;
@@ -57,11 +57,11 @@ public class KmFormStateModel extends JsonMarker {
         this.validationArray = validationArray;
     }
 
-    public SparseArray<String> getDateFieldArray() {
+    public SparseArray<Long> getDateFieldArray() {
         return dateFieldArray;
     }
 
-    public void setDateFieldArray(SparseArray<String> dateFieldArray) {
+    public void setDateFieldArray(SparseArray<Long> dateFieldArray) {
         this.dateFieldArray = dateFieldArray;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
@@ -15,6 +15,7 @@ public class KmFormStateModel extends JsonMarker {
     private SparseArray<HashSet<Integer>> checkBoxStates;
     private Map<String, String> hiddenFields;
     private SparseIntArray validationArray;
+    private SparseArray<String> dateFieldArray;
 
     public SparseArray<String> getTextFields() {
         return textFields;
@@ -54,5 +55,13 @@ public class KmFormStateModel extends JsonMarker {
 
     public void setValidationArray(SparseIntArray validationArray) {
         this.validationArray = validationArray;
+    }
+
+    public SparseArray<String> getDateFieldArray() {
+        return dateFieldArray;
+    }
+
+    public void setDateFieldArray(SparseArray<String> dateFieldArray) {
+        this.dateFieldArray = dateFieldArray;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -28,6 +28,16 @@ public class KmFormPayloadModel<T> extends JsonMarker {
         this.data = data;
     }
 
+    public boolean isTypeText() {
+        return KmFormPayloadModel.Type.TEXT.getValue().equals(type) || KmFormPayloadModel.Type.PASSWORD.getValue().equals(type);
+    }
+
+    public boolean isTypeDateTime() {
+        return KmFormPayloadModel.Type.DATE.getValue().equals(type)
+                || KmFormPayloadModel.Type.TIME.getValue().equals(type)
+                || KmFormPayloadModel.Type.DATE_TIME.getValue().equals(type);
+    }
+
     public static class Text extends JsonMarker {
         private String label;
         private String placeholder;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -153,6 +153,7 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
     public static class DateTimePicker extends JsonMarker {
         private String label;
+        private boolean amPm = true;
 
         public String getLabel() {
             return label;
@@ -160,6 +161,14 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
         public void setLabel(String label) {
             this.label = label;
+        }
+
+        public boolean isAmPm() {
+            return amPm;
+        }
+
+        public void setAmPm(boolean amPm) {
+            this.amPm = amPm;
         }
     }
 
@@ -169,6 +178,7 @@ public class KmFormPayloadModel<T> extends JsonMarker {
         CHECKBOX("checkbox"),
         DATE("date"),
         TIME("time"),
+        DATE_TIME("datetime-local"),
         ACTION("action"),
         SUBMIT("submit");
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -151,8 +151,26 @@ public class KmFormPayloadModel<T> extends JsonMarker {
         }
     }
 
+    public static class DateTimePicker extends JsonMarker {
+        private String label;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+    }
+
     public enum Type {
-        TEXT("text"), PASSWORD("password"), HIDDEN("hidden"), RADIO("radio"), CHECKBOX("checkbox"), ACTION("action"), SUBMIT("submit");
+        TEXT("text"), PASSWORD("password"),
+        HIDDEN("hidden"), RADIO("radio"),
+        CHECKBOX("checkbox"),
+        DATE("date"),
+        TIME("time"),
+        ACTION("action"),
+        SUBMIT("submit");
 
         private String value;
 
@@ -182,6 +200,11 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
     public KmRMActionModel<KmRMActionModel.SubmitButton> getAction() {
         return new Gson().fromJson(GsonUtils.getJsonFromObject(data, Object.class), new TypeToken<KmRMActionModel<KmRMActionModel.SubmitButton>>() {
+        }.getType());
+    }
+
+    public KmFormPayloadModel.DateTimePicker getDatePickerModel() {
+        return new Gson().fromJson(GsonUtils.getJsonFromObject(data, Object.class), new TypeToken<KmFormPayloadModel.DateTimePicker>() {
         }.getType());
     }
 

--- a/kommunicateui/src/main/res/layout/km_form_item_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_form_item_layout.xml
@@ -31,7 +31,7 @@
         android:layout_marginTop="5dp"
         android:visibility="gone" />
 
-    <EditText
+    <TextView
         android:id="@+id/kmFormDatePicker"
         android:layout_width="240dp"
         android:layout_height="32dp"
@@ -39,7 +39,6 @@
         android:background="@drawable/km_form_edit_text_background"
         android:maxLines="1"
         android:padding="5dp"
-        android:inputType="date"
         android:textSize="14sp"
         android:visibility="gone" />
 </LinearLayout>

--- a/kommunicateui/src/main/res/layout/km_form_item_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_form_item_layout.xml
@@ -3,8 +3,8 @@
     android:id="@+id/kmFormItemLayout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="10dp"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="10dp">
 
     <TextView
         android:id="@+id/kmFormLabel"
@@ -14,20 +14,32 @@
 
     <EditText
         android:id="@+id/kmFormEditText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
         android:width="240dp"
         android:height="32dp"
-        android:layout_marginTop="5dp"
         android:background="@drawable/km_form_edit_text_background"
-        android:layout_width="wrap_content"
-        android:padding="5dp"
         android:maxLines="1"
-        android:textSize="14sp"
-        android:layout_height="wrap_content" />
+        android:padding="5dp"
+        android:textSize="14sp" />
 
     <com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmFlowLayout
         android:id="@+id/kmFormSelectionItems"
         android:layout_width="220dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
+        android:visibility="gone" />
+
+    <EditText
+        android:id="@+id/kmFormDatePicker"
+        android:layout_width="240dp"
+        android:layout_height="32dp"
+        android:layout_marginTop="5dp"
+        android:background="@drawable/km_form_edit_text_background"
+        android:maxLines="1"
+        android:padding="5dp"
+        android:inputType="date"
+        android:textSize="14sp"
         android:visibility="gone" />
 </LinearLayout>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -282,4 +282,5 @@
     <string name="remaining_char_message">%1$d characters remaining</string>
     <string name="away">Away</string>
     <string name="default_form_validation_error_text">Please enter valid data</string>
+    <string name="invalid_regex_error">Invalid validation regex</string>
 </resources>


### PR DESCRIPTION
* Added support for three types: date, time and datetime-local
* Added support for 24hrs and 12hrs in time

Sample JSON:

```
{
"payload": [
      {
        "type": "date",     // for date
        "data": {
          "label": "Date"
        }
      }, 
      {
        "type": "time",  //for time
        "data": {
          "label": "Time",
           "amPm": true.      //optional field to set 24 hr and 12 hr time. Set false for 24 hrs
        }
      },
      {
        "type": "datetime-local",  //for time
        "data": {
          "label": "Date & Time",
           "amPm": true.      //optional field to set 24 hr and 12 hr time. Set false for 24 hrs
        }
    ]
}
```