### PR TITLE
Flexbox groupID changed

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicomkit.ApplozicClient;
@@ -67,7 +68,7 @@ public class KmUserClientService extends UserClientService {
     private static final String USER_PASSWORD_RESET = "/users/password-reset";
     private static final String INVALID_APP_ID = "INVALID_APPLICATIONID";
     private static final String CREATE_CONVERSATION_URL = "/create";
-    private static final String BOTS_BASE_URL = "https://bots.kommunicate.io";
+    private static final String BOTS_BASE_URL = "https://api.kommunicate.io";
     private static final String GET_AGENT_DETAILS = "/users/list";
     public HttpRequestUtils httpRequestUtils;
 
@@ -286,6 +287,7 @@ public class KmUserClientService extends UserClientService {
     public String getBotDetail(String applicationId, String botId) {
         String response = getResponse(getBotDetailUrl(applicationId, botId), "application/json", "application/json");
         Utils.printLog(context, TAG, "Bot detail response: " + response);
+        Log.e("bot:", response);
         return response;
     }
 

--- a/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicomkit.ApplozicClient;
@@ -68,7 +67,7 @@ public class KmUserClientService extends UserClientService {
     private static final String USER_PASSWORD_RESET = "/users/password-reset";
     private static final String INVALID_APP_ID = "INVALID_APPLICATIONID";
     private static final String CREATE_CONVERSATION_URL = "/create";
-    private static final String BOTS_BASE_URL = "https://api.kommunicate.io";
+    private static final String BOTS_BASE_URL = "https://bots.kommunicate.io";
     private static final String GET_AGENT_DETAILS = "/users/list";
     public HttpRequestUtils httpRequestUtils;
 
@@ -287,7 +286,6 @@ public class KmUserClientService extends UserClientService {
     public String getBotDetail(String applicationId, String botId) {
         String response = getResponse(getBotDetailUrl(applicationId, botId), "application/json", "application/json");
         Utils.printLog(context, TAG, "Bot detail response: " + response);
-        Log.e("bot:", response);
         return response;
     }
 

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     api 'androidx.cardview:cardview:1.0.0'
     api 'com.google.android.material:material:1.3.0'
     api "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
-    implementation 'com.google.android:flexbox:2.0.1'
+    implementation 'com.google.android.flexbox:flexbox:3.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     //Note: use this in case customization is not required
 }


### PR DESCRIPTION
To fix this error:
`Could not GET 'https://google.bintray.com/flexbox-layout/com/google/android/flexbox/2.0.1/flexbox-2.0.1.pom'. Received status code 403 from server: Forbidden`

The previous dependency was deprecated.

Flexbox: 
> Starting from 3.0.0, the groupId is changed to com.google.android.flexbox in preparation to uploading the artifacts to google maven. You can still download the artifacts from jcenter for the past versions with the prior groupId (com.google.android), but migrating the library 3.0.0 is recommended.

