### PR TITLE
add support for dropdown list in form template

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/utils/KmDateUtils.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmDateUtils.java
@@ -1,7 +1,6 @@
 package io.kommunicate.utils;
 
-import android.text.TextUtils;
-
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -16,39 +15,24 @@ public class KmDateUtils {
     private static final String FORM_SERIALISED_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
 
-    public static String getLocalisedDateFormat(String dateFormat) {
-        if (!TextUtils.isEmpty(dateFormat)) {
-            return dateFormat;
-        } else if (Locale.getDefault().equals(Locale.US)) {
-            return LocaleDateFormat.US;
-        }
+    public static String getLocalisedDateFormat() {
         return DEFAULT_DATE_FORMAT;
     }
 
-    public static String getLocalisedDateTimeFormat(String dateFormat, boolean isAmPm) {
-        return getLocalisedDateFormat(dateFormat) + " " + getTimeFormat(isAmPm);
+    public static String getLocalisedDateTimeFormat(boolean isAmPm) {
+        return getLocalisedDateFormat() + " " + getTimeFormat(isAmPm);
     }
 
-    public static String getFormattedDate(Long timeInMillis, String dateFormat) {
-        try {
-            return new SimpleDateFormat(getLocalisedDateFormat(dateFormat), Locale.getDefault()).format(new Date(timeInMillis));
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-        return new SimpleDateFormat(getLocalisedDateFormat(null), Locale.getDefault()).format(new Date(timeInMillis));
+    public static String getFormattedDate(Long timeInMillis) {
+        return DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault()).format(new Date(timeInMillis));
     }
 
     public static String getFormattedTime(Long timeInMillis, boolean isAmPm) {
         return new SimpleDateFormat(isAmPm ? DEFAULT_TIME_FORMAT_12 : DEFAULT_TIME_FORMAT_24, Locale.getDefault()).format(new Date(timeInMillis));
     }
 
-    public static String getFormattedDateTime(Long timeInMillis, String dateFormat, boolean isAmPm) {
-        try {
-            return new SimpleDateFormat(getLocalisedDateTimeFormat(dateFormat, isAmPm), Locale.getDefault()).format(new Date(timeInMillis));
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-        }
-        return new SimpleDateFormat(getLocalisedDateTimeFormat(null, isAmPm), Locale.getDefault()).format(new Date(timeInMillis));
+    public static String getFormattedDateTime(Long timeInMillis, boolean isAmPm) {
+        return DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault()).format(new Date(timeInMillis)) + " " + getFormattedTime(timeInMillis, isAmPm);
     }
 
     public static String getTimeFormat(boolean isAmPm) {
@@ -65,9 +49,5 @@ public class KmDateUtils {
 
     public static String getFormSerialisedDateTimeFormat(Long timeStamp) {
         return new SimpleDateFormat(FORM_SERIALISED_DATE_TIME_FORMAT, Locale.getDefault()).format(new Date(timeStamp));
-    }
-
-    public static class LocaleDateFormat {
-        public static final String US = "MM/dd/yyyy";
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmDateUtils.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmDateUtils.java
@@ -1,0 +1,73 @@
+package io.kommunicate.utils;
+
+import android.text.TextUtils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class KmDateUtils {
+
+    public static final String DEFAULT_DATE_FORMAT = "dd/MM/yyyy";
+    public static final String DEFAULT_TIME_FORMAT_24 = "HH:mm";
+    public static final String DEFAULT_TIME_FORMAT_12 = "hh:mm aa";
+
+    private static final String FORM_SERIALISED_DATE_FORMAT = "yyyy-MM-dd";
+    private static final String FORM_SERIALISED_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm";
+
+
+    public static String getLocalisedDateFormat(String dateFormat) {
+        if (!TextUtils.isEmpty(dateFormat)) {
+            return dateFormat;
+        } else if (Locale.getDefault().equals(Locale.US)) {
+            return LocaleDateFormat.US;
+        }
+        return DEFAULT_DATE_FORMAT;
+    }
+
+    public static String getLocalisedDateTimeFormat(String dateFormat, boolean isAmPm) {
+        return getLocalisedDateFormat(dateFormat) + " " + getTimeFormat(isAmPm);
+    }
+
+    public static String getFormattedDate(Long timeInMillis, String dateFormat) {
+        try {
+            return new SimpleDateFormat(getLocalisedDateFormat(dateFormat), Locale.getDefault()).format(new Date(timeInMillis));
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
+        return new SimpleDateFormat(getLocalisedDateFormat(null), Locale.getDefault()).format(new Date(timeInMillis));
+    }
+
+    public static String getFormattedTime(Long timeInMillis, boolean isAmPm) {
+        return new SimpleDateFormat(isAmPm ? DEFAULT_TIME_FORMAT_12 : DEFAULT_TIME_FORMAT_24, Locale.getDefault()).format(new Date(timeInMillis));
+    }
+
+    public static String getFormattedDateTime(Long timeInMillis, String dateFormat, boolean isAmPm) {
+        try {
+            return new SimpleDateFormat(getLocalisedDateTimeFormat(dateFormat, isAmPm), Locale.getDefault()).format(new Date(timeInMillis));
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        }
+        return new SimpleDateFormat(getLocalisedDateTimeFormat(null, isAmPm), Locale.getDefault()).format(new Date(timeInMillis));
+    }
+
+    public static String getTimeFormat(boolean isAmPm) {
+        return isAmPm ? DEFAULT_TIME_FORMAT_12 : DEFAULT_TIME_FORMAT_24;
+    }
+
+    public static String getFormSerialisedDateFormat(Long timeStamp) {
+        return new SimpleDateFormat(FORM_SERIALISED_DATE_FORMAT, Locale.getDefault()).format(new Date(timeStamp));
+    }
+
+    public static String getFormSerialisedTimeFormat(Long timeStamp) {
+        return new SimpleDateFormat(DEFAULT_TIME_FORMAT_24, Locale.getDefault()).format(new Date(timeStamp));
+    }
+
+    public static String getFormSerialisedDateTimeFormat(Long timeStamp) {
+        return new SimpleDateFormat(FORM_SERIALISED_DATE_TIME_FORMAT, Locale.getDefault()).format(new Date(timeStamp));
+    }
+
+    public static class LocaleDateFormat {
+        public static final String US = "MM/dd/yyyy";
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1077,13 +1077,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
         channel = ChannelService.getInstance(getActivity()).getChannelByChannelKey(channel.getKey());
 
-        if (channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS && !KmUtils.isAgent(getContext())) {
-            setFeedbackDisplay(true);
-        } else {
-            //conversation is open
-            //if the conversation is opened from the dashboard while the feedback input fragment is open, the feedback fragment will be closed
-            setFeedbackDisplay(false);
-        }
+        //conversation is open
+        //if the conversation is opened from the dashboard while the feedback input fragment is open, the feedback fragment will be closed
+        setFeedbackDisplay(channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS && !KmUtils.isAgent(getContext()));
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -243,7 +243,7 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                                             ? R.drawable.ic_query_builder_black_18dp
                                             : R.drawable.ic_calendar_today_black_18dp,
                                     0);
-                            formItemViewHolder.formDatePicker.setText(getFormattedDateByType(payloadModel.getType(), payloadModel.getDatePickerModel().getDateFormat(), dateFieldArray.get(position), dateTimePickerModel.isAmPm()));
+                            formItemViewHolder.formDatePicker.setText(getFormattedDateByType(payloadModel.getType(), dateFieldArray.get(position), dateTimePickerModel.isAmPm()));
                         }
                     } else if (payloadModel.isTypeDropdown()) {
                         final KmFormPayloadModel.DropdownList dropdownList = payloadModel.getDropdownList();
@@ -365,13 +365,13 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
         }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), !isAmPm).show();
     }
 
-    private String getFormattedDateByType(String type, String dateFormat, Long timeInMillis, boolean isAmPm) {
+    private String getFormattedDateByType(String type, Long timeInMillis, boolean isAmPm) {
         if (KmFormPayloadModel.Type.DATE.getValue().equals(type)) {
-            return timeInMillis == null ? KmDateUtils.getLocalisedDateFormat(dateFormat) : KmDateUtils.getFormattedDate(timeInMillis, dateFormat);
+            return timeInMillis == null ? KmDateUtils.getLocalisedDateFormat() : KmDateUtils.getFormattedDate(timeInMillis);
         } else if (KmFormPayloadModel.Type.TIME.getValue().equals(type)) {
             return timeInMillis == null ? KmDateUtils.getTimeFormat(isAmPm) : KmDateUtils.getFormattedTime(timeInMillis, isAmPm);
         } else if (KmFormPayloadModel.Type.DATE_TIME.getValue().equals(type)) {
-            return timeInMillis == null ? KmDateUtils.getLocalisedDateTimeFormat(dateFormat, isAmPm) : KmDateUtils.getFormattedDateTime(timeInMillis, dateFormat, isAmPm);
+            return timeInMillis == null ? KmDateUtils.getLocalisedDateTimeFormat(isAmPm) : KmDateUtils.getFormattedDateTime(timeInMillis, isAmPm);
         }
         return "";
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/form/KmDropdownItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/form/KmDropdownItemAdapter.java
@@ -1,0 +1,38 @@
+package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.form;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
+
+import java.util.List;
+
+public class KmDropdownItemAdapter extends ArrayAdapter<KmFormPayloadModel.Options> {
+    public KmDropdownItemAdapter(@NonNull Context context, int textViewResourceId, List<KmFormPayloadModel.Options> itemList) {
+        super(context, textViewResourceId, itemList);
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        TextView label = (TextView) super.getView(position, convertView, parent);
+        label.setTextColor(Color.BLACK);
+        label.setText(getItem(position).getLabel());
+        return label;
+    }
+
+    @Override
+    public View getDropDownView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        TextView label = (TextView) super.getDropDownView(position, convertView, parent);
+        label.setTextColor(Color.BLACK);
+        label.setText(getItem(position).getLabel());
+        return label;
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
@@ -8,10 +8,12 @@ import com.applozic.mobicommons.json.GsonUtils;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class KmFormStateHelper {
@@ -110,11 +112,40 @@ public class KmFormStateHelper {
                 for (int i = 0; i < formStateModel.getDateFieldArray().size(); i++) {
                     int key = formStateModel.getDateFieldArray().keyAt(i);
                     KmFormPayloadModel.DateTimePicker dateTimePicker = formPayloadModelList.get(key).getDatePickerModel();
-                    formDataMap.put(dateTimePicker.getLabel(), formStateModel.getDateFieldArray().get(key).toString());  //Might need to convert to formatted date
+
+                    if (KmFormPayloadModel.Type.DATE.getValue().equals(formPayloadModelList.get(key).getType())) {
+                        formDataMap.put(dateTimePicker.getLabel(), getFormattedDate(formStateModel.getDateFieldArray().get(key)));
+                    } else if (KmFormPayloadModel.Type.TIME.getValue().equals(formPayloadModelList.get(key).getType())) {
+                        formDataMap.put(dateTimePicker.getLabel(), getFormattedTime(formStateModel.getDateFieldArray().get(key)));
+                    } else {
+                        formDataMap.put(dateTimePicker.getLabel(), getFormattedDate(formStateModel.getDateFieldArray().get(key)) + "T" + getFormattedTime(formStateModel.getDateFieldArray().get(key)));
+                    }
+                }
+            }
+
+            if (formStateModel.getDropdownFieldArray() != null) {
+                for (int i = 0; i < formStateModel.getDropdownFieldArray().size(); i++) {
+                    formDataMap.put(formPayloadModelList.get(formStateModel.getDropdownFieldArray().keyAt(i)).getDropdownList().getName(), formStateModel.getDropdownFieldArray().valueAt(i).getValue());
                 }
             }
         }
 
         return formDataMap;
+    }
+
+    private static String getFormattedDate(Long timeStamp) {
+        Calendar calendar = Calendar.getInstance(Locale.getDefault());
+        calendar.setTimeInMillis(timeStamp);
+        return calendar.get(Calendar.YEAR) + "-" + getDoubleDigitTime(calendar.get(Calendar.MONTH) + 1) + "-" + getDoubleDigitTime(calendar.get(Calendar.DAY_OF_MONTH));
+    }
+
+    private static String getFormattedTime(Long timeStamp) {
+        Calendar calendar = Calendar.getInstance(Locale.getDefault());
+        calendar.setTimeInMillis(timeStamp);
+        return getDoubleDigitTime(calendar.get(Calendar.HOUR_OF_DAY)) + ":" + getDoubleDigitTime(calendar.get(Calendar.MINUTE));
+    }
+
+    private static String getDoubleDigitTime(int time) {
+        return time < 10 ? "0" + time : String.valueOf(time);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/helpers/KmFormStateHelper.java
@@ -8,13 +8,13 @@ import com.applozic.mobicommons.json.GsonUtils;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+
+import io.kommunicate.utils.KmDateUtils;
 
 public class KmFormStateHelper {
 
@@ -114,11 +114,11 @@ public class KmFormStateHelper {
                     KmFormPayloadModel.DateTimePicker dateTimePicker = formPayloadModelList.get(key).getDatePickerModel();
 
                     if (KmFormPayloadModel.Type.DATE.getValue().equals(formPayloadModelList.get(key).getType())) {
-                        formDataMap.put(dateTimePicker.getLabel(), getFormattedDate(formStateModel.getDateFieldArray().get(key)));
+                        formDataMap.put(dateTimePicker.getLabel(), KmDateUtils.getFormSerialisedDateFormat(formStateModel.getDateFieldArray().get(key)));
                     } else if (KmFormPayloadModel.Type.TIME.getValue().equals(formPayloadModelList.get(key).getType())) {
-                        formDataMap.put(dateTimePicker.getLabel(), getFormattedTime(formStateModel.getDateFieldArray().get(key)));
+                        formDataMap.put(dateTimePicker.getLabel(), KmDateUtils.getFormSerialisedTimeFormat(formStateModel.getDateFieldArray().get(key)));
                     } else {
-                        formDataMap.put(dateTimePicker.getLabel(), getFormattedDate(formStateModel.getDateFieldArray().get(key)) + "T" + getFormattedTime(formStateModel.getDateFieldArray().get(key)));
+                        formDataMap.put(dateTimePicker.getLabel(), KmDateUtils.getFormSerialisedDateTimeFormat(formStateModel.getDateFieldArray().get(key)));
                     }
                 }
             }
@@ -131,21 +131,5 @@ public class KmFormStateHelper {
         }
 
         return formDataMap;
-    }
-
-    private static String getFormattedDate(Long timeStamp) {
-        Calendar calendar = Calendar.getInstance(Locale.getDefault());
-        calendar.setTimeInMillis(timeStamp);
-        return calendar.get(Calendar.YEAR) + "-" + getDoubleDigitTime(calendar.get(Calendar.MONTH) + 1) + "-" + getDoubleDigitTime(calendar.get(Calendar.DAY_OF_MONTH));
-    }
-
-    private static String getFormattedTime(Long timeStamp) {
-        Calendar calendar = Calendar.getInstance(Locale.getDefault());
-        calendar.setTimeInMillis(timeStamp);
-        return getDoubleDigitTime(calendar.get(Calendar.HOUR_OF_DAY)) + ":" + getDoubleDigitTime(calendar.get(Calendar.MINUTE));
-    }
-
-    private static String getDoubleDigitTime(int time) {
-        return time < 10 ? "0" + time : String.valueOf(time);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/KmFormStateModel.java
@@ -3,6 +3,7 @@ package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models;
 import android.util.SparseArray;
 import android.util.SparseIntArray;
 
+import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
 import com.applozic.mobicommons.json.JsonMarker;
 
 import java.util.HashSet;
@@ -16,6 +17,7 @@ public class KmFormStateModel extends JsonMarker {
     private Map<String, String> hiddenFields;
     private SparseIntArray validationArray;
     private SparseArray<Long> dateFieldArray;
+    private SparseArray<KmFormPayloadModel.Options> dropdownFieldArray;
 
     public SparseArray<String> getTextFields() {
         return textFields;
@@ -63,5 +65,13 @@ public class KmFormStateModel extends JsonMarker {
 
     public void setDateFieldArray(SparseArray<Long> dateFieldArray) {
         this.dateFieldArray = dateFieldArray;
+    }
+
+    public SparseArray<KmFormPayloadModel.Options> getDropdownFieldArray() {
+        return dropdownFieldArray;
+    }
+
+    public void setDropdownFieldArray(SparseArray<KmFormPayloadModel.Options> dropdownFieldArray) {
+        this.dropdownFieldArray = dropdownFieldArray;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -198,7 +198,6 @@ public class KmFormPayloadModel<T> extends JsonMarker {
     public static class DateTimePicker extends JsonMarker {
         private String label;
         private boolean amPm = true;
-        private String dateFormat;
 
         public String getLabel() {
             return label;
@@ -214,14 +213,6 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
         public void setAmPm(boolean amPm) {
             this.amPm = amPm;
-        }
-
-        public String getDateFormat() {
-            return dateFormat;
-        }
-
-        public void setDateFormat(String dateFormat) {
-            this.dateFormat = dateFormat;
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -198,6 +198,7 @@ public class KmFormPayloadModel<T> extends JsonMarker {
     public static class DateTimePicker extends JsonMarker {
         private String label;
         private boolean amPm = true;
+        private String dateFormat;
 
         public String getLabel() {
             return label;
@@ -213,6 +214,14 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
         public void setAmPm(boolean amPm) {
             this.amPm = amPm;
+        }
+
+        public String getDateFormat() {
+            return dateFormat;
+        }
+
+        public void setDateFormat(String dateFormat) {
+            this.dateFormat = dateFormat;
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmFormPayloadModel.java
@@ -38,6 +38,14 @@ public class KmFormPayloadModel<T> extends JsonMarker {
                 || KmFormPayloadModel.Type.DATE_TIME.getValue().equals(type);
     }
 
+    public boolean isTypeDropdown() {
+        return Type.DROPDOWN.getValue().equals(type);
+    }
+
+    public boolean isTypeSelection() {
+        return Type.RADIO.getValue().equals(type) || Type.CHECKBOX.getValue().equals(type);
+    }
+
     public static class Text extends JsonMarker {
         private String label;
         private String placeholder;
@@ -122,6 +130,8 @@ public class KmFormPayloadModel<T> extends JsonMarker {
     public static class Options extends JsonMarker {
         private String label;
         private String value;
+        private boolean selected;
+        private boolean disabled;
 
         public String getLabel() {
             return label;
@@ -137,6 +147,30 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
         public void setValue(String value) {
             this.value = value;
+        }
+
+        public boolean isSelected() {
+            return selected;
+        }
+
+        public void setSelected(boolean selected) {
+            this.selected = selected;
+        }
+
+        public boolean isDisabled() {
+            return disabled;
+        }
+
+        public void setDisabled(boolean disabled) {
+            this.disabled = disabled;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Options options = (Options) o;
+            return label.equals(options.label);
         }
     }
 
@@ -182,12 +216,25 @@ public class KmFormPayloadModel<T> extends JsonMarker {
         }
     }
 
+    public static class DropdownList extends Selections {
+        private Validation validation;
+
+        public Validation getValidation() {
+            return validation;
+        }
+
+        public void setValidation(Validation validation) {
+            this.validation = validation;
+        }
+    }
+
     public enum Type {
         TEXT("text"), PASSWORD("password"),
         HIDDEN("hidden"), RADIO("radio"),
         CHECKBOX("checkbox"),
         DATE("date"),
         TIME("time"),
+        DROPDOWN("dropdown"),
         DATE_TIME("datetime-local"),
         ACTION("action"),
         SUBMIT("submit");
@@ -225,6 +272,11 @@ public class KmFormPayloadModel<T> extends JsonMarker {
 
     public KmFormPayloadModel.DateTimePicker getDatePickerModel() {
         return new Gson().fromJson(GsonUtils.getJsonFromObject(data, Object.class), new TypeToken<KmFormPayloadModel.DateTimePicker>() {
+        }.getType());
+    }
+
+    public KmFormPayloadModel.DropdownList getDropdownList() {
+        return new Gson().fromJson(GsonUtils.getJsonFromObject(data, Object.class), new TypeToken<KmFormPayloadModel.DropdownList>() {
         }.getType());
     }
 

--- a/kommunicateui/src/main/res/drawable/ic_arrow_drop_down_black_18dp.xml
+++ b/kommunicateui/src/main/res/drawable/ic_arrow_drop_down_black_18dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="18dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M7,10l5,5 5,-5z"/>
+</vector>

--- a/kommunicateui/src/main/res/drawable/ic_calendar_today_black_18dp.xml
+++ b/kommunicateui/src/main/res/drawable/ic_calendar_today_black_18dp.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="18dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M20,3h-1L19,1h-2v2L7,3L7,1L5,1v2L4,3c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,5c0,-1.1 -0.9,-2 -2,-2zM20,21L4,21L4,8h16v13z"/>
+</vector>

--- a/kommunicateui/src/main/res/drawable/ic_query_builder_black_18dp.xml
+++ b/kommunicateui/src/main/res/drawable/ic_query_builder_black_18dp.xml
@@ -1,0 +1,6 @@
+<vector android:autoMirrored="true" android:height="18dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#000000" android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+    <path android:fillColor="#000000" android:pathData="M12.5,7H11v6l5.25,3.15 0.75,-1.23 -4.5,-2.67z"/>
+</vector>

--- a/kommunicateui/src/main/res/drawable/km_dropdown_background_with_icon.xml
+++ b/kommunicateui/src/main/res/drawable/km_dropdown_background_with_icon.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item>
+        <shape>
+            <solid android:color="@color/applozic_transparent_color" />
+            <stroke
+                android:width="1dp"
+                android:color="#646262" />
+
+        </shape>
+    </item>
+
+    <item>
+        <bitmap
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="right"
+            app:srcCompat="@drawable/ic_arrow_drop_down_black_18dp" />
+    </item>
+</layer-list>

--- a/kommunicateui/src/main/res/layout/km_form_item_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_form_item_layout.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/kmFormItemLayout"
+    android:id="@+id/km_form_item_root_layout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="10dp">
 
     <TextView
-        android:id="@+id/kmFormLabel"
+        android:id="@+id/km_form_label_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="14sp" />
 
     <EditText
-        android:id="@+id/kmFormEditText"
+        android:id="@+id/km_form_edit_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
@@ -25,14 +25,14 @@
         android:textSize="14sp" />
 
     <com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmFlowLayout
-        android:id="@+id/kmFormSelectionItems"
-        android:layout_width="220dp"
+        android:id="@+id/km_form_selection_layout"
+        android:layout_width="240dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
         android:visibility="gone" />
 
     <TextView
-        android:id="@+id/kmFormDatePicker"
+        android:id="@+id/km_form_date_picker"
         android:layout_width="240dp"
         android:layout_height="32dp"
         android:layout_marginTop="5dp"
@@ -40,5 +40,31 @@
         android:maxLines="1"
         android:padding="5dp"
         android:textSize="14sp"
+        android:textColor="@color/black"
+        android:visibility="gone" />
+
+    <FrameLayout
+        android:id="@+id/km_form_dropdown_list_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/km_form_edit_text_background"
+        android:layout_marginTop="5dp"
+        android:visibility="gone">
+
+        <Spinner
+            android:id="@+id/km_form_dropdown_list"
+            android:layout_width="240dp"
+            android:layout_height="32dp"
+            android:maxLines="1"
+            android:padding="5dp"
+            android:textSize="14sp" />
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/km_form_validation_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:textColor="@color/km_toast_error_color"
         android:visibility="gone" />
 </LinearLayout>


### PR DESCRIPTION
This PR fixes CM-637 and CM-616

* Added support for dropdown list in form template
* Added Icons for date and time fields in form template
* Changed the UI and post data time and date formats matching web plugin

Some intentional codes:
* Date format as in web is not provided by SImpleDateFormat in Java/Android. So created the format Manually
* Android Spinner needs to have the item displayed by default in the item list. So disabled items will be there in the list at first position. The disabled items are not present in the list in web plugin.
* Form Item Adapter has multiple If/else for different types. This needs to be converted to Adapter factory pattern in future. Added TODO for that. 