### PR TITLE
[CM-747] - use default authenticationTypeId same as web sdk

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/User.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/User.java
@@ -34,7 +34,7 @@ public class User extends JsonMarker {
     private String imageLink;
     private boolean enableEncryption;
     private Short pushNotificationFormat;
-    private Short authenticationTypeId = AuthenticationType.CLIENT.getValue();
+    private Short authenticationTypeId = AuthenticationType.APPLOZIC.getValue();
     private String displayName;
     private String appModuleName;
     private Short userTypeId;


### PR DESCRIPTION
Changed the default authenticationTypeId to 1 so users will require a valid password to login.
For visitors, they can login without a password.