### PR TITLE
[CM-753] - Use GCM encryption

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/encryption/EncryptionUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/encryption/EncryptionUtils.java
@@ -4,11 +4,10 @@ import android.text.TextUtils;
 import android.util.Base64;
 
 import java.security.Key;
-import java.util.Arrays;
 
 import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-
 
 /**
  * Created by sunil on 26/8/16.
@@ -16,7 +15,7 @@ import javax.crypto.spec.SecretKeySpec;
 public class EncryptionUtils {
 
     private static final String TAG = "EncryptionUtils";
-    private static final String ALGORITHM = "AES/ECB/NoPadding";
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
     private static final String ALGORITHM_AES = "AES";
 
     // Performs Encryption
@@ -26,40 +25,26 @@ public class EncryptionUtils {
             return null;
         }
         Key key =  generateKey(ketString);
-        Cipher chiper = Cipher.getInstance(ALGORITHM);
-        chiper.init(Cipher.ENCRYPT_MODE, key);
-        byte[] w = plainText.getBytes();
-        int bufferLength = 3072;
-        int i = 0;
-        byte[] buf = new byte[bufferLength];
-        StringBuffer stringBuffer = new StringBuffer();
-        while (i < w.length) {
-            int size = Math.min(bufferLength, w.length - i);
-            Arrays.fill(buf, (byte) 0);
-            System.arraycopy(w, i, buf, 0, size);
-            buf = chiper.doFinal(buf);
-            stringBuffer.append(Base64.encodeToString(buf,Base64.DEFAULT));
-            i += size;
-        }
-        return stringBuffer.toString();
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(new byte[16]));
+        byte[] encryptedByteValue = cipher.doFinal(plainText.getBytes("UTF-8"));
+        return Base64.encodeToString(encryptedByteValue, Base64.DEFAULT);
     }
 
     // Performs decryption
     public static String decrypt(String ketString, String encryptedText) throws Exception {
         // generate key
         Key key =  generateKey(ketString);
-        Cipher chiper= Cipher.getInstance(ALGORITHM);
-        chiper.init(Cipher.DECRYPT_MODE, key);
-        byte[] decodedValue = Base64.decode(encryptedText,Base64.DEFAULT);
-        byte[] decValue = chiper.doFinal(decodedValue);
-        String decryptedValue = new String(decValue);
-        return TextUtils.isEmpty(decryptedValue)?null:decryptedValue.trim();
+        Cipher cipher= Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(new byte[16]));
+        byte[] decryptedValue64 = Base64.decode(encryptedText, Base64.DEFAULT);
+        byte[] decryptedByteValue = cipher.doFinal(decryptedValue64);
+        return new String(decryptedByteValue, "UTF-8");
     }
 
     //generateKey() is used to generate a secret key for AES algorithm
     private static Key generateKey(String ketString) throws Exception {
-        Key key = new SecretKeySpec(ketString.getBytes(), ALGORITHM_AES);
-        return key;
+        return new SecretKeySpec(ketString.getBytes(), ALGORITHM);
     }
 
 }


### PR DESCRIPTION
> From Google: Google recommends that developers use "AES/GCM/NoPadding" instead of the aforementioned insecure mode.

Changed encryption type from "AES/ECB/NoPadding" to "AES/GCM/NoPadding". 