### PR TITLE
[CM-767] - Auto-sync conversation when Agent is in All Conversation tab

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
@@ -45,7 +45,7 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
     private static final String TYPINGTOPIC = "typing-";
     private static final String OPEN_GROUP = "group-";
     private static final String MQTT_ENCRYPTION_TOPIC = "encr-";
-    private static final String SUPPORT_GROUP_TOPIC = "support-channel-";
+    private static final String SUPPORT_GROUP_TOPIC = "support-channel";
     private static ApplozicMqttService applozicMqttService;
     private AlMqttClient client;
     private MemoryPersistence memoryPersistence;
@@ -478,7 +478,15 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
                                 if (NOTIFICATION_TYPE.MESSAGE_SENT.getValue().equals(mqttMessageResponse.getType())) {
                                     GcmMessageResponse messageResponse = (GcmMessageResponse) GsonUtils.getObjectFromJson(messageDataString, GcmMessageResponse.class);
                                     Message sentMessageSync = messageResponse.getMessage();
-                                    syncCallService.syncMessages(sentMessageSync.getKeyString());
+                                    if (sentMessageSync.getGroupId() != null) {
+
+                                        Channel channel = ChannelService.getInstance(context).getChannelByChannelKey(sentMessageSync.getGroupId());
+                                        if (channel != null && channel.getKmStatus() == Channel.NOTSTARTED_CONVERSATIONS && !sentMessageSync.getGroupStatus().equals(Message.GroupStatus.INITIAL.getValue())) {
+                                            channel.setKmStatus(Channel.ALL_CONVERSATIONS);
+                                            ChannelService.getInstance(context).updateChannel(channel);
+                                        }
+                                    }
+                                    syncCallService.syncMessages(sentMessageSync.getKeyString(), sentMessageSync);
                                 }
 
                                 if (NOTIFICATION_TYPE.USER_BLOCKED.getValue().equals(mqttMessageResponse.getType()) ||

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
@@ -392,6 +392,12 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
                                     if (message.getGroupId() != null) {
                                         Channel channel = ChannelService.getInstance(context).getChannelByChannelKey(message.getGroupId());
 
+                                        //For agent app. If user replies to an Initial conversation then update the channel.
+                                        if(channel != null && channel.getKmStatus() == Channel.NOTSTARTED_CONVERSATIONS && !message.getGroupStatus().equals(Message.GroupStatus.INITIAL.getValue())) {
+                                            channel.setKmStatus(Channel.ALL_CONVERSATIONS);
+                                            ChannelService.getInstance(context).updateChannel(channel);
+                                        }
+
                                         if (channel != null && Channel.GroupType.OPEN.getValue().equals(channel.getType())) {
                                             if (!MobiComUserPreference.getInstance(context).getDeviceKeyString().equals(message.getDeviceKeyString())) {
                                                 syncCallService.syncMessages(message.getKeyString(), message);

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -38,6 +38,7 @@ public class Message extends JsonMarker {
     private boolean storeOnDevice;
     private String contactIds = "";
     private Integer groupId;
+    private Short groupStatus;
     private boolean sendToDevice;
     private Long scheduledAt;
     private Short source = Source.MT_MOBILE_APP.getValue();
@@ -676,6 +677,17 @@ public class Message extends JsonMarker {
         this.replyMessage = replyMessage;
     }
 
+
+    public Short getGroupStatus() {
+
+        return groupStatus;
+    }
+
+    public void setGroupStatus(Short groupStatus) {
+        this.groupStatus = groupStatus;
+    }
+
+
     public boolean isActionMessage() {
         return getMetadata() != null && (getMetadata().containsKey(BOT_ASSIGN) || getMetadata().containsKey(CONVERSATION_STATUS));
     }
@@ -734,6 +746,22 @@ public class Message extends JsonMarker {
 
     public boolean isAttachmentEncrypted() {
         return fileMeta != null && !TextUtils.isEmpty(fileMeta.getName()) && fileMeta.getName().startsWith(AWS_ENCRYPTED);
+    }
+
+    public enum GroupStatus {
+        INITIAL(Short.valueOf("-1")), OPEN(Short.valueOf("0")), PROGRESS(Short.valueOf("1")),
+        RESOLVED(Short.valueOf("2")), CLOSED(Short.valueOf("2")),
+        SPAM(Short.valueOf("3")), DUPLICATE(Short.valueOf("4")), ARCHIVE(Short.valueOf("5")),
+        UNRESPONDED(Short.valueOf("6")), WAITING(Short.valueOf("7"));
+        private Short value;
+
+        GroupStatus(Short c) {
+            value = c;
+        }
+
+        public Short getValue() {
+            return value;
+        }
     }
 
     public enum Source {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
@@ -479,6 +479,7 @@ public class MessageClientService extends MobiComKitClientService {
         newMessage.setDelivered(message.getDelivered());
         newMessage.setStatus(message.getStatus());
         newMessage.setMetadata(message.getMetadata());
+        newMessage.setGroupStatus(message.getGroupStatus());
 
         newMessage.setSendToDevice(message.isSendToDevice());
         newMessage.setContentType(message.getContentType());


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- When agents are in All Conversation tab, the conversation is not auto sync when end user - bot conversation is going on.
- This happens because Channel status is not refreshed when user replies for the first time
- Fix: Update channel locally when user has replied to a conversation
