### PR TITLE
[CM-783] - Pre-Chat lead form - Dropdown list

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -470,6 +470,7 @@ public class Kommunicate {
         try {
             Intent intent = new Intent(context, KmUtils.getClassFromName(KmConstants.PRECHAT_ACTIVITY_NAME));
             intent.putExtra(KmPrechatInputModel.KM_PRECHAT_MODEL_LIST, GsonUtils.getJsonFromObject(inputModelList, List.class));
+            intent.putExtra(KmConstants.PRECHAT_RETURN_DATA_MAP, true);
             intent.putExtra(KmConstants.PRECHAT_RESULT_RECEIVER, resultReceiver);
             context.startActivity(intent);
         } catch (ClassNotFoundException e) {

--- a/kommunicate/src/main/java/io/kommunicate/models/KmPrechatInputModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmPrechatInputModel.java
@@ -4,6 +4,8 @@ import android.text.InputType;
 
 import com.applozic.mobicommons.json.JsonMarker;
 
+import java.util.List;
+
 public class KmPrechatInputModel extends JsonMarker {
     public static final String KM_PRECHAT_MODEL_LIST = "preChatModelList";
     private String field;
@@ -13,6 +15,7 @@ public class KmPrechatInputModel extends JsonMarker {
     private String validationRegex;
     private String validationError;
     private String compositeRequiredField;
+    private List<String> options;
     private boolean required;
     private boolean displayValidationError;
     private boolean displayEmptyFieldError;
@@ -42,6 +45,14 @@ public class KmPrechatInputModel extends JsonMarker {
     public KmPrechatInputModel setType(String type) {
         this.type = type;
         return this;
+    }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<String> options) {
+        this.options = options;
     }
 
     public boolean isRequired() {

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -6,6 +6,7 @@ public class KmConstants {
     public static final int PRECHAT_RESULT_FAILURE = 111;
     public static final String PRECHAT_RESULT_RECEIVER = "kmPrechatReceiver";
     public static final String FINISH_ACTIVITY_RECEIVER = "kmFinishActivityReceiver";
+    public static final String PRECHAT_RETURN_DATA_MAP = "kmPrechatReturnData";
     public static final String TAKE_ORDER = "takeOrder";
     public static final String USER_ID = "userId";
     public static final String GROUP_ID = "groupId";

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/activities/LeadCollectionActivity.java
@@ -45,6 +45,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     private AlCustomizationSettings alCustomizationSettings;
     private TextView greetingText;
     private String greetingMessage;
+    private boolean returnDataMap;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,15 +63,17 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
         KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getStatusBarColor());
         if (getIntent() != null) {
             prechatReceiver = getIntent().getParcelableExtra(KmConstants.PRECHAT_RESULT_RECEIVER);
-
+            returnDataMap = getIntent().getBooleanExtra(KmConstants.PRECHAT_RETURN_DATA_MAP, false);
             String preChatModelListJson = getIntent().getStringExtra(KmPrechatInputModel.KM_PRECHAT_MODEL_LIST);
             if (!TextUtils.isEmpty(preChatModelListJson)) {
                 inputModelList = Arrays.asList((KmPrechatInputModel[]) GsonUtils.getObjectFromJson(preChatModelListJson, KmPrechatInputModel[].class));
                 for (KmPrechatInputModel model : inputModelList) {
-                    if (model.getField().equals(getString(R.string.emailEt))) {
-                        model.setValidationRegex(EMAIL_VALIDATION_REGEX);
-                    } else if (model.getField().equals(getString(R.string.phoneNumberEt))) {
-                        model.setValidationRegex(NUMBER_VALIDATION_REGEX);
+                    if(!TextUtils.isEmpty(model.getField())) {
+                        if (model.getField().equals(getString(R.string.emailEt))) {
+                            model.setValidationRegex(EMAIL_VALIDATION_REGEX);
+                        } else if (model.getField().equals(getString(R.string.phoneNumberEt))) {
+                            model.setValidationRegex(NUMBER_VALIDATION_REGEX);
+                        }
                     }
                 }
             }
@@ -86,7 +89,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
         LinearLayoutManager layoutManager = new LinearLayoutManager(this);
         layoutManager.setOrientation(RecyclerView.VERTICAL);
         kmPreChatRecyclerView.setLayoutManager(layoutManager);
-        prechatInputAdapter = new KmPrechatInputAdapter((inputModelList != null && !inputModelList.isEmpty()) ? inputModelList : getDefaultModelList());
+        prechatInputAdapter = new KmPrechatInputAdapter((inputModelList != null && !inputModelList.isEmpty()) ? inputModelList : getDefaultModelList(), this);
         kmPreChatRecyclerView.setAdapter(prechatInputAdapter);
 
         Button startConversationButton = findViewById(R.id.start_conversation);
@@ -109,7 +112,10 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     @Override
     public void onClick(View v) {
         if (prechatInputAdapter != null && prechatInputAdapter.areFieldsValid()) {
-
+            if(returnDataMap) {
+                sendPrechatData(prechatInputAdapter.getDataMap());
+                return;
+            }
             sendPrechatUser(prechatInputAdapter.getDataMap());
 
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatDropdownAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatDropdownAdapter.java
@@ -1,0 +1,62 @@
+package com.applozic.mobicomkit.uiwidgets.kommunicate.adapters;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
+
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.kommunicate.models.KmPrechatInputModel;
+
+/**
+ * Adapter class to handle prechat dropdown option
+ */
+
+public class KmPrechatDropdownAdapter extends ArrayAdapter<String> {
+    private KmPrechatInputModel prechatInputModel;
+
+    public  KmPrechatDropdownAdapter(@NonNull Context context, int textViewResourceId, KmPrechatInputModel inputModel, List<String> data) {
+        super(context, textViewResourceId, data);
+        this.prechatInputModel = inputModel;
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view = super.getDropDownView(position, convertView, parent);
+        TextView dropdownText = (TextView) view;
+        if(position == 0 && prechatInputModel.getPlaceholder() != null){
+            dropdownText.setTextColor(Color.GRAY);
+        }
+        else {
+            dropdownText.setTextColor(Color.BLACK);
+        }
+        return view;
+    }
+
+    @Override
+    public View getDropDownView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view = super.getDropDownView(position, convertView, parent);
+        TextView dropdownText = (TextView) view;
+        if(position == 0 && prechatInputModel.getPlaceholder() != null){
+            dropdownText.setTextColor(Color.GRAY);
+        }
+        else {
+            dropdownText.setTextColor(Color.BLACK);
+        }
+        return view;
+    }
+
+    @Override
+    public boolean isEnabled(int position) {
+        return position != 0;
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatInputAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmPrechatInputAdapter.java
@@ -1,5 +1,6 @@
 package com.applozic.mobicomkit.uiwidgets.kommunicate.adapters;
 
+import android.content.Context;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -7,6 +8,9 @@ import android.text.method.PasswordTransformationMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -22,83 +26,108 @@ import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public class KmPrechatInputAdapter extends RecyclerView.Adapter<KmPrechatInputAdapter.KmPrechatInputViewHolder> {
+/**
+ * Recycler view adapter to handle different prechat inputs: Textinput and Dropdown
+ */
+
+public class KmPrechatInputAdapter extends RecyclerView.Adapter {
 
     private List<KmPrechatInputModel> inputModelList;
     private Map<String, String> dataMap;
     private Map<String, String> inputTextMap;
+    private Context context;
+    public static final String PRECHAT_DROPDOWN_ELEMENT = "select";
 
-    public KmPrechatInputAdapter(List<KmPrechatInputModel> inputModelList) {
+    public KmPrechatInputAdapter(List<KmPrechatInputModel> inputModelList, Context context) {
         this.inputModelList = inputModelList;
         this.dataMap = new HashMap<>();
         this.inputTextMap = new HashMap<>();
+        this.context = context;
     }
 
     @NonNull
     @Override
-    public KmPrechatInputViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new KmPrechatInputViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.km_prechat_input_item_layout, parent, false));
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        LayoutInflater layoutInflater = (LayoutInflater) parent.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+
+        if (layoutInflater == null) {
+            return null;
+        }
+
+        if(viewType == 1) {
+            View dropdownHolder = layoutInflater.inflate(R.layout.km_prechat_dropdown_layout, parent, false);
+            return new KmPrechatDropdownViewHolder(dropdownHolder);
+        }
+        else {
+            View inputHolder = layoutInflater.inflate(R.layout.km_prechat_input_item_layout, parent, false);
+            return new KmPrechatInputViewHolder(inputHolder);
+        }
     }
 
     @Override
-    public void onBindViewHolder(@NonNull KmPrechatInputViewHolder holder, int position) {
-        KmPrechatInputModel inputModel = inputModelList.get(position);
-        if (inputModel != null) {
-            holder.bind(inputModel);
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
+        int type = getItemViewType(position);
+        KmPrechatInputModel inputModel = getItem(position);
+        if(inputModel == null)
+            return;
+        if(type == 1 ){
+            KmPrechatDropdownViewHolder dropdownViewHolder = (KmPrechatDropdownViewHolder) viewHolder;
+            List<String> dropdownList = new ArrayList<>();
+            if(!TextUtils.isEmpty(inputModel.getPlaceholder())) {
+                dropdownList.add(inputModel.getPlaceholder());
+            }
+            if(!inputModel.getOptions().isEmpty()) {
+                dropdownList.addAll(inputModel.getOptions());
+            }
+            ArrayAdapter<String> adapter = new KmPrechatDropdownAdapter(context,
+                    android.R.layout.simple_spinner_item, inputModel, dropdownList);
+            dropdownViewHolder.dropdownSpinner.setAdapter(adapter);
+            adapter.setDropDownViewResource(R.layout.mobiframework_custom_spinner);
         }
+        else {
+            KmPrechatInputViewHolder inputViewHolder = (KmPrechatInputViewHolder) viewHolder;
+            inputViewHolder.inputEditText.setInputType(KmPrechatInputModel.KmInputType.getInputType(inputModel.getType()));
+            inputViewHolder.inputEditText.setTransformationMethod(KmPrechatInputModel.KmInputType.PASSWORD.equals(inputModel.getType()) ? PasswordTransformationMethod.getInstance() : null);
+            inputViewHolder.textInputLayout.setHint(inputModel.getPlaceholder());
+
+            inputViewHolder.inputEditText.setText(inputTextMap != null && !TextUtils.isEmpty(inputTextMap.get(inputModel.getField())) ? inputTextMap.get(inputModel.getField()) : "");
+            inputViewHolder.inputEditText.setSelection(inputTextMap != null && inputTextMap.get(inputModel.getField()) != null ? inputTextMap.get(inputModel.getField()).length() : 0);
+            inputViewHolder.inputEditText.setError(getErrorText(inputModel));
+        }
+
+    }
+
+    /**
+     * Get the type of Viewholder required
+     * If model is null: 0
+     * If element is "select": 1
+     * if element is input: 2
+     */
+    @Override
+    public int getItemViewType(int position) {
+        KmPrechatInputModel model = getItem(position);
+        if(model == null) {
+            return 0;
+        }
+        if(model.getElement() != null && model.getElement().equals(PRECHAT_DROPDOWN_ELEMENT)) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private KmPrechatInputModel getItem(int position) {
+        return inputModelList.get(position);
     }
 
     @Override
     public int getItemCount() {
         return inputModelList != null ? inputModelList.size() : 0;
-    }
-
-    public class KmPrechatInputViewHolder extends RecyclerView.ViewHolder {
-        private TextInputEditText inputEditText;
-        private TextInputLayout textInputLayout;
-
-        public KmPrechatInputViewHolder(@NonNull View itemView) {
-            super(itemView);
-            inputEditText = itemView.findViewById(R.id.prechatInputEt);
-            textInputLayout = itemView.findViewById(R.id.prechatTextInputLayout);
-
-            inputEditText.addTextChangedListener(new TextWatcher() {
-                @Override
-                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-
-                }
-
-                @Override
-                public void onTextChanged(CharSequence s, int start, int before, int count) {
-
-                }
-
-                @Override
-                public void afterTextChanged(Editable s) {
-                    KmPrechatInputModel model = inputModelList.get(getAdapterPosition());
-                    if (model != null) {
-                        dataMap.put(model.getField(), s.toString());
-                    }
-                }
-            });
-        }
-
-        public void bind(KmPrechatInputModel inputModel) {
-            if (inputModel != null) {
-                inputEditText.setInputType(KmPrechatInputModel.KmInputType.getInputType(inputModel.getType()));
-                inputEditText.setTransformationMethod(KmPrechatInputModel.KmInputType.PASSWORD.equals(inputModel.getType()) ? PasswordTransformationMethod.getInstance() : null);
-                textInputLayout.setHint(inputModel.getPlaceholder());
-
-                inputEditText.setText(inputTextMap != null && !TextUtils.isEmpty(inputTextMap.get(inputModel.getField())) ? inputTextMap.get(inputModel.getField()) : "");
-                inputEditText.setSelection(inputTextMap != null && inputTextMap.get(inputModel.getField()) != null ? inputTextMap.get(inputModel.getField()).length() : 0);
-                inputEditText.setError(getErrorText(inputModel));
-            }
-        }
     }
 
     public Map<String, String> getDataMap() {
@@ -121,6 +150,11 @@ public class KmPrechatInputAdapter extends RecyclerView.Adapter<KmPrechatInputAd
 
             if (isInValidCompositeField(inputModel)) {
                 KmToast.error(ApplozicService.getAppContext(), getString(R.string.prechat_screen_toast_error_message, inputModel.getField(), inputModel.getCompositeRequiredField()), Toast.LENGTH_SHORT).show();
+                return false;
+            }
+
+            if(inputModel.getElement() != null && inputModel.getElement().equals(PRECHAT_DROPDOWN_ELEMENT) && inputModel.isRequired() && TextUtils.isEmpty(inputTextMap.get(inputModel.getField()))) {
+                KmToast.error(ApplozicService.getAppContext(), getString(R.string.prechat_dropdown_toast_error_message), Toast.LENGTH_SHORT).show();
                 return false;
             }
         }
@@ -147,5 +181,62 @@ public class KmPrechatInputAdapter extends RecyclerView.Adapter<KmPrechatInputAd
             return !TextUtils.isEmpty(inputModel.getValidationError()) ? inputModel.getValidationError() : getString(R.string.km_validation_error, inputModel.getField());
         }
         return null;
+    }
+
+    public class KmPrechatInputViewHolder extends RecyclerView.ViewHolder {
+        private TextInputEditText inputEditText;
+        private TextInputLayout textInputLayout;
+
+        public KmPrechatInputViewHolder(@NonNull View itemView) {
+            super(itemView);
+            inputEditText = itemView.findViewById(R.id.prechatInputEt);
+            textInputLayout = itemView.findViewById(R.id.prechatTextInputLayout);
+
+            inputEditText.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                }
+
+                @Override
+                public void afterTextChanged(Editable s) {
+                    KmPrechatInputModel model = getItem(getAdapterPosition());
+                    if (model != null) {
+                        dataMap.put(model.getField(), s.toString());
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * Dropdown view holder. If placeholder is present, then select the 1st option otherwise neglect it
+     */
+    public class KmPrechatDropdownViewHolder extends RecyclerView.ViewHolder {
+
+        private Spinner dropdownSpinner;
+
+        public KmPrechatDropdownViewHolder(@NonNull View itemView) {
+            super(itemView);
+            dropdownSpinner = itemView.findViewById(R.id.prechatDropdownSpinner);
+            dropdownSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                    KmPrechatInputModel model = getItem(getAdapterPosition());
+                    if (model != null) {
+                        if(model.getPlaceholder() != null && i > 0) {
+                            dataMap.put(model.getField(), adapterView.getItemAtPosition(i).toString());
+                        } else if(model.getPlaceholder() == null) {
+                            dataMap.put(model.getField(), adapterView.getItemAtPosition(i).toString());
+                        }
+                    }
+                }
+                @Override
+                public void onNothingSelected(AdapterView<?> adapterView) {}
+            });
+        }
     }
 }

--- a/kommunicateui/src/main/res/layout/km_prechat_dropdown_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_prechat_dropdown_layout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+<Spinner
+    android:id="@+id/prechatDropdownSpinner"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp"/>
+</LinearLayout>

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -240,6 +240,7 @@
     <string name="phoneNumberEt">Phone</string>
     <string name="prechat_screen_text">We just need a few details to help you get started</string>
     <string name="prechat_screen_toast_error_message">Either %1$s or %2$s is required</string>
+    <string name="prechat_dropdown_toast_error_message">You must select one of the options</string>
     <string name="invalid_contact_number">Please enter a valid contact number</string>
     <string name="invalid_email_id">Please enter a valid emailId</string>
     <string name="via_email_text">via email</string>


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->
### What do you want to achieve?
- Create dropdown list for Prechat lead collection - similar to Web SDK
- Can be created using the same Model as text input Model. Only different is we have to set Element = "select" for dropdown menu, and pass a List of String as options.
```
 KmPrechatInputModel dropdownField = new KmPrechatInputModel();
                dropdownField.setOptions(Arrays.asList("Kommunicate", "Intentive", "Applozic"));
                dropdownField.setPlaceholder("Enter details");
                dropdownField.setField("Company");
                dropdownField.setElement("select");
```

-Have different viewholder for Dropdown and Text input.
-KmPrechatInputAdapter now checks the element type and then assigns a Viewholder accordingly.

![image](https://user-images.githubusercontent.com/22256112/149756268-6a13f5c6-9aa9-4c23-bf3b-172e4b01998e.png)


