### PR TITLE
Support for Localization of editTextHintText

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -119,7 +119,7 @@
     ":file": true,
     ":audio": true
   },
-  "editTextHintText": "Type your message...",
+  "editTextHintText": "",
   "replyMessageLayoutSentMessageBackground": "#C0C0C0",
   "replyMessageLayoutReceivedMessageBackground": "#F5F5F5",
   "groupInfoScreenVisible": true,

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -97,7 +97,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private int totalOnlineUsers = 0;
     private String themeColorPrimary;
     private String themeColorPrimaryDark;
-    private String editTextHintText = "Write a Message..";
+    private String editTextHintText = "";
     private boolean replyOption = false;
     private String replyMessageLayoutSentMessageBackground = "#C0C0C0";
     private String replyMessageLayoutReceivedMessageBackground = "#F5F5F5";

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -8,7 +8,7 @@
     <string name="select_at_least">At least 1 contact must be selected</string>
     <string name="group_name_hint">Name of the group</string>
     <string name="empty_conversations">No conversations!</string>
-    <string name="enter_message_hint">Write a message...</string>
+    <string name="enter_message_hint">Write a message…</string>
     <string name="send_text">SEND</string>
     <string name="cancel_text">CANCEL</string>
     <string name="ok_text">OK</string>


### PR DESCRIPTION
`messageEditText.setHint(!TextUtils.isEmpty(alCustomizationSettings.getEditTextHintText()) ? alCustomizationSettings.getEditTextHintText() : getString(R.string.enter_message_hint));`

editTextHintText checked for value in alCustomizationSettings (applozic-settings.json) before localization using strings. 
Inside alCustomizationSettings, default value was set so localization using string was not happening.
Removed the default value from alCustomizationSettings  so now localization as well as custom settings will work.