### PR TITLE
[TD-2091] - ProgressDialog crash fix

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/authentication/AlAuthService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/authentication/AlAuthService.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.os.Build;
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -70,7 +71,7 @@ public class AlAuthService {
         }
     }
 
-    public static void refreshToken(Context context, String loadingMessage, final AlCallback callback) {
+    public static void refreshToken(final Context context, String loadingMessage, final AlCallback callback) {
         final ProgressDialog progressDialog = new ProgressDialog(getActivity(context));
         progressDialog.setMessage(loadingMessage);
         progressDialog.setCancelable(false);
@@ -79,8 +80,14 @@ public class AlAuthService {
         refreshToken(context, new AlCallback() {
             @Override
             public void onSuccess(Object response) {
-                if (progressDialog != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    if(progressDialog != null && (!getActivity(context).isDestroyed())) {
+                        progressDialog.dismiss();
+                    }
+                }
+                if (progressDialog != null && (!getActivity(context).isFinishing())) {
                     progressDialog.dismiss();
+
                 }
                 if (callback != null) {
                     callback.onSuccess(response);
@@ -89,7 +96,12 @@ public class AlAuthService {
 
             @Override
             public void onError(Object error) {
-                if (progressDialog != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    if(progressDialog != null && (!getActivity(context).isDestroyed())) {
+                        progressDialog.dismiss();
+                    }
+                }
+                if (progressDialog != null && (!getActivity(context).isFinishing())) {
                     progressDialog.dismiss();
                 }
                 if (callback != null) {


### PR DESCRIPTION
To fix this crash: java.lang.IllegalArgumentException; View not attached to window manager

While the conversations are getting fetched, a ProgressDialog is shown. When the async task to fetch the conversations is done, the dialog is dismissed. If the activity is destroyed or changed while the async task is running, it will crash the app and send a crash report to the Firebase server.

To fix this, do not dismiss the dialog when the Activity is finishing or destroyed.. 
isDestroyed has a minimum SDK version of 17. 
For SDk version 16, isFinishing() should work in most of the cases.