### PR TITLE
[CM-917] - Fix for encoded header being sent

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/HttpRequestUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/HttpRequestUtils.java
@@ -241,7 +241,7 @@ public class HttpRequestUtils {
             }
 
             if (!TextUtils.isEmpty(userId)) {
-                connection.setRequestProperty(OF_USER_ID_HEADER, URLEncoder.encode(userId, "UTF-8"));
+                connection.setRequestProperty(OF_USER_ID_HEADER, userId);
             }
             String applicationKey = MobiComKitClientService.getApplicationKey(context);
 


### PR DESCRIPTION
Mobile SDK was sending encoded userid in header "of-user-id".
Server is not decoding the header so for some API, the call was failing. 