### PR TITLE
[TD-2220] - Use S3 for attachment upload and downloading Encrypted attachment

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/ApplozicMultipartUtility.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/ApplozicMultipartUtility.java
@@ -21,6 +21,7 @@ import java.net.URLConnection;
 
 public class ApplozicMultipartUtility {
     private static final String LINE_FEED = "\r\n";
+    private static final String AWS_ENCRYPTED = "AWS-ENCRYPTED-";
     final String TAG = "AlMultipartUtility";
     private final String boundary;
     private HttpURLConnection httpConn;
@@ -53,7 +54,7 @@ public class ApplozicMultipartUtility {
         writer.append("--" + boundary).append(LINE_FEED);
         writer.append(
                 "Content-Disposition: form-data; name=\"" + fieldName
-                        + "\"; filename=\"" + fileName + "\"")
+                        + "\"; filename=\"" + AWS_ENCRYPTED + fileName + "\"")
                 .append(LINE_FEED);
         writer.append(
                 "Content-Type: "

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
@@ -14,6 +14,7 @@ import android.text.TextUtils;
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.HttpRequestUtils;
 import com.applozic.mobicomkit.api.MobiComKitClientService;
+import com.applozic.mobicomkit.api.attachment.urlservice.S3URLService;
 import com.applozic.mobicomkit.api.attachment.urlservice.URLServiceProvider;
 import com.applozic.mobicomkit.api.conversation.Message;
 import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
@@ -254,13 +255,8 @@ public class FileClientService extends MobiComKitClientService {
         try {
 
             ApplozicMultipartUtility multipart = new ApplozicMultipartUtility(getUploadURL(), "UTF-8", context);
-            if (ApplozicClient.getInstance(context).isS3StorageServiceEnabled()) {
-                multipart.addFilePart("file", new File(path), handler, oldMessageKey);
-            } else {
-                multipart.addFilePart("files[]", new File(path), handler, oldMessageKey);
-            }
+            multipart.addFilePart("file", new File(path), handler, oldMessageKey);
             return multipart.getResponse();
-//            return new URLServiceProvider(context).getMultipartFile(path, handler).getResponse();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -268,7 +264,7 @@ public class FileClientService extends MobiComKitClientService {
     }
 
     public String getUploadURL() {
-        String fileUrl = new URLServiceProvider(context).getFileUploadUrl();
+        String fileUrl = new S3URLService(context).getFileUploadUrl();
         return fileUrl;
     }
 

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
@@ -264,7 +264,7 @@ public class FileClientService extends MobiComKitClientService {
     }
 
     public String getUploadURL() {
-        String fileUrl = new S3URLService(context).getFileUploadUrl();
+        String fileUrl = new URLServiceProvider(context).getFileUploadUrl();
         return fileUrl;
     }
 

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/urlservice/S3URLService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/urlservice/S3URLService.java
@@ -20,7 +20,7 @@ public class S3URLService implements URLService {
     private static final String GET_SIGNED_URL = "/rest/ws/file/url?key=";
 
 
-    S3URLService(Context context) {
+    public S3URLService(Context context) {
         mobiComKitClientService = new MobiComKitClientService(context);
         httpRequestUtils = new HttpRequestUtils(context);
     }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/urlservice/URLServiceProvider.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/urlservice/URLServiceProvider.java
@@ -48,7 +48,12 @@ public class URLServiceProvider {
         HttpURLConnection connection;
 
         try {
-            connection = getUrlService(context).getAttachmentConnection(message);
+            if(message.isAttachmentEncrypted()) {
+                connection = new S3URLService(context).getAttachmentConnection(message);
+            }
+            else {
+                connection = getUrlService(context).getAttachmentConnection(message);
+            }
         } catch (Exception e) {
             throw new IOException("Error connecting");
         }
@@ -57,14 +62,20 @@ public class URLServiceProvider {
 
     public String getThumbnailURL(Message message) throws IOException {
         try {
-            return getUrlService(context).getThumbnailURL(message);
+            if(message.isAttachmentEncrypted()) {
+                return new S3URLService(context).getThumbnailURL(message);
+            }
+            else {
+                return getUrlService(context).getThumbnailURL(message);
+            }
         } catch (Exception e) {
             throw new IOException("Error connecting");
         }
     }
 
+    //Upload to only S3 but download from any service
     public String getFileUploadUrl() {
-        return getUrlService(context).getFileUploadUrl();
+        return new S3URLService(context).getFileUploadUrl();
     }
 
     public String getImageURL(Message message) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -79,6 +79,7 @@ public class Message extends JsonMarker {
     public static final String STATUS_CLOSED = "closed";
     public static final String STATUS_OPEN = "open";
     public static final String RICH_MESSAGE_CONTENT_TYPE = "300";
+    private static final String AWS_ENCRYPTED = "AWS-ENCRYPTED-";
 
     public Message() {
 
@@ -729,6 +730,10 @@ public class Message extends JsonMarker {
 
     public boolean isRichMessage() {
         return metadata != null && RICH_MESSAGE_CONTENT_TYPE.equals(metadata.get("contentType"));
+    }
+
+    public boolean isAttachmentEncrypted() {
+        return getFileMetas().getName().startsWith(AWS_ENCRYPTED);
     }
 
     public enum Source {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
@@ -427,7 +427,6 @@ public class MessageClientService extends MobiComKitClientService {
                         BroadcastService.sendMessageUpdateBroadcast(context, BroadcastService.INTENT_ACTIONS.UPLOAD_ATTACHMENT_FAILED.toString(), message);
                         return;
                     }
-                    if (ApplozicClient.getInstance(context).isS3StorageServiceEnabled()) {
                         if (!TextUtils.isEmpty(fileMetaResponse)) {
                             message.setFileMetas((FileMeta) GsonUtils.getObjectFromJson(fileMetaResponse, FileMeta.class));
                             if (handler != null) {
@@ -438,21 +437,6 @@ public class MessageClientService extends MobiComKitClientService {
                                 msg.sendToTarget();
                             }
                         }
-                    } else {
-                        JsonParser jsonParser = new JsonParser();
-                        JsonObject jsonObject = jsonParser.parse(fileMetaResponse).getAsJsonObject();
-                        if (jsonObject.has(FILE_META)) {
-                            Gson gson = new Gson();
-                            message.setFileMetas(gson.fromJson(jsonObject.get(FILE_META), FileMeta.class));
-                            if (handler != null) {
-                                android.os.Message msg = handler.obtainMessage();
-                                msg.what = MobiComConversationService.UPLOAD_COMPLETED;
-                                msg.getData().putString(MobiComKitConstants.OLD_MESSAGE_KEY_INTENT_EXTRA, oldMessageKey);
-                                msg.getData().putString("error", null);
-                                msg.sendToTarget();
-                            }
-                        }
-                    }
                 } catch (Exception ex) {
                     Utils.printLog(context, TAG, "Error uploading file to server: " + filePath);
                     if (handler != null) {


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Attachment upload will be uploaded to S3 by default.
- Encrypted images will be downloaded using S3, rest will be downloading using default service.

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [X] Tested in SDK and Agent app both
