### PR TITLE
add functionality to update conversation metadata and assignee

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/HttpRequestUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/HttpRequestUtils.java
@@ -405,6 +405,55 @@ public class HttpRequestUtils {
         return null;
     }
 
+    public String makePatchRequest(String stringUrl, String data) throws Exception {
+        HttpURLConnection connection;
+        URL url = new URL(stringUrl);
+        connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("PATCH");
+        connection.setRequestProperty("Content-Type", "application/json");
+        if (!TextUtils.isEmpty(MobiComUserPreference.getInstance(context).getDeviceKeyString())) {
+            connection.setRequestProperty(DEVICE_KEY_HEADER, MobiComUserPreference.getInstance(context).getDeviceKeyString());
+        }
+        connection.setDoInput(true);
+        connection.setDoOutput(true);
+
+        addGlobalHeaders(connection, null);
+        connection.connect();
+
+        if (data != null) {
+            byte[] dataBytes = data.getBytes("UTF-8");
+            DataOutputStream dataOutputStream = new DataOutputStream(connection.getOutputStream());
+            dataOutputStream.write(dataBytes);
+            dataOutputStream.flush();
+            dataOutputStream.close();
+        }
+
+        BufferedReader bufferedReader = null;
+        if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+            InputStream inputStream = connection.getInputStream();
+            bufferedReader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+        } else {
+            Utils.printLog(context, TAG, "Response code for " + stringUrl + " : " + connection.getResponseCode());
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        try {
+            String line;
+            if (bufferedReader != null) {
+                while ((line = bufferedReader.readLine()) != null) {
+                    stringBuilder.append(line);
+                }
+            }
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        } finally {
+            if (bufferedReader != null) {
+                bufferedReader.close();
+            }
+        }
+        Utils.printLog(context, TAG, "Response for " + stringUrl + " : " + stringBuilder.toString());
+        return stringBuilder.toString();
+    }
+
     public void addGlobalHeaders(HttpURLConnection connection, String userId) {
         try {
             if (MobiComKitClientService.getAppModuleName(context) != null) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/register/RegisterUserClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/register/RegisterUserClientService.java
@@ -205,7 +205,7 @@ public class RegisterUserClientService extends MobiComKitClientService {
             Map<String, String> tokenRefreshBodyMap = new HashMap<>();
             tokenRefreshBodyMap.put("applicationId", applicationId);
             tokenRefreshBodyMap.put("userId", userId);
-            String response = httpRequestUtils.postDataForAuthToken(getRefreshTokenUrl(), "application/json", "application/json", GsonUtils.getJsonFromObject(tokenRefreshBodyMap, Map.class), userId);
+            String response = httpRequestUtils.postDataForAuthToken(getRefreshTokenUrl(), GsonUtils.getJsonFromObject(tokenRefreshBodyMap, Map.class), userId);
             if (!TextUtils.isEmpty(response)) {
                 ApiResponse<String> jwtTokenResponse = (ApiResponse<String>) GsonUtils.getObjectFromJson(response, ApiResponse.class);
                 if (jwtTokenResponse != null && !TextUtils.isEmpty(jwtTokenResponse.getResponse())) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserClientService.java
@@ -421,7 +421,7 @@ public class UserClientService extends MobiComKitClientService {
                 userUpdate.setMetadata(metadata);
             }
 
-            String response = httpRequestUtils.postData(getUserProfileUpdateUrl(), "application/json", "application/json", GsonUtils.getJsonFromObject(userUpdate, AlUserUpdate.class), userId);
+            String response = httpRequestUtils.postData(getUserProfileUpdateUrl(), GsonUtils.getJsonFromObject(userUpdate, AlUserUpdate.class), userId);
             Utils.printLog(context, TAG, response);
             return ((ApiResponse) GsonUtils.getObjectFromJson(response, ApiResponse.class));
         } catch (JSONException e) {

--- a/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
@@ -41,6 +41,7 @@ public class Channel extends JsonMarker {
     public static final String AL_CATEGORY = "AL_CATEGORY";
     public static final String CONVERSATION_STATUS = "CONVERSATION_STATUS";
     public static final String CONVERSATION_ASSIGNEE = "CONVERSATION_ASSIGNEE";
+    public static final String KM_TEAM_ID = "KM_TEAM_ID";
     public static final int CLOSED_CONVERSATIONS = 3;
     public static final int ASSIGNED_CONVERSATIONS = 1;
     public static final int ALL_CONVERSATIONS = 2;
@@ -273,6 +274,10 @@ public class Channel extends JsonMarker {
 
     public String getConversationAssignee() {
         return (GroupType.SUPPORT_GROUP.getValue().equals(getType()) && getMetadata() != null && !TextUtils.isEmpty(getMetadata().get(CONVERSATION_ASSIGNEE))) ? getMetadata().get(CONVERSATION_ASSIGNEE) : null;
+    }
+
+    public String getTeamId() {
+        return (GroupType.SUPPORT_GROUP.getValue().equals(getType()) && getMetadata() != null && !TextUtils.isEmpty(getMetadata().get(KM_TEAM_ID))) ? getMetadata().get(KM_TEAM_ID) : null;
     }
 
     public boolean isOpenGroup() {

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import io.kommunicate.async.KmAssigneeUpdateTask;
 import io.kommunicate.async.KmConversationCreateTask;
 import io.kommunicate.async.KmConversationInfoTask;
 import io.kommunicate.async.KmGetAgentListTask;
@@ -558,33 +559,9 @@ public class KmConversationHelper {
         KmGetConversationInfoCallback conversationInfoCallback = new KmGetConversationInfoCallback() {
             @Override
             public void onSuccess(final Channel channel, Context context) {
-                Map<String, String> metadataForUpdate = getMetadataForUpdate(conversationBuilder, channel);
-                if (!metadataForUpdate.isEmpty()) {
-                    Utils.printLog(context, TAG, "Updating conversation metadata : " + GsonUtils.getJsonFromObject(metadataForUpdate, Map.class));
-
-                    GroupInfoUpdate groupInfoUpdate = new GroupInfoUpdate(metadataForUpdate, channel.getKey());
-
-                    KmUpdateConversationTask.KmConversationUpdateListener kmConversationUpdateListener = new KmUpdateConversationTask.KmConversationUpdateListener() {
-                        @Override
-                        public void onSuccess(Context context) {
-                            if (callback != null) {
-                                callback.onSuccess(channel, context);
-                            }
-                        }
-
-                        @Override
-                        public void onFailure(Context context) {
-                            if (callback != null) {
-                                callback.onSuccess(channel, context);
-                            }
-                        }
-                    };
-
-                    new KmUpdateConversationTask(context, groupInfoUpdate, kmConversationUpdateListener).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-                } else {
-                    if (callback != null) {
-                        callback.onSuccess(channel, context);
-                    }
+                checkForConversationUpdates(context, conversationBuilder, channel, null);
+                if (callback != null) {
+                    callback.onSuccess(channel, context);
                 }
             }
 
@@ -599,6 +576,62 @@ public class KmConversationHelper {
         };
 
         new KmConversationInfoTask(conversationBuilder.getContext(), conversationBuilder.getClientConversationId(), conversationInfoCallback).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    /**
+     * Checks for any updates in the existing conversation like metadata, assignee and team.
+     * If any updates are found, this method updates them.
+     *
+     * Let these things run in background, we don't need to wait for them to finish in order to launch the conversation.
+     * If they fail due to network issues, it can happen in the next call.
+     **/
+    private static void checkForConversationUpdates(final Context context, KmConversationBuilder conversationBuilder, final Channel channel, final KmStartConversationHandler callback) {
+        Map<String, String> metadataForUpdate = getMetadataForUpdate(conversationBuilder, channel);
+        if (!metadataForUpdate.isEmpty()) {
+            Utils.printLog(context, TAG, "Updating conversation metadata for : " + channel.getKey() + "\nMetadata : " + GsonUtils.getJsonFromObject(metadataForUpdate, Map.class));
+
+            GroupInfoUpdate groupInfoUpdate = new GroupInfoUpdate(metadataForUpdate, channel.getKey());
+
+            KmSettings.updateConversation(context, groupInfoUpdate, new KmUpdateConversationTask.KmConversationUpdateListener() {
+                @Override
+                public void onSuccess(Context context) {
+                    Utils.printLog(context, TAG, "Successfully updated conversation metadata for : " + channel.getKey());
+                    if (callback != null) {
+                        callback.onSuccess(channel, context);
+                    }
+                }
+
+                @Override
+                public void onFailure(Context context) {
+                    Utils.printLog(context, TAG, "Failed to update conversation metadata for : " + channel.getKey());
+                    if (callback != null) {
+                        callback.onFailure(null, context);
+                    }
+                }
+            });
+        }
+
+        if (!TextUtils.isEmpty(conversationBuilder.getConversationAssignee()) && !conversationBuilder.getConversationAssignee().equals(channel.getConversationAssignee())) {
+            Utils.printLog(context, TAG, "Updating conversation assignee for : " + channel.getKey() + "\nAssignee : " + conversationBuilder.getConversationAssignee());
+
+            new KmAssigneeUpdateTask(channel.getKey(), conversationBuilder.getConversationAssignee(), new KmCallback() {
+                @Override
+                public void onSuccess(Object message) {
+                    Utils.printLog(context, TAG, "Successfully updated conversation assignee for : " + channel.getKey());
+                    if (callback != null) {
+                        callback.onSuccess(channel, context);
+                    }
+                }
+
+                @Override
+                public void onFailure(Object error) {
+                    Utils.printLog(context, TAG, "Failed to update conversation assignee for : " + channel.getKey());
+                    if (callback != null) {
+                        callback.onFailure(null, context);
+                    }
+                }
+            }).execute();
+        }
     }
 
     private static void createConversation(KmConversationBuilder conversationBuilder, KmStartConversationHandler handler) throws KmException {
@@ -900,13 +933,6 @@ public class KmConversationHelper {
 
         if (!TextUtils.isEmpty(conversationBuilder.getTeamId()) && !conversationBuilder.getTeamId().equals(channel.getTeamId())) {
             newMetadata.put(KM_TEAM_ID, conversationBuilder.getTeamId());
-        }
-
-        if (!TextUtils.isEmpty(conversationBuilder.getConversationAssignee()) && !conversationBuilder.getConversationAssignee().equals(channel.getConversationAssignee())) {
-            /*newMetadata.put(CONVERSATION_ASSIGNEE, conversationBuilder.getConversationAssignee());
-            newMetadata.put(SKIP_ROUTING, "true");*/
-
-            //TODO: Need to call conversationAssignee update API here
         }
 
         return newMetadata;

--- a/kommunicate/src/main/java/io/kommunicate/KmSettings.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmSettings.java
@@ -4,10 +4,13 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.ApplozicClient;
+import com.applozic.mobicomkit.feed.GroupInfoUpdate;
 import com.applozic.mobicommons.json.GsonUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import io.kommunicate.async.KmUpdateConversationTask;
 
 public class KmSettings {
 
@@ -69,5 +72,9 @@ public class KmSettings {
 
         existingMetadata.putAll(metadata);
         ApplozicClient.getInstance(context).setMessageMetaData(existingMetadata);
+    }
+
+    public static void updateConversation(Context context, GroupInfoUpdate groupInfoUpdate, KmUpdateConversationTask.KmConversationUpdateListener listener) {
+        new KmUpdateConversationTask(context, groupInfoUpdate, listener).execute();
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/async/KmAssigneeUpdateTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmAssigneeUpdateTask.java
@@ -1,0 +1,61 @@
+package io.kommunicate.async;
+
+import android.text.TextUtils;
+
+import com.applozic.mobicomkit.feed.ApiResponse;
+import com.applozic.mobicommons.ApplozicService;
+import com.applozic.mobicommons.json.GsonUtils;
+import com.applozic.mobicommons.task.AlAsyncTask;
+
+import io.kommunicate.callbacks.KmCallback;
+import io.kommunicate.services.KmClientService;
+
+public class KmAssigneeUpdateTask extends AlAsyncTask<Void, String> {
+    private Integer groupId;
+    private String assigneeId;
+    private boolean switchAssignee;
+    private boolean sendNotifyMessage;
+    private boolean takeOverFromBot;
+    private KmCallback callback;
+    private KmClientService clientService;
+
+    public KmAssigneeUpdateTask(Integer conversationId, String assigneeId, KmCallback callback) {
+        this(conversationId, assigneeId, true, true, true, callback);
+    }
+
+    public KmAssigneeUpdateTask(Integer groupId, String assigneeId, boolean switchAssignee, boolean sendNotifyMessage, boolean takeOverFromBot, KmCallback callback) {
+        this.groupId = groupId;
+        this.assigneeId = assigneeId;
+        this.switchAssignee = switchAssignee;
+        this.sendNotifyMessage = sendNotifyMessage;
+        this.takeOverFromBot = takeOverFromBot;
+        this.callback = callback;
+        this.clientService = new KmClientService(ApplozicService.getAppContext());
+    }
+
+    @Override
+    protected String doInBackground() throws Exception {
+        return clientService.switchConversationAssignee(groupId, assigneeId, switchAssignee, sendNotifyMessage, takeOverFromBot);
+    }
+
+    @Override
+    protected void onPostExecute(String s) {
+        if (callback != null) {
+            if (!TextUtils.isEmpty(s)) {
+                ApiResponse<String> apiResponse = (ApiResponse<String>) GsonUtils.getObjectFromJson(s, ApiResponse.class);
+                if (apiResponse != null) {
+                    if (apiResponse.isSuccess()) {
+                        callback.onSuccess(apiResponse.getResponse());
+                    } else {
+                        callback.onFailure(apiResponse.getErrorResponse());
+                    }
+                } else {
+                    callback.onFailure("Failed to update Assignee");
+                }
+            } else {
+                callback.onFailure("Failed to update Assignee");
+            }
+        }
+        super.onPostExecute(s);
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUpdateConversationTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUpdateConversationTask.java
@@ -1,14 +1,14 @@
 package io.kommunicate.async;
 
 import android.content.Context;
-import android.os.AsyncTask;
 
 import com.applozic.mobicomkit.channel.service.ChannelService;
 import com.applozic.mobicomkit.feed.GroupInfoUpdate;
+import com.applozic.mobicommons.task.AlAsyncTask;
 
 import java.lang.ref.WeakReference;
 
-public class KmUpdateConversationTask extends AsyncTask<Void, Void, String> {
+public class KmUpdateConversationTask extends AlAsyncTask<Void, String> {
 
     private WeakReference<Context> context;
     private GroupInfoUpdate groupInfoUpdate;
@@ -22,7 +22,7 @@ public class KmUpdateConversationTask extends AsyncTask<Void, Void, String> {
     }
 
     @Override
-    protected String doInBackground(Void... voids) {
+    protected String doInBackground() {
         return ChannelService.getInstance(context.get()).updateChannel(groupInfoUpdate);
     }
 

--- a/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
@@ -12,6 +12,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,6 +34,7 @@ public class KmClientService extends MobiComKitClientService {
     public static final String KM_HELPCENTER = "km_helpcenter_url";
     private static final String CONVERSATION_FEEDBACK_URL = "/feedback";
     public static final String APP_SETTING_URL = "/users/v2/chat/plugin/settings?appId=";
+    private static final String CHANGE_CONVERSATION_ASSIGNEE_URL = "/rest/ws/group/assignee/change?groupId=";
 
     private static final String TAG = "KmClientService";
 
@@ -76,6 +78,21 @@ public class KmClientService extends MobiComKitClientService {
         }
 
         return httpRequestUtils.getResponse(urlBuilder.toString(), "application/json", "application/json");
+    }
+
+    public String switchConversationAssignee(Integer groupId, String assigneeId, boolean switchAssignee, boolean sendNotifyMessage, boolean takeOverFromBot) {
+        try {
+            String url = getBaseUrl() + CHANGE_CONVERSATION_ASSIGNEE_URL + groupId
+                    + "&assignee=" + URLEncoder.encode(assigneeId, "UTF-8").trim()
+                    + "&switchAssignee=" + switchAssignee
+                    + "&sendNotifyMessage=" + sendNotifyMessage
+                    + "&takeOverFromBot=" + takeOverFromBot;
+
+            return httpRequestUtils.makePatchRequest(url, null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public String getKmAutoSuggestions() {

--- a/kommunicate/src/main/java/io/kommunicate/services/KmService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmService.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 
 import com.applozic.mobicomkit.api.account.user.User;
 import com.applozic.mobicomkit.contact.BaseContactService;
-import com.applozic.mobicomkit.feed.GroupInfoUpdate;
 import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.people.channel.Channel;
 import com.applozic.mobicommons.people.contact.Contact;
@@ -20,7 +19,6 @@ import java.util.Set;
 
 import io.kommunicate.async.KmConversationFeedbackTask;
 import io.kommunicate.async.KmConversationRemoveMemberTask;
-import io.kommunicate.async.KmUpdateConversationTask;
 import io.kommunicate.callbacks.KmFeedbackCallback;
 import io.kommunicate.callbacks.KmRemoveMemberCallback;
 import io.kommunicate.database.KmAutoSuggestionDatabase;
@@ -139,10 +137,6 @@ public class KmService {
             new KmConversationRemoveMemberTask(context, channelKey, userId, i, recListener).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             i++;
         }
-    }
-
-    public static void updateConversation(Context context, GroupInfoUpdate groupInfoUpdate, KmUpdateConversationTask.KmConversationUpdateListener listener) {
-        new KmUpdateConversationTask(context, groupInfoUpdate, listener).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
     /**

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -194,6 +194,7 @@ import java.util.regex.PatternSyntaxException;
 
 import de.hdodenhof.circleimageview.CircleImageView;
 import io.kommunicate.KmBotPreference;
+import io.kommunicate.KmSettings;
 import io.kommunicate.Kommunicate;
 import io.kommunicate.async.AgentGetStatusTask;
 import io.kommunicate.async.KmConversationFeedbackTask;
@@ -4636,7 +4637,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 }
                 metadata.put(Channel.CONVERSATION_ASSIGNEE, loggedInUserId);
                 groupInfoUpdate.setMetadata(metadata);
-                KmService.updateConversation(ApplozicService.getContext(getContext()), groupInfoUpdate, new KmUpdateConversationTask.KmConversationUpdateListener() {
+                KmSettings.updateConversation(ApplozicService.getContext(getContext()), groupInfoUpdate, new KmUpdateConversationTask.KmConversationUpdateListener() {
                     @Override
                     public void onSuccess(Context context) {
                         Message message = new Message();


### PR DESCRIPTION
* Added functionality to update conversation metadata via conversation builder
* Added functionality to update conversationAssignee if a different assignee is passed in the conversation builder
* Moved the updates into parallel tasks so it doesn't affect the response time of conversation builder
* Use the below method to update conversation metadata:

```java
  Map<String, String> map = new HashMap<>();
            map.put("TicketId", "123456");
            map.put("Status", "ActiveNo");

            new KmConversationBuilder(context)
                    //other properties might go here
                    .setConversationAssignee(newAssignee)
                    .setConversationMetadata(map)
                    .launchConversation(new KmCallback() {
                        @Override
                        public void onSuccess(Object message) {
            
                        }

                        @Override
                        public void onFailure(Object error) {
                            
                        }
                    });
```

Below test cases are satisfied:
1) If this is a new conversation, the conversation will be created and the above metadata will be set.
2) If this is an existing conversation, this metadata will be set, if conversation does not have metadata this metadata
3) If the values change or new metadata is passed, the metadata will be updated accordingly.
4) If same metadata is passed, no update occurs.