### PR TITLE
[TD-2082] - Fix notification for agents

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -161,13 +161,19 @@ public class BroadcastService {
 
             if (MobiComUserPreference.getInstance(context).isLoggedIn()) {
                 Channel channel = ChannelService.getInstance(context).getChannelInfo(message.getGroupId());
-                Contact contact = null;
+                Contact contact = new AppContactService(context).getContactById(message.getContactIds());
+
+                //Do not send BOT and Agent message notification to agents, roletype 3 = user
+                if(MobiComUserPreference.getInstance(context).getUserRoleType() != 3) {
+                        if(contact.getRoleType() != 3) {
+                            return;
+                        }
+                }
+
                 if (message.getConversationId() != null) {
                     ConversationService.getInstance(context).getConversation(message.getConversationId());
                 }
-                if (message.getGroupId() == null) {
-                    contact = new AppContactService(context).getContactById(message.getContactIds());
-                }
+
                 if (ApplozicClient.getInstance(context).isNotificationStacking()) {
                     notificationService.notifyUser(contact, channel, message, index);
                 } else {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -164,9 +164,13 @@ public class BroadcastService {
                 Contact contact = new AppContactService(context).getContactById(message.getContactIds());
 
                 //Do not send BOT and Agent message notification to agents, roletype 3 = user
+                //TODO: Notification should be handled from server side. Change this code when server side changes is done
                 if(MobiComUserPreference.getInstance(context).getUserRoleType() != 3) {
                         if(contact.getRoleType() != 3) {
                             return;
+                        }
+                        if(!channel.getConversationAssignee().equals(MobiComUserPreference.getInstance(context).getUserId())) {
+                             return;
                         }
                 }
 


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Agents should not receive notifications for Bot messages and agents message

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [X] Tested in SDK and Agent app both


removed `if (message.getGroupId() == null)` because it was not of any use, in any case.
