### PR TITLE
CM-477: change toolbar text color from settings file

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -20,6 +20,8 @@ public class AlCustomizationSettings extends JsonMarker {
     private String editTextBackgroundColorOrDrawable;
     private String editTextLayoutBackgroundColorOrDrawable;
     private String channelCustomMessageBgColor = "#cccccc";
+    private String toolbarTitleColor = "#ffffff";
+    private String toolbarSubtitleColor = "#ffffff";
 
     private String sentContactMessageTextColor = "#5fba7d";
     private String receivedContactMessageTextColor = "#646262";
@@ -639,6 +641,22 @@ public class AlCustomizationSettings extends JsonMarker {
         return restrictedWordRegex;
     }
 
+    public String getToolbarTitleColor() {
+        return toolbarTitleColor;
+    }
+
+    public void setToolbarTitleColor(String toolbarTitleColor) {
+        this.toolbarTitleColor = toolbarTitleColor;
+    }
+
+    public String getToolbarSubtitleColor() {
+        return toolbarSubtitleColor;
+    }
+
+    public void setToolbarSubtitleColor(String toolbarSubtitleColor) {
+        this.toolbarSubtitleColor = toolbarSubtitleColor;
+    }
+
     @Override
     public String toString() {
         return "AlCustomizationSettings{" +
@@ -695,6 +713,8 @@ public class AlCustomizationSettings extends JsonMarker {
                 ", maxAttachmentAllowed=" + maxAttachmentAllowed +
                 ", maxAttachmentSizeAllowed=" + maxAttachmentSizeAllowed +
                 ", totalOnlineUsers=" + totalOnlineUsers +
+                ", toolbarTitleColor=" + toolbarTitleColor +
+                ", toolbarSubtitleColor=" + toolbarSubtitleColor +
                 '}';
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -365,6 +365,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getSecondaryColor());
         customToolbarLayout = myToolbar.findViewById(R.id.custom_toolbar_root_layout);
         setSupportActionBar(myToolbar);
+        setToolbarTitleSubtitleColorFromSettings();
         baseContactService = new AppContactService(this);
         conversationUIService = new ConversationUIService(this);
         mobiComMessageService = new MobiComMessageService(this, MessageIntentService.class);
@@ -679,6 +680,29 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public int parseColorWithDefaultWhite(String color) {
+        try {
+            return Color.parseColor(color);
+        } catch (Exception invalidColorException) {
+            return Color.WHITE;
+        }
+    }
+
+    public void setToolbarTitleSubtitleColorFromSettings() {
+        if(customToolbarLayout == null) {
+            return;
+        }
+
+        int titleColor = parseColorWithDefaultWhite(alCustomizationSettings.getToolbarTitleColor());
+        int subtitleColor = parseColorWithDefaultWhite(alCustomizationSettings.getToolbarSubtitleColor());
+
+        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_title)).setTextColor(titleColor);
+        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_subtitle)).setTextColor(subtitleColor);
+        ((TextView) customToolbarLayout.findViewById(R.id.offlineTextView)).setTextColor(subtitleColor);
+        ((TextView) customToolbarLayout.findViewById(R.id.onlineTextView)).setTextColor(subtitleColor);
+        ((TextView) customToolbarLayout.findViewById(R.id.awayTextView)).setTextColor(subtitleColor);
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -682,27 +682,14 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         }
     }
 
-    public int parseColorWithDefaultWhite(String color) {
-        try {
-            return Color.parseColor(color);
-        } catch (Exception invalidColorException) {
-            return Color.WHITE;
-        }
-    }
-
     public void setToolbarTitleSubtitleColorFromSettings() {
         if(customToolbarLayout == null) {
             return;
         }
 
-        int titleColor = parseColorWithDefaultWhite(alCustomizationSettings.getToolbarTitleColor());
-        int subtitleColor = parseColorWithDefaultWhite(alCustomizationSettings.getToolbarSubtitleColor());
-
-        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_title)).setTextColor(titleColor);
-        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_subtitle)).setTextColor(subtitleColor);
-        ((TextView) customToolbarLayout.findViewById(R.id.offlineTextView)).setTextColor(subtitleColor);
-        ((TextView) customToolbarLayout.findViewById(R.id.onlineTextView)).setTextColor(subtitleColor);
-        ((TextView) customToolbarLayout.findViewById(R.id.awayTextView)).setTextColor(subtitleColor);
+        KmThemeHelper kmThemeHelper = KmThemeHelper.getInstance(this, alCustomizationSettings);
+        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_title)).setTextColor(kmThemeHelper.getToolbarTitleColor());
+        ((TextView) customToolbarLayout.findViewById(R.id.toolbar_subtitle)).setTextColor(kmThemeHelper.getToolbarSubtitleColor());
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -23,6 +23,8 @@ public class KmThemeHelper implements KmCallback {
     private int sendButtonBackgroundColor = -1;
     private int sentMessageBorderColor = -1;
     private int messageStatusIconColor = -1;
+    private int toolbarTitleColor = -1;
+    private int toolbarSubtitleColor = -1;
 
     public static KmThemeHelper getInstance(Context context, AlCustomizationSettings alCustomizationSettings) {
         if (kmThemeHelper == null) {
@@ -38,12 +40,33 @@ public class KmThemeHelper implements KmCallback {
         appSettingPreferences.setCallback(this);
     }
 
+    public int parseColorWithDefault(String color, int defaultColor) {
+        try {
+            return Color.parseColor(color);
+        } catch (Exception invalidColorException) {
+            return defaultColor;
+        }
+    }
+
     public int getPrimaryColor() {
         if (primaryColor == -1) {
-            String colorStr = appSettingPreferences.getPrimaryColor();
-            primaryColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary);
+            primaryColor = parseColorWithDefault(appSettingPreferences.getPrimaryColor(), context.getResources().getColor(R.color.applozic_theme_color_primary));
         }
         return primaryColor;
+    }
+
+    public int getToolbarTitleColor() {
+        if (toolbarTitleColor == -1) {
+            toolbarTitleColor = parseColorWithDefault(alCustomizationSettings.getToolbarTitleColor(), context.getResources().getColor(R.color.toolbar_title_color));
+        }
+        return toolbarTitleColor;
+    }
+
+    public int getToolbarSubtitleColor() {
+        if (toolbarSubtitleColor == -1) {
+            toolbarSubtitleColor = parseColorWithDefault(alCustomizationSettings.getToolbarSubtitleColor(), context.getResources().getColor(R.color.toolbar_subtitle_color));
+        }
+        return toolbarSubtitleColor;
     }
 
     public int getSentMessageBackgroundColor() {
@@ -53,19 +76,19 @@ public class KmThemeHelper implements KmCallback {
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
             }
-            sentMessageBackgroundColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary);
+            sentMessageBackgroundColor = parseColorWithDefault(colorStr, context.getResources().getColor(R.color.applozic_theme_color_primary));
         }
         return sentMessageBackgroundColor;
     }
 
     public int getSentMessageBorderColor() {
-        if (sentMessageBackgroundColor == -1) {
+        if (sentMessageBorderColor == -1) {
             String colorStr = alCustomizationSettings.getSentMessageBorderColor();
 
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
             }
-            sentMessageBorderColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary);
+            sentMessageBorderColor = parseColorWithDefault(colorStr, context.getResources().getColor(R.color.applozic_theme_color_primary));
         }
         return sentMessageBorderColor;
     }
@@ -77,7 +100,7 @@ public class KmThemeHelper implements KmCallback {
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
             }
-            sendButtonBackgroundColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary);
+            sendButtonBackgroundColor = parseColorWithDefault(colorStr, context.getResources().getColor(R.color.applozic_theme_color_primary));
         }
         return sendButtonBackgroundColor;
     }
@@ -90,15 +113,14 @@ public class KmThemeHelper implements KmCallback {
                 colorStr = appSettingPreferences.getPrimaryColor();
             }
 
-            messageStatusIconColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.message_status_icon_colors);
+            messageStatusIconColor = parseColorWithDefault(colorStr, context.getResources().getColor(R.color.message_status_icon_colors));
         }
         return messageStatusIconColor;
     }
 
     public int getSecondaryColor() {
         if (secondaryColor == -1) {
-            String colorStr = appSettingPreferences.getSecondaryColor();
-            secondaryColor = !TextUtils.isEmpty(colorStr) ? Color.parseColor(colorStr) : context.getResources().getColor(R.color.applozic_theme_color_primary_dark);
+            secondaryColor = parseColorWithDefault(appSettingPreferences.getSecondaryColor(), context.getResources().getColor(R.color.applozic_theme_color_primary_dark));
         }
         return secondaryColor;
     }
@@ -118,7 +140,5 @@ public class KmThemeHelper implements KmCallback {
     }
 
     @Override
-    public void onFailure(Object error) {
-
-    }
+    public void onFailure(Object error) { }
 }

--- a/kommunicateui/src/main/res/values/mobicom_colors.xml
+++ b/kommunicateui/src/main/res/values/mobicom_colors.xml
@@ -36,6 +36,8 @@
     <color name="incoming_call">#ff0099cc</color>
     <color name="outgoing_call">#ff008000</color>
 
+    <color name="toolbar_title_color">#FFFFFFFF</color>
+    <color name="toolbar_subtitle_color">#FFFFFFFF</color>
 
     <color name="contact_name_text_color">#ff000000</color>
     <color name="contact_userId_text_color">#838b83</color>


### PR DESCRIPTION
Change:
To change the conversation screen toolbar title and subtitle color now you can add "toolbarTitleColor" and "toolbarSubtitleColor" fields to the applozic-settings.json file. Any error in entry will result in the default being white.
**_Tested locally_**, by going through a simple flow to customize the color, as it would likely be followed by a customer.

Note: Working on moving the toolbar logic to new class. This doesn't concern the issue CM-477 and hasn't been pushed now. It's WIP.