### PR TITLE
[TD-2260] Pre Chat Collection Support 

### DIFF
--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -101,32 +101,33 @@ public class MainActivity extends AppCompatActivity {
                 progressDialog.setCancelable(false);
                 progressDialog.show();
                 Kommunicate.init(MainActivity.this, APP_ID);
-                Kommunicate.loginAsVisitor(MainActivity.this, new KMLoginHandler() {
+//                Kommunicate.loginAsVisitor(MainActivity.this, new KMLoginHandler() {
+//                    @Override
+//                    public void onSuccess(RegistrationResponse registrationResponse, Context context) {
+//                        finish();
+//                        progressDialog.dismiss();
+//                        Kommunicate.openConversation(context, null);
+//                    }
+//
+//                    @Override
+//                    public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
+//                        progressDialog.dismiss();
+//                        createLoginErrorDialog(registrationResponse, exception);
+//                    }
+//                });
+                Kommunicate.loginAsVisitorV2(MainActivity.this, new KmCallback() {
                     @Override
-                    public void onSuccess(RegistrationResponse registrationResponse, Context context) {
+                    public void onSuccess(Object message) {
                         finish();
                         progressDialog.dismiss();
-                        Kommunicate.openConversation(context, null);
                     }
 
                     @Override
-                    public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-                        progressDialog.dismiss();
-                        createLoginErrorDialog(registrationResponse, exception);
+                    public void onFailure(Object error) {
+                        createLoginErrorDialog(null, (Exception) error);
+
                     }
                 });
-//                Kommunicate.loginAsVisitorV2(MainActivity.this, new KmCallback() {
-//                    @Override
-//                    public void onSuccess(Object message) {
-//                        finish();
-//                        progressDialog.dismiss();
-//                    }
-//
-//                    @Override
-//                    public void onFailure(Object error) {
-//
-//                    }
-//                });
             }
         });
     }

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -115,7 +115,7 @@ public class MainActivity extends AppCompatActivity {
 //                        createLoginErrorDialog(registrationResponse, exception);
 //                    }
 //                });
-                Kommunicate.loginAsVisitorV2(MainActivity.this, new KmCallback() {
+                Kommunicate.launchConversationWithPreChat(MainActivity.this, new KmCallback() {
                     @Override
                     public void onSuccess(Object message) {
                         finish();
@@ -125,7 +125,7 @@ public class MainActivity extends AppCompatActivity {
                     @Override
                     public void onFailure(Object error) {
                         progressDialog.dismiss();
-                        createLoginErrorDialog(null,(Exception) error);
+                        createLoginErrorDialog(null, (Exception) error);
 
                     }
                 });

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -115,6 +115,18 @@ public class MainActivity extends AppCompatActivity {
                         createLoginErrorDialog(registrationResponse, exception);
                     }
                 });
+//                Kommunicate.loginAsVisitorV2(MainActivity.this, new KmCallback() {
+//                    @Override
+//                    public void onSuccess(Object message) {
+//                        finish();
+//                        progressDialog.dismiss();
+//                    }
+//
+//                    @Override
+//                    public void onFailure(Object error) {
+//
+//                    }
+//                });
             }
         });
     }

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -115,7 +115,7 @@ public class MainActivity extends AppCompatActivity {
 //                        createLoginErrorDialog(registrationResponse, exception);
 //                    }
 //                });
-                Kommunicate.launchConversationWithPreChat(MainActivity.this, new KmCallback() {
+                Kommunicate.launchConversationWithPreChat(MainActivity.this, progressDialog, new KmCallback() {
                     @Override
                     public void onSuccess(Object message) {
                         finish();

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -124,7 +124,8 @@ public class MainActivity extends AppCompatActivity {
 
                     @Override
                     public void onFailure(Object error) {
-                        createLoginErrorDialog(null, (Exception) error);
+                        progressDialog.dismiss();
+                        createLoginErrorDialog(null,(Exception) error);
 
                     }
                 });

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -101,20 +101,6 @@ public class MainActivity extends AppCompatActivity {
                 progressDialog.setCancelable(false);
                 progressDialog.show();
                 Kommunicate.init(MainActivity.this, APP_ID);
-//                Kommunicate.loginAsVisitor(MainActivity.this, new KMLoginHandler() {
-//                    @Override
-//                    public void onSuccess(RegistrationResponse registrationResponse, Context context) {
-//                        finish();
-//                        progressDialog.dismiss();
-//                        Kommunicate.openConversation(context, null);
-//                    }
-//
-//                    @Override
-//                    public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-//                        progressDialog.dismiss();
-//                        createLoginErrorDialog(registrationResponse, exception);
-//                    }
-//                });
                 Kommunicate.launchConversationWithPreChat(MainActivity.this, progressDialog, new KmCallback() {
                     @Override
                     public void onSuccess(Object message) {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -182,7 +182,7 @@ public class Kommunicate {
                     if (callback != null) {
                         callback.onReceive(user, context, (ResultReceiver) resultData.getParcelable(KmConstants.FINISH_ACTIVITY_RECEIVER));
                     }
-                }else {
+                } else {
                     callback.onError("Failed to Load Pre Chat Lead Collection!!");
                 }
             }
@@ -202,7 +202,7 @@ public class Kommunicate {
         login(context, getVisitor(), handler);
     }
 
-    public static void loginAsVisitorV2(final Context context, final KmCallback callback) {
+    public static void launchConversationWithPreChat(final Context context, final KmCallback callback) {
         final KMUser kmUser = getVisitor();
         if (isLoggedIn(context)) {
             String loggedInUserId = MobiComUserPreference.getInstance(context).getUserId();
@@ -288,7 +288,7 @@ public class Kommunicate {
 
             @Override
             public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-                Utils.printLog(context, TAG, "Registration Failure"+exception.getMessage());
+                Utils.printLog(context, TAG, "Registration Failure" + exception.getMessage());
                 callback.onFailure(exception);
             }
         }, context, null).execute();

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -7,7 +7,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.ResultReceiver;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicomkit.ApplozicClient;
@@ -189,16 +188,12 @@ public class Kommunicate {
                             Utils.printLog(context, TAG, "Failed to launch the Lead Collection Screen");
                             handler.onFailure(null, e);
                         }
-
-
                     } else {
                         Utils.printLog(context, TAG, "Failed to fetch the App setting model.So redirecting to login as visitor.");
-
                         new KmUserLoginTask(kmUser, false, handler, context, null).execute();
                     }
                 } else {
                     Utils.printLog(context, TAG, "Failed to fetch the app settings!!.Redirecting to Login As Visitor");
-
                     new KmUserLoginTask(kmUser, false, handler, context, null).execute();
                 }
 
@@ -206,7 +201,7 @@ public class Kommunicate {
 
             @Override
             public void onFailure(Object error) {
-                Log.i(TAG, "Failed to fetch the Lead Collection");
+                Utils.printLog(context, TAG, "Failed to fetch the Lead Collection");
                 handler.onFailure(null, (Exception) error);
             }
         }).execute();

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -166,16 +166,15 @@ public class Kommunicate {
             kmUser.setHideActionMessages(true);
             kmUser.setSkipDeletedGroups(true);
         }
-//
 
         new KmAppSettingTask(context, Applozic.getInstance(context).getApplicationKey(), new KmCallback() {
             @Override
             public void onSuccess(Object message) {
                 KmAppSettingModel model = (KmAppSettingModel) message;
-                if (model != null && model.getResponse() != null){
+                if (model != null && model.getResponse() != null) {
                     if (model.getResponse().isCollectLead()) {
-                        try{
-                            launchLeadCollection(context,model.getResponse().getLeadCollection(), new KmPrechatCallback<KMUser>() {
+                        try {
+                            launchLeadCollection(context, model.getResponse().getLeadCollection(), new KmPrechatCallback<KMUser>() {
                                 @Override
                                 public void onReceive(KMUser data, Context context, ResultReceiver finishActivityReceiver) {
                                     new KmUserLoginTask(data, false, handler, context, null).execute();
@@ -186,17 +185,19 @@ public class Kommunicate {
                                     handler.onFailure(null, null);
                                 }
                             });
-                        }catch (Exception e){
-                            Utils.printLog(context,TAG,"Failed to launch the Lead Collection Screen");
-                            handler.onFailure(null,e);
+                        } catch (Exception e) {
+                            Utils.printLog(context, TAG, "Failed to launch the Lead Collection Screen");
+                            handler.onFailure(null, e);
                         }
 
 
                     } else {
+                        Utils.printLog(context, TAG, "Failed to fetch the App setting model.So redirecting to login as visitor.");
+
                         new KmUserLoginTask(kmUser, false, handler, context, null).execute();
                     }
-                }else{
-                    Utils.printLog(context, TAG, "Failed to fetch the app settings!!");
+                } else {
+                    Utils.printLog(context, TAG, "Failed to fetch the app settings!!.Redirecting to Login As Visitor");
 
                     new KmUserLoginTask(kmUser, false, handler, context, null).execute();
                 }
@@ -211,7 +212,7 @@ public class Kommunicate {
         }).execute();
     }
 
-    public static void launchLeadCollection(final Context context, List<KmPrechatInputModel> inputModelList,final KmPrechatCallback<KMUser> callback) throws KmException {
+    public static void launchLeadCollection(final Context context, List<KmPrechatInputModel> inputModelList, final KmPrechatCallback<KMUser> callback) throws KmException {
         if (!(context instanceof Activity)) {
             throw new KmException("This method needs Activity context");
         }
@@ -299,7 +300,7 @@ public class Kommunicate {
         }
     }
 
-    public static void launchPrechatWithResult(final Context context,final KmPrechatCallback<KMUser> callback) throws KmException {
+    public static void launchPrechatWithResult(final Context context, final KmPrechatCallback<KMUser> callback) throws KmException {
         if (!(context instanceof Activity)) {
             throw new KmException("This method needs Activity context");
         }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -170,6 +170,16 @@ public class Kommunicate {
         new KmUserLoginTask(kmUser, false, handler, context, prechatReceiver).execute();
     }
 
+    /**
+     * To Launch the Pre Chat Lead Collection and get result from the Lead Collection Screen
+     *
+     * @param context          the context
+     * @param progressDialog   the loading progressbar if needed otherwise can pass null
+     * @param inputModelList   input model list to create the form in Lead Collection Screen
+     * @param preChatGreetings To set the Greetings Label on Lead Collection Screen.
+     * @param callback         To update the status
+     * @throws KmException
+     */
     public static void launchLeadCollection(final Context context, final ProgressDialog progressDialog, List<KmPrechatInputModel> inputModelList, final String preChatGreetings, final KmPrechatCallback<KMUser> callback) throws KmException {
         if (!(context instanceof Activity)) {
             throw new KmException("This method needs Activity context");
@@ -209,6 +219,14 @@ public class Kommunicate {
         login(context, getVisitor(), handler);
     }
 
+    /**
+     * To Check the Login status & launch the Pre Chat Lead Collection Screen
+     *
+     * @param context        the context
+     * @param progressDialog progress dialog if needed otherwise can pass null
+     * @param callback       the callback to update status
+     */
+
     public static void launchConversationWithPreChat(final Context context, final ProgressDialog progressDialog, final KmCallback callback) {
         final KMUser kmUser = getVisitor();
         if (isLoggedIn(context)) {
@@ -234,6 +252,14 @@ public class Kommunicate {
 
     }
 
+    /**
+     * To Check Lead Collection enabled or not by fetching the appsetting.
+     *
+     * @param context        the context
+     * @param progressDialog the progressDialog if needed otherwise can pass null
+     * @param kmUser         Randomly created KMUser Object for registration if lead collection is disabled
+     * @param callback       callback to update the status
+     */
     public static void checkForLeadCollection(final Context context, final ProgressDialog progressDialog, final KMUser kmUser, final KmCallback callback) {
         new KmAppSettingTask(context, Applozic.getInstance(context).getApplicationKey(), new KmCallback() {
             @Override
@@ -262,7 +288,14 @@ public class Kommunicate {
         }).execute();
     }
 
-    // To Login the user from Lead Collection Details and Launch the Chat directly
+    /**
+     * To Login the user from Lead Collection Details.
+     *
+     * @param context         the context
+     * @param appSettingModel appsetting model to get lead collection screen's input field & Greeting Message
+     * @param progressDialog  progressbar used in previous activities to close the progressbar if coming back from lead collection screeen
+     * @param callback        To update the status.
+     **/
     public static void loginLeadUserAndOpenChat(final Context context, KmAppSettingModel appSettingModel, ProgressDialog progressDialog, final KmCallback callback) {
         try {
             launchLeadCollection(context, progressDialog, appSettingModel.getResponse().getLeadCollection(), appSettingModel.getChatWidget().getPreChatGreetingMsg(), new KmPrechatCallback<KMUser>() {
@@ -285,6 +318,13 @@ public class Kommunicate {
         }
     }
 
+    /**
+     * To Log in the user with given KmUser object
+     *
+     * @param context  the context
+     * @param kmUser   kmUser to log in
+     * @param callback to update the status
+     */
     public static void loginUserWithKmCallBack(final Context context, KMUser kmUser, final KmCallback callback) {
 
         new KmUserLoginTask(kmUser, false, new KMLoginHandler() {
@@ -301,6 +341,12 @@ public class Kommunicate {
         }, context, null).execute();
     }
 
+    /**
+     * To launch the chat screen directly if the user is new or user has only one previous conversation.Otherwise widget will open Conversation List Screen.
+     *
+     * @param context  the context
+     * @param callback callback to update status
+     */
     public static void launchChatDirectly(final Context context, final KmCallback callback) {
         KmConversationBuilder conversationBuilder = new KmConversationBuilder(context);
         conversationBuilder.launchAndCreateIfEmpty(new KmCallback() {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -182,6 +182,8 @@ public class Kommunicate {
                     if (callback != null) {
                         callback.onReceive(user, context, (ResultReceiver) resultData.getParcelable(KmConstants.FINISH_ACTIVITY_RECEIVER));
                     }
+                }else {
+                    callback.onError("Failed to Load Pre Chat Lead Collection!!");
                 }
             }
         };
@@ -266,11 +268,12 @@ public class Kommunicate {
                 @Override
                 public void onError(String error) {
                     Utils.printLog(context, TAG, "Failed to load Pre Chat Screen" + error);
-                    callback.onFailure(error);
+                    callback.onFailure(new Exception(error));
                 }
             });
         } catch (Exception e) {
             Utils.printLog(context, TAG, "Failed to launch the Lead Collection Screen");
+
             callback.onFailure(e);
         }
     }
@@ -285,7 +288,7 @@ public class Kommunicate {
 
             @Override
             public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-                Utils.printLog(context, TAG, "Registration Failure" + exception.getMessage());
+                Utils.printLog(context, TAG, "Registration Failure"+exception.getMessage());
                 callback.onFailure(exception);
             }
         }, context, null).execute();

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -184,7 +184,9 @@ public class Kommunicate {
                         callback.onReceive(user, context, (ResultReceiver) resultData.getParcelable(KmConstants.FINISH_ACTIVITY_RECEIVER));
                     }
                 } else {
-                    progressDialog.dismiss();
+                    if (progressDialog != null) {
+                        progressDialog.dismiss();
+                    }
                 }
             }
         };

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
@@ -79,8 +79,10 @@ public class KmUserLoginTask extends UserLoginTask {
             if (handler != null) {
                 if (response.isRegistrationSuccess()) {
                     handler.onSuccess(response, context.get());
-                } else {
+                } else if(e != null) {
                     handler.onFailure(response, e);
+                }else{
+                    handler.onFailure(response,new Exception(response.getMessage()));
                 }
             }
         } else {

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
@@ -79,10 +79,10 @@ public class KmUserLoginTask extends UserLoginTask {
             if (handler != null) {
                 if (response.isRegistrationSuccess()) {
                     handler.onSuccess(response, context.get());
-                } else if(e != null) {
+                } else if (e != null) {
                     handler.onFailure(response, e);
-                }else{
-                    handler.onFailure(response,new Exception(response.getMessage()));
+                } else {
+                    handler.onFailure(response, new Exception(response.getMessage()));
                 }
             }
         } else {

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -9,6 +9,7 @@ public class KmAppSettingModel extends JsonMarker {
     private String code;
     private KmResponse response;
     public static final String SUCCESS = "SUCCESS";
+    public static final String PRE_CHAT_GREETINGS = "PRE_CHAT_GREETINGS";
 
     public String getCode() {
         return code;
@@ -113,6 +114,15 @@ public class KmAppSettingModel extends JsonMarker {
         private int botMessageDelayInterval;
         @SerializedName("isSingleThreaded")
         private boolean singleThreaded;
+        private String preChatGreetingMsg;
+
+        public String getPreChatGreetingMsg() {
+            return preChatGreetingMsg;
+        }
+
+        public void setPreChatGreetingMsg(String preChatGreetingMsg) {
+            this.preChatGreetingMsg = preChatGreetingMsg;
+        }
 
         public String getPrimaryColor() {
             return primaryColor;

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -3,6 +3,8 @@ package io.kommunicate.models;
 import com.applozic.mobicommons.json.JsonMarker;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
+
 public class KmAppSettingModel extends JsonMarker {
     private String code;
     private KmResponse response;
@@ -39,6 +41,24 @@ public class KmAppSettingModel extends JsonMarker {
         private boolean collectFeedback;
         private boolean hidePostCTA;
         private KmChatWidget chatWidget;
+        private boolean collectLead;
+        private List<KmPrechatInputModel> leadCollection;
+
+        public List<KmPrechatInputModel> getLeadCollection() {
+            return leadCollection;
+        }
+
+        public void setLeadCollection(List<KmPrechatInputModel> leadCollection) {
+            this.leadCollection = leadCollection;
+        }
+
+        public boolean isCollectLead() {
+            return collectLead;
+        }
+
+        public void setCollectLead(boolean collectLead) {
+            this.collectLead = collectLead;
+        }
 
         public String getUserName() {
             return userName;

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -3,6 +3,7 @@ package io.kommunicate.utils;
 public class KmConstants {
 
     public static final int PRECHAT_RESULT_CODE = 100;
+    public static final int PRECHAT_RESULT_FAILURE = 111;
     public static final String PRECHAT_RESULT_RECEIVER = "kmPrechatReceiver";
     public static final String FINISH_ACTIVITY_RECEIVER = "kmFinishActivityReceiver";
     public static final String TAKE_ORDER = "takeOrder";

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -11,12 +11,14 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.adapters.KmPrechatInputAdapter;
 
 import io.kommunicate.Kommunicate;
+import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.models.KmPrechatInputModel;
 
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
@@ -40,6 +42,8 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     private KmPrechatInputAdapter prechatInputAdapter;
     private List<KmPrechatInputModel> inputModelList;
     private AlCustomizationSettings alCustomizationSettings;
+    private TextView greetingText;
+    private String greetingMessage;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,8 +66,14 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             if (!TextUtils.isEmpty(preChatModelListJson)) {
                 inputModelList = Arrays.asList((KmPrechatInputModel[]) GsonUtils.getObjectFromJson(preChatModelListJson, KmPrechatInputModel[].class));
             }
-        }
+            greetingMessage = getIntent().getStringExtra(KmAppSettingModel.PRE_CHAT_GREETINGS);
+            if (TextUtils.isEmpty(greetingMessage)) {
+                greetingMessage = getString(R.string.prechat_screen_text);
+            }
 
+        }
+        greetingText = (TextView) findViewById(R.id.kmPreChatGreetingText);
+        setGreetingsText();
         RecyclerView kmPreChatRecyclerView = findViewById(R.id.kmPreChatRecyclerView);
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         layoutManager.setOrientation(RecyclerView.VERTICAL);
@@ -82,6 +92,10 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE, null);
         }
 
+    }
+
+    private void setGreetingsText() {
+        greetingText.setText(greetingMessage);
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -16,6 +16,7 @@ import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.adapters.KmPrechatInputAdapter;
 
+import io.kommunicate.Kommunicate;
 import io.kommunicate.models.KmPrechatInputModel;
 
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
@@ -77,11 +78,9 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     @Override
     public void onClick(View v) {
         if (prechatInputAdapter != null && prechatInputAdapter.areFieldsValid()) {
-            if (inputModelList != null) {
-                sendPrechatData(prechatInputAdapter.getDataMap());
-            } else {
-                sendPrechatUser(prechatInputAdapter.getDataMap());
-            }
+
+            sendPrechatUser(prechatInputAdapter.getDataMap());
+
         }
     }
 
@@ -146,6 +145,10 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             KMUser user = new KMUser();
 
             user.setUserName(!TextUtils.isEmpty(dataMap.get(EMAIL_FIELD)) ? dataMap.get(EMAIL_FIELD) : dataMap.get(CONTACT_NUMBER_FILED));
+
+            if (TextUtils.isEmpty(user.getUserId())){
+                user = Kommunicate.getVisitor();
+            }
 
             if (!TextUtils.isEmpty(dataMap.get(EMAIL_FIELD))) {
                 user.setEmail(dataMap.get(EMAIL_FIELD));

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -38,6 +38,7 @@ import io.kommunicate.utils.KmUtils;
 public class LeadCollectionActivity extends AppCompatActivity implements View.OnClickListener {
     public static final String EMAIL_VALIDATION_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
     public static final String PHONE_NUMBER_VALIDATION_REGEX = "^\\d{10}$";
+    public static final String NUMBER_VALIDATION_REGEX = "[0-9]+";
     private ResultReceiver prechatReceiver;
     private KmPrechatInputAdapter prechatInputAdapter;
     private List<KmPrechatInputModel> inputModelList;
@@ -69,7 +70,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
                     if (model.getField().equals(getString(R.string.emailEt))) {
                         model.setValidationRegex(EMAIL_VALIDATION_REGEX);
                     } else if (model.getField().equals(getString(R.string.phoneNumberEt))) {
-                        model.setValidationRegex(PHONE_NUMBER_VALIDATION_REGEX);
+                        model.setValidationRegex(NUMBER_VALIDATION_REGEX);
                     }
                 }
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -76,6 +76,15 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     }
 
     @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        if(prechatReceiver != null){
+            prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE,null);
+        }
+
+    }
+
+    @Override
     public void onClick(View v) {
         if (prechatInputAdapter != null && prechatInputAdapter.areFieldsValid()) {
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -65,6 +65,13 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             String preChatModelListJson = getIntent().getStringExtra(KmPrechatInputModel.KM_PRECHAT_MODEL_LIST);
             if (!TextUtils.isEmpty(preChatModelListJson)) {
                 inputModelList = Arrays.asList((KmPrechatInputModel[]) GsonUtils.getObjectFromJson(preChatModelListJson, KmPrechatInputModel[].class));
+                for (KmPrechatInputModel model : inputModelList) {
+                    if (model.getField().equals(getString(R.string.emailEt))) {
+                        model.setValidationRegex(EMAIL_VALIDATION_REGEX);
+                    } else if (model.getField().equals(getString(R.string.phoneNumberEt))) {
+                        model.setValidationRegex(PHONE_NUMBER_VALIDATION_REGEX);
+                    }
+                }
             }
             greetingMessage = getIntent().getStringExtra(KmAppSettingModel.PRE_CHAT_GREETINGS);
             if (TextUtils.isEmpty(greetingMessage)) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -78,8 +78,8 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        if(prechatReceiver != null){
-            prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE,null);
+        if (prechatReceiver != null) {
+            prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE, null);
         }
 
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -146,7 +146,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
 
             user.setUserName(!TextUtils.isEmpty(dataMap.get(EMAIL_FIELD)) ? dataMap.get(EMAIL_FIELD) : dataMap.get(CONTACT_NUMBER_FILED));
 
-            if (TextUtils.isEmpty(user.getUserId())){
+            if (TextUtils.isEmpty(user.getUserId())) {
                 user = Kommunicate.getVisitor();
             }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatInputAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatInputAdapter.java
@@ -92,7 +92,7 @@ public class KmPrechatInputAdapter extends RecyclerView.Adapter<KmPrechatInputAd
             if (inputModel != null) {
                 inputEditText.setInputType(KmPrechatInputModel.KmInputType.getInputType(inputModel.getType()));
                 inputEditText.setTransformationMethod(KmPrechatInputModel.KmInputType.PASSWORD.equals(inputModel.getType()) ? PasswordTransformationMethod.getInstance() : null);
-                textInputLayout.setHint(inputModel.getField());
+                textInputLayout.setHint(inputModel.getPlaceholder());
 
                 inputEditText.setText(inputTextMap != null && !TextUtils.isEmpty(inputTextMap.get(inputModel.getField())) ? inputTextMap.get(inputModel.getField()) : "");
                 inputEditText.setSelection(inputTextMap != null && inputTextMap.get(inputModel.getField()) != null ? inputTextMap.get(inputModel.getField()).length() : 0);

--- a/kommunicateui/src/main/res/layout/activity_km_lead_collection.xml
+++ b/kommunicateui/src/main/res/layout/activity_km_lead_collection.xml
@@ -22,6 +22,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
+                android:visibility="invisible"
                 android:layout_marginTop="25dp">
 
                 <View
@@ -39,10 +40,11 @@
             </FrameLayout>
 
             <TextView
-                android:layout_width="269dp"
+                android:id="@+id/kmPreChatGreetingText"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="46dp"
-                android:layout_marginLeft="46dp"
+                android:layout_marginStart="45dp"
+                android:layout_marginLeft="45dp"
                 android:layout_marginTop="15dp"
                 android:layout_marginEnd="45dp"
                 android:layout_marginRight="45dp"
@@ -62,9 +64,9 @@
                 android:layout_marginLeft="37dp"
                 android:layout_marginTop="46dp"
                 android:layout_marginEnd="39dp"
-                android:nestedScrollingEnabled="false"
                 android:layout_marginRight="39dp"
-                android:layout_marginBottom="8dp" />
+                android:layout_marginBottom="8dp"
+                android:nestedScrollingEnabled="false" />
 
             <Button
                 android:id="@+id/start_conversation"

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -204,7 +204,7 @@
     <string name="km_not_read">Not read yet</string>
     <string name="km_not_sent">Not sent</string>
     <string name="default_start_new_conversation">Start new conversation</string>
-    <string name="start_conversation">Start conversation</string>
+    <string name="start_conversation">Start Conversation</string>
     <string name="info_file_attachment_mime_type_not_supported">Can\'t send this type of files!</string>
     <string name="processing_take_over_from_bot">Taking over from bot</string>
 

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -237,7 +237,7 @@
 
     <string name="emailEt">Email</string>
     <string name="nameEt">Name</string>
-    <string name="phoneNumberEt">Phone number</string>
+    <string name="phoneNumberEt">Phone</string>
     <string name="prechat_screen_text">We just need a few details to help you get started</string>
     <string name="prechat_screen_toast_error_message">Either %1$s or %2$s is required</string>
     <string name="invalid_contact_number">Please enter a valid contact number</string>


### PR DESCRIPTION
**Feature Description:**
If user enables `Lead Collection` in the Dashboard, In the Chat widget when user clicked` Login AS Visitor`, instead of creating random user, widget will show the `User Lead Collection` Screen and after collecting those details, 
widget will create new User based on those details.

once has been created & registered, chat widget launch
1. conversation list screen if user has multiple conversation.
2. particular previous chat screen if user has only one conversation.
3. create a new conversation & show conversation screen if user has no previous conversation.


