### PR TITLE
[TD-2150] - Set serialVersionUID to Serializable class

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
@@ -18,8 +18,8 @@ import java.util.TimeZone;
  * Created by devashish on 5/9/14.
  */
 public class Channel extends JsonMarker {
-
-    private static final long serialVersionUID = 200L;
+    
+    private static final long serialVersionUID = -8104332998622250852L;
     private Map<String, String> metadata = new HashMap<>();
     private Integer key;
     private Integer parentKey;

--- a/kommunicate/src/main/java/com/applozic/mobicommons/people/contact/Contact.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/people/contact/Contact.java
@@ -18,7 +18,7 @@ import java.util.TimeZone;
  */
 public class Contact extends JsonMarker {
 
-    private static final long serialVersionUID = 100L;
+    private static final long serialVersionUID = 6539430363524436833L;
     public static final String R_DRAWABLE = "R.drawable";
     public static final String DISABLE_CHAT_WITH_USER = "DISABLE_CHAT_WITH_USER";
     public static final String TRUE = "true";


### PR DESCRIPTION
> Caused by java.io.InvalidClassException
> com.applozic.mobicommons.people.channel.Channel; local class incompatible: stream classdesc serialVersionUID = 4048506603905733325, local class serialVersionUID = 9095551226066317591

This happens when the serialVersionUID of sender class and receiver class does not match. 
It is recommended for a Serializable class to have their own serialVersionUID so we have set it's value to the previous default value, which should fix the issue.