### PR TITLE
[CM-696] - Speech to Text in Android 11 fix

### DIFF
--- a/kommunicateui/src/main/AndroidManifest.xml
+++ b/kommunicateui/src/main/AndroidManifest.xml
@@ -9,6 +9,12 @@
         </intent>
     </queries>
 
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"


### PR DESCRIPTION
Android 11 requires a SpeechRecognition query intent to be added in Manifest, for speech recognition to work.