### PR TITLE
move kommunicate repo url to library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,6 @@ allprojects {
         google()
         mavenCentral()
         jcenter()
-        maven {
-            url 'https://kommunicate.jfrog.io/artifactory/kommunicate-android-sdk'
-        }
     }
 }
 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -1,5 +1,12 @@
 apply plugin: 'com.android.library'
 
+rootProject.allprojects {
+    repositories {
+        maven {
+            url 'https://kommunicate.jfrog.io/artifactory/kommunicate-android-sdk'
+        }
+    }
+}
 android {
     compileSdkVersion 28
 


### PR DESCRIPTION
After this change is release with version 2.1.7, customers don't have to do the extra step of adding the jsfrog URL in their project level build.gradle file. The URL will be added by kommunicate module's build.gradle file automatically to the project level buidl.gradle file.

The below step will not be required:
```
repositories {
        maven {
            url 'https://kommunicate.jfrog.io/artifactory/kommunicate-android-sdk'
        }
    }
```