### PR TITLE
[ TD- 1828 ] Invalid conversation showing in Agent app fix

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
@@ -45,6 +45,7 @@ public class Channel extends JsonMarker {
     public static final int CLOSED_CONVERSATIONS = 3;
     public static final int ASSIGNED_CONVERSATIONS = 1;
     public static final int ALL_CONVERSATIONS = 2;
+    public static final int NOTSTARTED_CONVERSATIONS = -1;
     public static final String AL_BLOCK = "AL_BLOCK";
 
     public Channel() {
@@ -257,6 +258,10 @@ public class Channel extends JsonMarker {
 
         if (getMetadata().containsKey(CONVERSATION_STATUS) && ("2".equals(getMetadata().get(CONVERSATION_STATUS)) || "3".equals(getMetadata().get(CONVERSATION_STATUS)))) {
             return CLOSED_CONVERSATIONS;
+        }
+
+        if(getMetadata().containsKey(CONVERSATION_STATUS) && ("-1".equals(getMetadata().get(CONVERSATION_STATUS)))) {
+            return NOTSTARTED_CONVERSATIONS;
         }
 
         if (getMetadata().containsKey(CONVERSATION_ASSIGNEE) && !TextUtils.isEmpty(getMetadata().get(CONVERSATION_ASSIGNEE))) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Conversations initiated by bots but had no reply should not show up in the Agent App
- Those conversations have Conversation Status = -1

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] Deleted Shared Preferences and tested
