### PR TITLE
Use KM API URL for bot details

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
@@ -67,7 +67,7 @@ public class KmUserClientService extends UserClientService {
     private static final String USER_PASSWORD_RESET = "/users/password-reset";
     private static final String INVALID_APP_ID = "INVALID_APPLICATIONID";
     private static final String CREATE_CONVERSATION_URL = "/create";
-    private static final String BOTS_BASE_URL = "https://bots.kommunicate.io";
+    private static final String BOTS_BASE_URL = "https://api.kommunicate.io";
     private static final String GET_AGENT_DETAILS = "/users/list";
     public HttpRequestUtils httpRequestUtils;
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- `application/<key>/bot/<botID>` endpoint could be removed from the bot server, so changed to KM API URL: `api.kommunicate.io`. 

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [X] Deleted Shared Preferences and tested
