### PR TITLE
Fix for wrong storage permission on SDK >= 28

### DIFF
--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
         tools:node="merge" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage"
         tools:node="merge" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"


### PR DESCRIPTION
Fix for this issue: https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/issues/212

