### PR TITLE
[CM-698] - Update Away/Online status using Mqtt

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
@@ -555,6 +555,11 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
                                 if (NOTIFICATION_TYPE.DEACTIVATED.getValue().equals(mqttMessageResponse.getType())) {
                                     BroadcastService.sendUserActivatedBroadcast(context, AlMessageEvent.ActionType.USER_DEACTIVATED);
                                 }
+
+                                if(NOTIFICATION_TYPE.USER_ONLINE_STATUS.getValue().equals(mqttMessageResponse.getType())) {
+                                    String[] parts = mqttMessageResponse.getMessage().toString().split(",");
+                                    syncCallService.updateAwayStatus(parts[0], Integer.valueOf(parts[1]));
+                                }
                             }
 
                         } catch (Exception e) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/SyncCallService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/SyncCallService.java
@@ -231,4 +231,10 @@ public class SyncCallService {
     public void processLoggedUserDelete() {
         messageClientService.processLoggedUserDeletedFromServer();
     }
+
+    public void updateAwayStatus(String userId, Integer status) {
+        if(userId != null && status != null) {
+            BroadcastService.sendAgentStatusBroadcast(context, BroadcastService.INTENT_ACTIONS.AGENT_STATUS.toString(), userId, status);
+        }
+    }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -339,6 +339,14 @@ public class BroadcastService {
         sendBroadcast(context, intent);
     }
 
+    public static void sendAgentStatusBroadcast(Context context, String action, String userId, Integer status) {
+        Intent intent = new Intent();
+        intent.setAction(action);
+        intent.putExtra("userId", userId);
+        intent.putExtra("status", status);
+        sendBroadcast(context, intent);
+    }
+
     public static IntentFilter getIntentFilter() {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(INTENT_ACTIONS.FIRST_TIME_SYNC_COMPLETE.toString());
@@ -371,6 +379,7 @@ public class BroadcastService {
         intentFilter.addAction(INTENT_ACTIONS.GROUP_MUTE.toString());
         intentFilter.addAction(INTENT_ACTIONS.CONTACT_PROFILE_CLICK.toString());
         intentFilter.addAction(INTENT_ACTIONS.LOGGED_USER_DELETE.toString());
+        intentFilter.addAction(INTENT_ACTIONS.AGENT_STATUS.toString());
         intentFilter.addCategory(Intent.CATEGORY_DEFAULT);
         return intentFilter;
     }
@@ -389,6 +398,7 @@ public class BroadcastService {
         UPLOAD_ATTACHMENT_FAILED, MESSAGE_ATTACHMENT_DOWNLOAD_DONE, MESSAGE_ATTACHMENT_DOWNLOAD_FAILD,
         UPDATE_LAST_SEEN_AT_TIME, UPDATE_TYPING_STATUS, MESSAGE_READ_AND_DELIVERED, MESSAGE_READ_AND_DELIVERED_FOR_CONTECT, CHANNEL_SYNC,
         CONTACT_VERIFIED, NOTIFY_USER, MQTT_DISCONNECTED, UPDATE_CHANNEL_NAME, UPDATE_TITLE_SUBTITLE, CONVERSATION_READ, UPDATE_USER_DETAIL,
-        MESSAGE_METADATA_UPDATE, MUTE_USER_CHAT, MQTT_CONNECTED, USER_ONLINE, USER_OFFLINE, GROUP_MUTE, CONTACT_PROFILE_CLICK, LOGGED_USER_DELETE
+        MESSAGE_METADATA_UPDATE, MUTE_USER_CHAT, MQTT_CONNECTED, USER_ONLINE, USER_OFFLINE, GROUP_MUTE, CONTACT_PROFILE_CLICK, LOGGED_USER_DELETE,
+        AGENT_STATUS
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -20,4 +20,6 @@ public class KmConstants {
     public static final String CONVERSATION_ACTIVITY_NAME = "com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity";
     public static final int STATUS_AWAY = 2;
     public static final int STATUS_ONLINE = 3;
+    public static final int STATUS_OFFLINE = 0;
+    public static final int STATUS_CONNECTED = 1;
 }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -18,4 +18,6 @@ public class KmConstants {
     public static final String KM_HELPCENTER_URL = "KM_HELPCENTER_URL";
     public static final String PRECHAT_ACTIVITY_NAME = "com.applozic.mobicomkit.uiwidgets.kommunicate.activities.LeadCollectionActivity";
     public static final String CONVERSATION_ACTIVITY_NAME = "com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity";
+    public static final int STATUS_AWAY = 2;
+    public static final int STATUS_ONLINE = 3;
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -639,11 +639,19 @@ public class ConversationUIService {
     public void updateAgentStatus(String userId, Integer status) {
         if(userId != null && status != null && getConversationFragment().getChannel().getConversationAssignee().equals(userId)) {
                 if(status.equals(KmConstants.STATUS_AWAY)) {
-                    getConversationFragment().showAwayMessage(true, null);
                     getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), false);
+                    getConversationFragment().showAwayMessage(true, null);
                 } else if(status.equals(KmConstants.STATUS_ONLINE)) {
-                    getConversationFragment().showAwayMessage(false, null);
                     getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), true);
+                    getConversationFragment().showAwayMessage(false, null);
+                }
+                else if(status.equals(KmConstants.STATUS_OFFLINE)){
+                    getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
+                    getConversationFragment().showAwayMessage(true, null);
+                }
+                else if(status.equals(KmConstants.STATUS_CONNECTED)){
+                    getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
+                    getConversationFragment().loadAwayMessage();
                 }
         }
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -636,6 +636,18 @@ public class ConversationUIService {
         }
     }
 
+    public void updateAgentStatus(String userId, Integer status) {
+        if(userId != null && status != null && getConversationFragment().getChannel().getConversationAssignee().equals(userId)) {
+                if(status.equals(KmConstants.STATUS_AWAY)) {
+                    getConversationFragment().showAwayMessage(true, null);
+                    getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), false);
+                } else if(status.equals(KmConstants.STATUS_ONLINE)) {
+                    getConversationFragment().showAwayMessage(false, null);
+                    getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), true);
+                }
+        }
+    }
+
 
     public void startMessageInfoFragment(String messageJson) {
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -4,6 +4,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import androidx.fragment.app.FragmentActivity;
+import io.kommunicate.utils.KmConstants;
+
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.ApplozicClient;
@@ -126,7 +128,7 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
         } else if (BroadcastService.INTENT_ACTIONS.MUTE_USER_CHAT.toString().equals(action)) {
             conversationUIService.muteUserChat(intent.getBooleanExtra("mute", false), intent.getStringExtra("userId"));
         } else if(BroadcastService.INTENT_ACTIONS.AGENT_STATUS.toString().equals(action)) {
-            conversationUIService.updateAgentStatus(intent.getStringExtra("userId"), intent.getIntExtra("status", 3));
+            conversationUIService.updateAgentStatus(intent.getStringExtra("userId"), intent.getIntExtra("status", KmConstants.STATUS_ONLINE));
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -125,6 +125,8 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
             conversationUIService.updateMessageMetadata(keyString);
         } else if (BroadcastService.INTENT_ACTIONS.MUTE_USER_CHAT.toString().equals(action)) {
             conversationUIService.muteUserChat(intent.getBooleanExtra("mute", false), intent.getStringExtra("userId"));
+        } else if(BroadcastService.INTENT_ACTIONS.AGENT_STATUS.toString().equals(action)) {
+            conversationUIService.updateAgentStatus(intent.getStringExtra("userId"), intent.getIntExtra("status", 3));
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -898,7 +898,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
 
         if (channel != null && Channel.GroupType.SUPPORT_GROUP.getValue().equals(channel.getType())) {
-            loadAwayMessage();
+            showAwayMessage(true, null);
         }
 
         emoticonsBtn.setVisibility(View.GONE);
@@ -1061,7 +1061,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         setFeedbackDisplay(channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS && !KmUtils.isAgent(getContext()));
 
         if (existingAssignee != null && !existingAssignee.equals(channel.getConversationAssignee())) {
-            loadAwayMessage();
+            showAwayMessage(true, null);
         }
     }
 
@@ -4309,13 +4309,21 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             }
         });
     }
-
+    /**
+     * displays/hides the away layout
+     *
+     * @param show true to display/ false to not, if response is null, then fetch from cache
+     */
     public void showAwayMessage(boolean show, KmApiResponse.KmDataResponse response) {
         if (response != null) {
             kmAwayView.setupAwayMessage(response, channel);
-            if (alCustomizationSettings.getAwayMessageTextColor() != null) {
-                kmAwayView.getAwayMessageTv().setTextColor(Color.parseColor(alCustomizationSettings.getAwayMessageTextColor()));
-            }
+        } else if(show && response == null && kmAwayView.getAwayMessage() != null) {
+                kmAwayView.handleAwayMessage(show);
+        } else if (show){
+            loadAwayMessage();
+        }
+        if (alCustomizationSettings.getAwayMessageTextColor() != null) {
+            kmAwayView.getAwayMessageTv().setTextColor(Color.parseColor(alCustomizationSettings.getAwayMessageTextColor()));
         }
         kmAwayView.setVisibility(show && alCustomizationSettings.isEnableAwayMessage()? VISIBLE : GONE);
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3100,6 +3100,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (isEmailConversation(channel)) {
             emailReplyReminderLayout.setVisibility(VISIBLE);
         }
+
+        loadAwayMessage();
     }
 
     public void showTakeOverFromBotLayout(boolean show, final Contact assigneeBot) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3060,6 +3060,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     updateChannelSubTitle(channel);
                     ChannelService.isUpdateTitle = false;
                 }
+
+                loadAwayMessage();
+                processSupportGroupDetails(channel);
             }
 
             if (appContactService != null && contact != null) {
@@ -3101,7 +3104,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             emailReplyReminderLayout.setVisibility(VISIBLE);
         }
 
-        loadAwayMessage();
     }
 
     public void showTakeOverFromBotLayout(boolean show, final Contact assigneeBot) {
@@ -4319,9 +4321,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     public void showAwayMessage(boolean show, KmApiResponse.KmDataResponse response) {
         if (response != null) {
             kmAwayView.setupAwayMessage(response, channel);
-        } else if(show && response == null && kmAwayView.getAwayMessage() != null) {
-                kmAwayView.handleAwayMessage(show);
-        } else if (show){
+        } else if(show && kmAwayView.getAwayMessage() != null) {
+                kmAwayView.handleAwayMessage(true);
+        } else if(show){
             loadAwayMessage();
         }
         if (alCustomizationSettings.getAwayMessageTextColor() != null) {
@@ -4776,12 +4778,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
     public abstract void onStartLoading(boolean loadingStarted);
 
-    protected void loadAwayMessage() {
+    public void loadAwayMessage() {
         if (loggedInUserRole == User.RoleType.USER_ROLE.getValue()) {
             Kommunicate.loadAwayMessage(getContext(), channel.getKey(), new KmAwayMessageHandler() {
                 @Override
                 public void onSuccess(Context context, KmApiResponse.KmDataResponse response) {
                     showAwayMessage(true, response);
+
                 }
 
                 @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmAwayView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmAwayView.java
@@ -99,6 +99,10 @@ public class KmAwayView extends LinearLayout {
         return awayMessageTv;
     }
 
+    public String getAwayMessage() {
+        return awayMessage;
+    }
+
     public boolean isUserAnonymous() {
         return isUserAnonymous;
     }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Away/online status changed is published to a topic: https://kommunicate.atlassian.net/browse/TD-1641
- Message type is "APPLOZIC_25" - fetches for it, then sends a Broadcast
- Updated the UI when we receive the away/online status
- Away message is stored in cache and API away is only called once.



