### PR TITLE
add support for hidePostCTA setting

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -149,5 +149,6 @@
     "enabled": false,
     "sendMessageOnSpeechEnd": true,
     "languageCode": "en-US"
-  }
+  },
+  "hidePostCTA": false
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -717,6 +717,10 @@ public class Message extends JsonMarker {
         return ((ApplozicClient.getInstance(context).isActionMessagesHidden() && isActionMessage()) || hasHideKey());
     }
 
+    public boolean isRichMessage() {
+        return metadata != null && "300".equals(metadata.get("contentType"));
+    }
+
     public enum Source {
 
         DEVICE_NATIVE_APP(Short.valueOf("0")), WEB(Short.valueOf("1")), MT_MOBILE_APP(Short.valueOf("2")), API(Short.valueOf("3"));

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -77,6 +77,7 @@ public class Message extends JsonMarker {
     public static final String AL_DELETE_MESSAGE_FOR_ALL_KEY = "AL_DELETE_GROUP_MESSAGE_FOR_ALL";
     public static final String AUTO_SUGGESTION_TYPE_MESSAGE = "KM_AUTO_SUGGESTION";
     public static final String STATUS_CLOSED = "closed";
+    public static final String RICH_MESSAGE_CONTENT_TYPE = "300";
 
     public Message() {
 
@@ -718,7 +719,7 @@ public class Message extends JsonMarker {
     }
 
     public boolean isRichMessage() {
-        return metadata != null && "300".equals(metadata.get("contentType"));
+        return metadata != null && RICH_MESSAGE_CONTENT_TYPE.equals(metadata.get("contentType"));
     }
 
     public enum Source {

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -37,6 +37,7 @@ public class KmAppSettingModel extends JsonMarker {
         private String agentId;
         private String agentName;
         private boolean collectFeedback;
+        private boolean hidePostCTA;
         private KmChatWidget chatWidget;
 
         public String getUserName() {
@@ -65,6 +66,10 @@ public class KmAppSettingModel extends JsonMarker {
 
         public boolean isCollectFeedback() {
             return collectFeedback;
+        }
+
+        public boolean isHidePostCTA() {
+            return hidePostCTA;
         }
 
         public void setCollectFeedback(boolean collectFeedback) {

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
@@ -6,7 +6,6 @@ import android.os.AsyncTask;
 
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicommons.ApplozicService;
-import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.json.GsonUtils;
 
 import io.kommunicate.async.KmAppSettingTask;
@@ -27,6 +26,7 @@ public class KmAppSettingPreferences {
     private static final String KM_BOT_MESSAGE_DELAY_INTERVAL = "KM_BOT_MESSAGE_DELAY_INTERVAL";
     private static final String LOGGED_IN_AT_TIME = "LOGGED_IN_AT_TIME";
     private static final String CHAT_SESSION_DELETE_TIME = "CHAT_SESSION_DELETE_TIME";
+    private static final String HIDE_POST_CTA = "HIDE_POST_CTA";
 
     private KmAppSettingPreferences() {
         preferences = ApplozicService.getAppContext().getSharedPreferences(KM_THEME_PREFERENCES, Context.MODE_PRIVATE);
@@ -54,6 +54,7 @@ public class KmAppSettingPreferences {
             }
             if (appSetting.getResponse() != null) {
                 setCollectFeedback(appSetting.getResponse().isCollectFeedback());
+                setHidePostCTA(appSetting.getResponse().isHidePostCTA());
             }
         }
     }
@@ -82,6 +83,15 @@ public class KmAppSettingPreferences {
 
     public KmAppSettingPreferences setCollectFeedback(boolean collectFeedback) {
         preferences.edit().putBoolean(KM_COLLECT_FEEDBACK, collectFeedback).commit();
+        return this;
+    }
+
+    public boolean isHidePostCTA() {
+        return preferences.getBoolean(HIDE_POST_CTA, false);
+    }
+
+    public KmAppSettingPreferences setHidePostCTA(boolean hidePostCTA) {
+        preferences.edit().putBoolean(HIDE_POST_CTA, hidePostCTA).commit();
         return this;
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -127,6 +127,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private KmSpeechSetting textToSpeech;
     private KmSpeechSetting speechToText;
     private boolean restrictMessageTypingWithBots = false;
+    private Boolean hidePostCTA;
 
     public String getNoConversationLabel() {
         return noConversationLabel;
@@ -665,6 +666,10 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public KmSpeechSetting getSpeechToText() {
         return speechToText == null ? new KmSpeechSetting() : speechToText;
+    }
+
+    public Boolean isHidePostCTA() {
+        return hidePostCTA;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -127,7 +127,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private KmSpeechSetting textToSpeech;
     private KmSpeechSetting speechToText;
     private boolean restrictMessageTypingWithBots = false;
-    private Boolean hidePostCTA;
+    private Map<String, Boolean> hidePostCTA;
 
     public String getNoConversationLabel() {
         return noConversationLabel;
@@ -668,7 +668,7 @@ public class AlCustomizationSettings extends JsonMarker {
         return speechToText == null ? new KmSpeechSetting() : speechToText;
     }
 
-    public Boolean isHidePostCTA() {
+    public Map<String, Boolean> isHidePostCTA() {
         return hidePostCTA;
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -146,7 +146,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     private float[] receivedMessageCornerRadii = {0, 0, 0, 0, 0, 0, 0, 0};
     private KmFontManager fontManager;
     private KmThemeHelper themeHelper;
-    private Message unProcessedRichMessage;
+    private Message lastSentMessage;
 
     public void setAlCustomizationSettings(AlCustomizationSettings alCustomizationSettings) {
         this.alCustomizationSettings = alCustomizationSettings;
@@ -196,8 +196,8 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         this(context, textViewResourceId, messageList, contact, null, messageIntentClass, emojiconHandler);
     }
 
-    public void setUnProcessedRichMessage(Message message) {
-        this.unProcessedRichMessage = message;
+    public void setLastSentMessage(Message message) {
+        this.lastSentMessage = message;
     }
 
     public DetailedConversationAdapter(final Context context, int textViewResourceId, List<Message> messageList, final Contact contact, Channel channel, Class messageIntentClass, EmojiconHandler emojiconHandler) {
@@ -1074,19 +1074,15 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     }
 
     private boolean showRichMessage(Message message) {
-        if (themeHelper.isHidePostCTA() && unProcessedRichMessage != null) {
-            return unProcessedRichMessage.getKeyString().equals(message.getKeyString());
+        if (themeHelper.isHidePostCTA()) {
+            return message.getCreatedAtTime() > (lastSentMessage != null ? lastSentMessage.getCreatedAtTime() : 0);
         }
-        return !themeHelper.isHidePostCTA();
+        return true;
     }
 
-    public void updateLastRichMessage(Message message) {
-        if (themeHelper.isHidePostCTA()) {
-            if (message.isTypeOutbox() && unProcessedRichMessage != null) {
-                unProcessedRichMessage = null;
-            } else if (message.isRichMessage()) {
-                unProcessedRichMessage = message;
-            }
+    public void updateLastSentMessage(Message message) {
+        if (themeHelper.isHidePostCTA() && message.isTypeOutbox()) {
+            lastSentMessage = message;
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1030,15 +1030,11 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                             myHolder.messageTextLayout.setVisibility(GONE);
                         }
 
-                        if (showRichMessage(message)) {
-                            myHolder.richMessageLayout.setVisibility(View.VISIBLE);
-                            try {
-                                KmRichMessageFactory.getInstance().getRichMessage(context, myHolder.richMessageLayout, message, listener, alCustomizationSettings).createRichMessage();
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                                myHolder.richMessageLayout.setVisibility(View.GONE);
-                            }
-                        } else {
+                        myHolder.richMessageLayout.setVisibility(View.VISIBLE);
+                        try {
+                            KmRichMessageFactory.getInstance().getRichMessage(context, myHolder.richMessageLayout, message, listener, alCustomizationSettings).createRichMessage(isMessageProcessed(message));
+                        } catch (Exception e) {
+                            e.printStackTrace();
                             myHolder.richMessageLayout.setVisibility(View.GONE);
                         }
                     } else {
@@ -1073,11 +1069,11 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         }
     }
 
-    private boolean showRichMessage(Message message) {
+    private boolean isMessageProcessed(Message message) {
         if (themeHelper.isHidePostCTA()) {
-            return message.getCreatedAtTime() > (lastSentMessage != null ? lastSentMessage.getCreatedAtTime() : 0);
+            return lastSentMessage != null && lastSentMessage.getCreatedAtTime() > message.getCreatedAtTime();
         }
-        return true;
+        return false;
     }
 
     public void updateLastSentMessage(Message message) {
@@ -1403,7 +1399,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
             protected FilterResults performFiltering(CharSequence constraint) {
 
                 final FilterResults oReturn = new FilterResults();
-                final List<Message> results = new ArrayList<Message>();
+                final List<Message> results = new ArrayList<>();
                 if (originalList == null)
                     originalList = messageList;
                 if (constraint != null) {
@@ -1438,7 +1434,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     private int indexOfSearchQuery(String message) {
         if (!TextUtils.isEmpty(searchString)) {
             return message.toLowerCase(Locale.getDefault()).indexOf(
-                    searchString.toString().toLowerCase(Locale.getDefault()));
+                    searchString.toLowerCase(Locale.getDefault()));
         }
         return -1;
     }
@@ -1672,7 +1668,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         };
     }
 
-    class MyViewHolder2 extends RecyclerView.ViewHolder {
+    static class MyViewHolder2 extends RecyclerView.ViewHolder {
         TextView dateView;
         TextView dayTextView;
 
@@ -1683,7 +1679,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         }
     }
 
-    class MyViewHolder3 extends RecyclerView.ViewHolder {
+    static class MyViewHolder3 extends RecyclerView.ViewHolder {
         TextView customContentTextView;
 
         public MyViewHolder3(View itemView) {
@@ -1692,7 +1688,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         }
     }
 
-    class MyViewHolder4 extends RecyclerView.ViewHolder {
+    static class MyViewHolder4 extends RecyclerView.ViewHolder {
         TextView channelMessageTextView;
 
         public MyViewHolder4(View itemView) {
@@ -1701,7 +1697,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         }
     }
 
-    class MyViewHolder5 extends RecyclerView.ViewHolder {
+    static class MyViewHolder5 extends RecyclerView.ViewHolder {
         TextView statusTextView;
         TextView timeTextView;
         TextView durationTextView;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4765,9 +4765,4 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             individualMessageSendLayout.setVisibility(VISIBLE);
         }
     }
-
-    protected void checkMessageIndex(Message message) {
-        int index = messageList.indexOf(message);
-
-    }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1484,7 +1484,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 if (added) {
                     //Todo: update unread count
                     linearLayoutManager.setStackFromEnd(true);
-                    recyclerDetailConversationAdapter.updateLastRichMessage(message);
+                    recyclerDetailConversationAdapter.updateLastSentMessage(message);
                     recyclerDetailConversationAdapter.notifyDataSetChanged();
                     linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
                     emptyTextView.setVisibility(View.GONE);
@@ -3873,17 +3873,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             }
 
             conversationService.read(contact, channel);
-            Message lastRepliedMessage = null;
-            Message lastRichMessage = null;
+            Message lastSentMessage = null;
 
             if (!messageList.isEmpty()) {
                 for (int i = messageList.size() - 1; i >= 0; i--) {
                     Message message = messageList.get(i);
-                    if (lastRichMessage == null && message.isRichMessage()) {
-                        lastRichMessage = message;
-                    }
-                    if (lastRepliedMessage == null && message.isTypeOutbox()) {
-                        lastRepliedMessage = message;
+                    if (lastSentMessage == null && message.isTypeOutbox()) {
+                        lastSentMessage = message;
                     }
                     if (!message.isRead() && !message.isTempDateType() && !message.isCustom()) {
                         if (message.getMessageId() != null) {
@@ -3894,9 +3890,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 }
             }
 
-            if (recyclerDetailConversationAdapter != null && lastRichMessage != null
-                    && lastRichMessage.getCreatedAtTime() > (lastRepliedMessage != null ? lastRepliedMessage.getCreatedAtTime() : 0)) {
-                recyclerDetailConversationAdapter.setUnProcessedRichMessage(lastRichMessage);
+            if (recyclerDetailConversationAdapter != null) {
+                recyclerDetailConversationAdapter.setLastSentMessage(lastSentMessage);
             }
 
             if (conversations != null && conversations.size() > 0) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1457,6 +1457,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 return;
             }
         }
+
         handleAddMessage(message);
     }
 
@@ -1483,6 +1484,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 if (added) {
                     //Todo: update unread count
                     linearLayoutManager.setStackFromEnd(true);
+                    recyclerDetailConversationAdapter.updateLastRichMessage(message);
                     recyclerDetailConversationAdapter.notifyDataSetChanged();
                     linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
                     emptyTextView.setVisibility(View.GONE);
@@ -3871,10 +3873,18 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             }
 
             conversationService.read(contact, channel);
+            Message lastRepliedMessage = null;
+            Message lastRichMessage = null;
 
             if (!messageList.isEmpty()) {
                 for (int i = messageList.size() - 1; i >= 0; i--) {
                     Message message = messageList.get(i);
+                    if (lastRichMessage == null && message.isRichMessage()) {
+                        lastRichMessage = message;
+                    }
+                    if (lastRepliedMessage == null && message.isTypeOutbox()) {
+                        lastRepliedMessage = message;
+                    }
                     if (!message.isRead() && !message.isTempDateType() && !message.isCustom()) {
                         if (message.getMessageId() != null) {
                             message.setRead(Boolean.TRUE);
@@ -3882,6 +3892,11 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         }
                     }
                 }
+            }
+
+            if (recyclerDetailConversationAdapter != null && lastRichMessage != null
+                    && lastRichMessage.getCreatedAtTime() > (lastRepliedMessage != null ? lastRepliedMessage.getCreatedAtTime() : 0)) {
+                recyclerDetailConversationAdapter.setUnProcessedRichMessage(lastRichMessage);
             }
 
             if (conversations != null && conversations.size() > 0) {
@@ -4749,5 +4764,10 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         } else {
             individualMessageSendLayout.setVisibility(VISIBLE);
         }
+    }
+
+    protected void checkMessageIndex(Message message) {
+        int index = messageList.indexOf(message);
+
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/KmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/KmRichMessage.java
@@ -82,7 +82,7 @@ public abstract class KmRichMessage {
     }
 
     //bind views and set the visibilities according to the type of message
-    public void createRichMessage() {
+    public void createRichMessage(boolean isMessageProcessed) {
         if (model.getTemplateId() <= 0) {
             containerView.setVisibility(View.GONE);
             return;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmCardRMAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmCardRMAdapter.java
@@ -18,6 +18,7 @@ import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.KmRichMessage;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.callbacks.KmRichMessageListener;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.KmRichMessageModel;
+import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.types.ButtonKmRichMessage;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 import com.applozic.mobicommons.json.GsonUtils;
 import com.bumptech.glide.Glide;
@@ -31,10 +32,12 @@ public class KmCardRMAdapter extends KmRichMessageAdapter {
 
     private List<KmRichMessageModel.KmPayloadModel> payloadList;
     private KmThemeHelper themeHelper;
+    private boolean isMessageProcessed;
 
-    KmCardRMAdapter(Context context, KmRichMessageModel model, KmRichMessageListener listener, Message message, KmThemeHelper themeHelper) {
+    KmCardRMAdapter(Context context, KmRichMessageModel model, KmRichMessageListener listener, Message message, KmThemeHelper themeHelper, boolean isMessageProcessed) {
         super(context, model, listener, message, themeHelper);
         this.themeHelper = themeHelper;
+        this.isMessageProcessed = isMessageProcessed;
         this.payloadList = Arrays.asList((KmRichMessageModel.KmPayloadModel[])
                 GsonUtils.getObjectFromJson(model.getPayload(), KmRichMessageModel.KmPayloadModel[].class));
     }
@@ -165,6 +168,9 @@ public class KmCardRMAdapter extends KmRichMessageAdapter {
                 try {
                     List<KmRichMessageModel.KmButtonModel> actionsList = payloadModel.getButtons();
                     for (int i = 0; i < actionsList.size(); i++) {
+                        if (isMessageProcessed && ButtonKmRichMessage.hideMessage(themeHelper, actionsList.get(i).getType())) {
+                            continue;
+                        }
                         setupBookActions(viewHolder, i, actionsList);
                     }
                 } catch (Exception e) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmRichMessageAdapterFactory.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmRichMessageAdapterFactory.java
@@ -33,9 +33,9 @@ public class KmRichMessageAdapterFactory {
         return RMFactoryHelper.INSTANCE;
     }
 
-    public KmRichMessageAdapter getRMAdapter(Context context, KmRichMessageModel model, KmRichMessageListener listener, Message message, KmThemeHelper themeHelper) {
+    public KmRichMessageAdapter getRMAdapter(Context context, KmRichMessageModel model, KmRichMessageListener listener, Message message, KmThemeHelper themeHelper, boolean isMessageProcessed) {
         if (model.getTemplateId() == KmRichMessageFactory.CARD_RICH_MESSAGE) {
-            return new KmCardRMAdapter(context, model, listener, message, themeHelper);
+            return new KmCardRMAdapter(context, model, listener, message, themeHelper, isMessageProcessed);
         } else if (model.getTemplateId() == KmRichMessageFactory.BUTTON_RICH_MESSAGE || model.getTemplateId() == KmRichMessageFactory.REPLY_RICH_MESSAGE || model.getTemplateId() == KmRichMessageFactory.MIXED_BUTTON_RICH_MESSAGE) {
             return new KmButtonRMAdapter(context, model, listener, message, themeHelper);
         } else return null;
@@ -45,7 +45,7 @@ public class KmRichMessageAdapterFactory {
         return new KmImageRMAdapter(context, model, listener, message, alCustomizationSettings);
     }
 
-    public KmRichMessageAdapter getListRMAdapter(Context context, Message message, List<KmRichMessageModel.KmElementModel> elementList, Map<String, Object> replyMetadata, KmRichMessageListener messageListener, AlCustomizationSettings alCustomizationSettings) {
+    public KmRichMessageAdapter getListRMAdapter(Context context, Message message, List<KmRichMessageModel.KmElementModel> elementList, Map<String, Object> replyMetadata, KmRichMessageListener messageListener, AlCustomizationSettings alCustomizationSettings, boolean isMessageProcessed) {
         return new KmListRMAdapter(context, message, elementList, replyMetadata, messageListener, KmThemeHelper.getInstance(context, alCustomizationSettings));
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
@@ -25,6 +25,8 @@ import io.kommunicate.utils.KmUtils;
 
 public class ButtonKmRichMessage extends KmRichMessage {
 
+    public static final int QUICK_REPLY_TEMPLATE_ID = 6;
+
     public ButtonKmRichMessage(Context context, LinearLayout containerView, Message message, KmRichMessageListener listener, AlCustomizationSettings alCustomizationSettings) {
         super(context, containerView, message, listener, alCustomizationSettings);
     }
@@ -37,7 +39,7 @@ public class ButtonKmRichMessage extends KmRichMessage {
 
         flowLayout.removeAllViews();
         for (final KmRichMessageModel.KmPayloadModel payloadModel : payloadList) {
-            if (isMessageProcessed && hideMessage(themeHelper, getActionType(payloadModel))) {
+            if (isMessageProcessed && hideMessage(themeHelper, getActionType(payloadModel, model.getTemplateId()))) {
                 continue;
             }
             View view = LayoutInflater.from(context).inflate(R.layout.km_rich_message_single_text_item, null);
@@ -63,7 +65,7 @@ public class ButtonKmRichMessage extends KmRichMessage {
                         if (payloadModel.getAction() != null && !TextUtils.isEmpty(payloadModel.getAction().getType()) || !TextUtils.isEmpty(payloadModel.getType())) {
                             listener.onAction(context, actionType, message, payloadModel, payloadModel.getReplyMetadata());
                         } else {
-                            listener.onAction(context, model.getTemplateId() == 6 ? QUICK_REPLY : SUBMIT_BUTTON, message, model.getTemplateId() == 6 ? payloadModel : model, payloadModel.getReplyMetadata());
+                            listener.onAction(context, model.getTemplateId() == QUICK_REPLY_TEMPLATE_ID ? QUICK_REPLY : SUBMIT_BUTTON, message, model.getTemplateId() == 6 ? payloadModel : model, payloadModel.getReplyMetadata());
                         }
                     }
                 }
@@ -99,7 +101,10 @@ public class ButtonKmRichMessage extends KmRichMessage {
         }
     }
 
-    public String getActionType(KmRichMessageModel.KmPayloadModel payloadModel) {
+    public String getActionType(KmRichMessageModel.KmPayloadModel payloadModel, Short templateId) {
+        if (payloadModel.getAction() == null) {
+            return templateId == QUICK_REPLY_TEMPLATE_ID ? QUICK_REPLY : SUBMIT_BUTTON;
+        }
         return payloadModel.getAction() != null && !TextUtils.isEmpty(payloadModel.getAction().getType()) ? payloadModel.getAction().getType() : payloadModel.getType();
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
@@ -15,6 +15,7 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.callbacks.Km
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.KmRichMessageModel;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmRMActionModel;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.DimensionsUtils;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 import com.applozic.mobicommons.json.GsonUtils;
 
 import java.util.Arrays;
@@ -29,13 +30,16 @@ public class ButtonKmRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
         final List<KmRichMessageModel.KmPayloadModel> payloadList = Arrays.asList((KmRichMessageModel.KmPayloadModel[])
                 GsonUtils.getObjectFromJson(model.getPayload(), KmRichMessageModel.KmPayloadModel[].class));
 
         flowLayout.removeAllViews();
         for (final KmRichMessageModel.KmPayloadModel payloadModel : payloadList) {
+            if (isMessageProcessed && hideMessage(themeHelper, getActionType(payloadModel))) {
+                continue;
+            }
             View view = LayoutInflater.from(context).inflate(R.layout.km_rich_message_single_text_item, null);
             TextView itemTextView = view.findViewById(R.id.singleTextItem);
 
@@ -93,5 +97,15 @@ public class ButtonKmRichMessage extends KmRichMessage {
 
             flowLayout.addView(view);
         }
+    }
+
+    public String getActionType(KmRichMessageModel.KmPayloadModel payloadModel) {
+        return payloadModel.getAction() != null && !TextUtils.isEmpty(payloadModel.getAction().getType()) ? payloadModel.getAction().getType() : payloadModel.getType();
+    }
+
+    public static boolean hideMessage(KmThemeHelper themeHelper, String action) {
+        return (themeHelper.hideLinkButtonsPostCTA() && KmRichMessage.WEB_LINK.equals(action))
+                || (themeHelper.hideQuickRepliesPostCTA() && KmRichMessage.QUICK_REPLY.equals(action))
+                || (themeHelper.hideSubmitButtonsPostCTA() && KmRichMessage.SUBMIT_BUTTON.equals(action));
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/CardTypeKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/CardTypeKmRichMessage.java
@@ -20,11 +20,11 @@ public class CardTypeKmRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
         LinearLayoutManager layoutManager = new LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false);
         genericCardRecycler.setLayoutManager(layoutManager);
-        KmCardRMAdapter adapter = (KmCardRMAdapter) KmRichMessageAdapterFactory.getInstance().getRMAdapter(context, model, listener, message, KmThemeHelper.getInstance(context, alCustomizationSettings));
+        KmCardRMAdapter adapter = (KmCardRMAdapter) KmRichMessageAdapterFactory.getInstance().getRMAdapter(context, model, listener, message, KmThemeHelper.getInstance(context, alCustomizationSettings), isMessageProcessed);
         genericCardRecycler.setAdapter(adapter);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/FaqKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/FaqKmRichMessage.java
@@ -26,8 +26,8 @@ public class FaqKmRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
 
         if (model != null) {
             TextView headerText = faqLayout.findViewById(R.id.headerText);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ImageKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ImageKmRichMessage.java
@@ -19,8 +19,8 @@ public class ImageKmRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
 
         LinearLayoutManager layoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
         imageListRecycler.setLayoutManager(layoutManager);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
@@ -31,13 +31,17 @@ public class KmFormRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
 
         LinearLayoutManager formLayoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
         alFormLayoutRecycler.setLayoutManager(formLayoutManager);
         final KmFormItemAdapter formItemAdapter = new KmFormItemAdapter(context, kmRichMessageModel.getFormModelList(), message.getKeyString());
         alFormLayoutRecycler.setAdapter(formItemAdapter);
+
+        if (isMessageProcessed && themeHelper.hideSubmitButtonsPostCTA()) {
+            return;
+        }
 
         List<Object> actionModelList = new ArrayList<>();
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
@@ -21,6 +21,7 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.KmRic
 import com.applozic.mobicommons.json.GsonUtils;
 import com.bumptech.glide.Glide;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ListKmRichMessage extends KmRichMessage {
@@ -44,7 +45,7 @@ public class ListKmRichMessage extends KmRichMessage {
                     RecyclerView listRecycler = listItemLayout.findViewById(R.id.alListItemRecycler);
                     LinearLayoutManager layoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
                     listRecycler.setLayoutManager(layoutManager);
-                    KmListRMAdapter adapter = (KmListRMAdapter) KmRichMessageAdapterFactory.getInstance().getListRMAdapter(context, message, payload.getElements(), payload.getReplyMetadata(), listener, alCustomizationSettings, isMessageProcessed);
+                    KmListRMAdapter adapter = (KmListRMAdapter) KmRichMessageAdapterFactory.getInstance().getListRMAdapter(context, message, getFilteredList(isMessageProcessed, payload.getElements()), payload.getReplyMetadata(), listener, alCustomizationSettings, isMessageProcessed);
                     listRecycler.setAdapter(adapter);
 
                     if (!TextUtils.isEmpty(payload.getHeaderText())) {
@@ -64,15 +65,15 @@ public class ListKmRichMessage extends KmRichMessage {
                     if (payload.getButtons() != null) {
                         final List<KmRichMessageModel.KmButtonModel> action = payload.getButtons();
 
-                        if (action.get(0) != null) {
+                        if (showAction(isMessageProcessed, action.get(0))) {
                             setActionTextView((TextView) listItemLayout.findViewById(R.id.actionButton1), null, action.get(0), payload, model);
                         }
 
-                        if (action.size() > 1 && action.get(1) != null) {
+                        if (action.size() > 1 && showAction(isMessageProcessed, action.get(1))) {
                             setActionTextView((TextView) listItemLayout.findViewById(R.id.actionButton2), listItemLayout.findViewById(R.id.actionDivider2), action.get(1), payload, model);
                         }
 
-                        if (action.size() > 2 && action.get(2) != null) {
+                        if (action.size() > 2 && showAction(isMessageProcessed, action.get(2))) {
                             setActionTextView((TextView) listItemLayout.findViewById(R.id.actionButton3), listItemLayout.findViewById(R.id.actionDivider3), action.get(2), payload, model);
                         }
                     }
@@ -90,5 +91,20 @@ public class ListKmRichMessage extends KmRichMessage {
         if (actionDivider != null) {
             actionDivider.setVisibility(View.VISIBLE);
         }
+    }
+
+    private List<KmRichMessageModel.KmElementModel> getFilteredList(boolean isMessageProcessed, List<KmRichMessageModel.KmElementModel> elementList) {
+        List<KmRichMessageModel.KmElementModel> newList = new ArrayList<>();
+        for (KmRichMessageModel.KmElementModel element : elementList) {
+            if (isMessageProcessed && ButtonKmRichMessage.hideMessage(themeHelper, element.getAction().getType())) {
+                continue;
+            }
+            newList.add(element);
+        }
+        return newList;
+    }
+
+    private boolean showAction(boolean isMessageProcessed, KmRichMessageModel.KmButtonModel action) {
+        return action != null && !(isMessageProcessed && ButtonKmRichMessage.hideMessage(themeHelper, action.getType()));
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
@@ -32,8 +32,8 @@ public class ListKmRichMessage extends KmRichMessage {
     }
 
     @Override
-    public void createRichMessage() {
-        super.createRichMessage();
+    public void createRichMessage(boolean isMessageProcessed) {
+        super.createRichMessage(isMessageProcessed);
 
         if (model != null) {
             if (model.getPayload() != null) {
@@ -44,7 +44,7 @@ public class ListKmRichMessage extends KmRichMessage {
                     RecyclerView listRecycler = listItemLayout.findViewById(R.id.alListItemRecycler);
                     LinearLayoutManager layoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
                     listRecycler.setLayoutManager(layoutManager);
-                    KmListRMAdapter adapter = (KmListRMAdapter) KmRichMessageAdapterFactory.getInstance().getListRMAdapter(context, message, payload.getElements(), payload.getReplyMetadata(), listener, alCustomizationSettings);
+                    KmListRMAdapter adapter = (KmListRMAdapter) KmRichMessageAdapterFactory.getInstance().getListRMAdapter(context, message, payload.getElements(), payload.getReplyMetadata(), listener, alCustomizationSettings, isMessageProcessed);
                     listRecycler.setAdapter(adapter);
 
                     if (!TextUtils.isEmpty(payload.getHeaderText())) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -19,7 +19,7 @@ public class KmThemeHelper implements KmCallback {
 
     private static final String SUBMIT_BUTTON = "submit";
     private static final String LINK_BUTTON = "link";
-    private static final String QUICK_REPLIES = "quick-reply";
+    private static final String QUICK_REPLIES = "quickReply";
     private static KmThemeHelper kmThemeHelper;
     private final Context context;
     private final KmAppSettingPreferences appSettingPreferences;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -8,15 +8,22 @@ import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicommons.ApplozicService;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.utils.KmAppSettingPreferences;
 
 public class KmThemeHelper implements KmCallback {
 
+    private static final String SUBMIT_BUTTON = "submit";
+    private static final String LINK_BUTTON = "link";
+    private static final String QUICK_REPLIES = "quick-reply";
     private static KmThemeHelper kmThemeHelper;
-    private Context context;
-    private KmAppSettingPreferences appSettingPreferences;
-    private AlCustomizationSettings alCustomizationSettings;
+    private final Context context;
+    private final KmAppSettingPreferences appSettingPreferences;
+    private final AlCustomizationSettings alCustomizationSettings;
     private Boolean collectFeedback;
     private int primaryColor = -1;
     private int secondaryColor = -1;
@@ -29,7 +36,7 @@ public class KmThemeHelper implements KmCallback {
     private int toolbarColor = -1;
     private int statusBarColor = -1;
     private int richMessageThemeColor = -1;
-    private Boolean hidePostCTA;
+    private Map<String, Boolean> hidePostCTA = new HashMap<>();
 
     public static KmThemeHelper getInstance(Context context, AlCustomizationSettings alCustomizationSettings) {
         if (kmThemeHelper == null) {
@@ -93,14 +100,35 @@ public class KmThemeHelper implements KmCallback {
         return collectFeedback;
     }
 
-    public boolean isHidePostCTA() {
+    public Map<String, Boolean> getHidePostCTA() {
+        hidePostCTA = alCustomizationSettings.isHidePostCTA();
         if (hidePostCTA == null) {
-            hidePostCTA = alCustomizationSettings.isHidePostCTA();
-            if (hidePostCTA == null) {
-                hidePostCTA = appSettingPreferences.isHidePostCTA();
-            }
+            hidePostCTA = new HashMap<>();
         }
         return hidePostCTA;
+    }
+
+    public boolean isHidePostCTA() {
+        if (getHidePostCTA().isEmpty()) {
+            return false;
+        }
+        HashSet<Boolean> values = new HashSet<>(getHidePostCTA().values());
+        return !(values.size() == 1 && values.contains(false));
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public boolean hideSubmitButtonsPostCTA() {
+        return getHidePostCTA().get(SUBMIT_BUTTON) != null ? getHidePostCTA().get(SUBMIT_BUTTON) : false;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public boolean hideLinkButtonsPostCTA() {
+        return getHidePostCTA().get(LINK_BUTTON) != null ? getHidePostCTA().get(LINK_BUTTON) : false;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public boolean hideQuickRepliesPostCTA() {
+        return getHidePostCTA().get(QUICK_REPLIES) != null ? getHidePostCTA().get(QUICK_REPLIES) : false;
     }
 
     public int getSentMessageBorderColor() {
@@ -174,11 +202,8 @@ public class KmThemeHelper implements KmCallback {
 
     @Override
     public void onSuccess(Object message) {
-        if (message instanceof String) {
-            switch ((String) message) {
-                case KmAppSettingPreferences.CLEAR_THEME_INSTANCE:
-                    clearInstance();
-            }
+        if (message instanceof String && KmAppSettingPreferences.CLEAR_THEME_INSTANCE.equals((String) message)) {
+            clearInstance();
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -29,6 +29,7 @@ public class KmThemeHelper implements KmCallback {
     private int toolbarColor = -1;
     private int statusBarColor = -1;
     private int richMessageThemeColor = -1;
+    private Boolean hidePostCTA;
 
     public static KmThemeHelper getInstance(Context context, AlCustomizationSettings alCustomizationSettings) {
         if (kmThemeHelper == null) {
@@ -90,6 +91,16 @@ public class KmThemeHelper implements KmCallback {
             collectFeedback = appSettingPreferences.isCollectFeedback();
         }
         return collectFeedback;
+    }
+
+    public boolean isHidePostCTA() {
+        if (hidePostCTA == null) {
+            hidePostCTA = alCustomizationSettings.isHidePostCTA();
+            if (hidePostCTA == null) {
+                hidePostCTA = appSettingPreferences.isHidePostCTA();
+            }
+        }
+        return hidePostCTA;
     }
 
     public int getSentMessageBorderColor() {


### PR DESCRIPTION
* If the setting is enabled, all the rich messages after the last sent message will be visible
* The buttons not having any type in card/list will not be affected since the check is only based on the type
* In web currently only quick replies are hidden, I have provided setting for hiding all three types, links, submit and quickReply.