### PR TITLE
[CM-939] - Added support to set default conversation settings

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.kommunicate.callbacks.KmCallback;
+import io.kommunicate.preference.KmPreference;
 import io.kommunicate.users.KMUser;
 
 public class KmConversationBuilder extends JsonMarker {

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationBuilder.java
@@ -23,6 +23,7 @@ public class KmConversationBuilder extends JsonMarker {
     private List<String> agentIds;
     private List<String> botIds;
     private List<String> userIds;
+    private String defaultAssignee;
     private boolean skipConversationList = true;
     private String conversationId;
     private String fcmDeviceToken;
@@ -183,6 +184,14 @@ public class KmConversationBuilder extends JsonMarker {
     public KmConversationBuilder setConversationAssignee(String conversationAssignee) {
         this.conversationAssignee = conversationAssignee;
         return this;
+    }
+    public KmConversationBuilder setDefaultAssignee(String defaultAssignee) {
+        this.defaultAssignee = defaultAssignee;
+        return this;
+    }
+
+    public String getDefaultAssignee() {
+        return defaultAssignee;
     }
 
     public boolean isUseOriginalTitle() {

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -367,10 +367,13 @@ public class KmConversationHelper {
                 conversationBuilder.setAgentIds(new ArrayList<String>(defaultSettingPreference.getDefaultAgentIds()));
             }
             if(defaultSettingPreference.getDefaultAssignee() != null) {
-                conversationBuilder.setConversationAssignee(defaultSettingPreference.getDefaultAssignee());
+                conversationBuilder.setDefaultAssignee(defaultSettingPreference.getDefaultAssignee());
             }
             if(defaultSettingPreference.getDefaultTeamId() != null) {
                 conversationBuilder.setTeamId(defaultSettingPreference.getDefaultTeamId());
+            }
+            if(defaultSettingPreference.isSkipRouting()) {
+                conversationBuilder.skipConversationRoutingRules(true);
             }
             try {
                 startConversation(true, conversationBuilder,
@@ -652,6 +655,9 @@ public class KmConversationHelper {
         if (!TextUtils.isEmpty(conversationBuilder.getConversationAssignee())) {
             metadata.put(CONVERSATION_ASSIGNEE, conversationBuilder.getConversationAssignee());
             metadata.put(SKIP_ROUTING, "true");
+        }
+        if(!TextUtils.isEmpty(conversationBuilder.getDefaultAssignee())) {
+            metadata.put(CONVERSATION_ASSIGNEE, conversationBuilder.getDefaultAssignee());
         }
 
         if (conversationBuilder.isSkipConversationRoutingRules()) {

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -39,6 +39,7 @@ import io.kommunicate.callbacks.KmGetConversationInfoCallback;
 import io.kommunicate.callbacks.KmPrechatCallback;
 import io.kommunicate.callbacks.KmStartConversationHandler;
 import io.kommunicate.models.KmAppSettingModel;
+import io.kommunicate.preference.KmDefaultSettingPreference;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
@@ -358,6 +359,18 @@ public class KmConversationHelper {
     public static void launchConversationIfLoggedIn(Context context, KmCallback callback) {
         if (Kommunicate.isLoggedIn(context)) {
             KmConversationBuilder conversationBuilder = new KmConversationBuilder(context);
+            if(KmDefaultSettingPreference.getInstance().getDefaultBotIds() != null) {
+                conversationBuilder.setBotIds(new ArrayList<String>(KmDefaultSettingPreference.getInstance().getDefaultBotIds()));
+            }
+            if(KmDefaultSettingPreference.getInstance().getDefaultAgentIds() != null) {
+                conversationBuilder.setAgentIds(new ArrayList<String>(KmDefaultSettingPreference.getInstance().getDefaultAgentIds()));
+            }
+            if(KmDefaultSettingPreference.getInstance().getDefaultAssignee() != null) {
+                conversationBuilder.setConversationAssignee(KmDefaultSettingPreference.getInstance().getDefaultAssignee());
+            }
+            if(KmDefaultSettingPreference.getInstance().getDefaultTeamId() != null) {
+                conversationBuilder.setTeamId(KmDefaultSettingPreference.getInstance().getDefaultTeamId());
+            }
             try {
                 startConversation(true, conversationBuilder,
                         getStartConversationHandler(conversationBuilder.isSkipConversationList(), true, null, null, callback));

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -359,17 +359,18 @@ public class KmConversationHelper {
     public static void launchConversationIfLoggedIn(Context context, KmCallback callback) {
         if (Kommunicate.isLoggedIn(context)) {
             KmConversationBuilder conversationBuilder = new KmConversationBuilder(context);
-            if(KmDefaultSettingPreference.getInstance().getDefaultBotIds() != null) {
-                conversationBuilder.setBotIds(new ArrayList<String>(KmDefaultSettingPreference.getInstance().getDefaultBotIds()));
+            KmDefaultSettingPreference defaultSettingPreference = KmDefaultSettingPreference.getInstance();
+            if(defaultSettingPreference.getDefaultBotIds() != null) {
+                conversationBuilder.setBotIds(new ArrayList<String>(defaultSettingPreference.getDefaultBotIds()));
             }
-            if(KmDefaultSettingPreference.getInstance().getDefaultAgentIds() != null) {
-                conversationBuilder.setAgentIds(new ArrayList<String>(KmDefaultSettingPreference.getInstance().getDefaultAgentIds()));
+            if(defaultSettingPreference.getDefaultAgentIds() != null) {
+                conversationBuilder.setAgentIds(new ArrayList<String>(defaultSettingPreference.getDefaultAgentIds()));
             }
-            if(KmDefaultSettingPreference.getInstance().getDefaultAssignee() != null) {
-                conversationBuilder.setConversationAssignee(KmDefaultSettingPreference.getInstance().getDefaultAssignee());
+            if(defaultSettingPreference.getDefaultAssignee() != null) {
+                conversationBuilder.setConversationAssignee(defaultSettingPreference.getDefaultAssignee());
             }
-            if(KmDefaultSettingPreference.getInstance().getDefaultTeamId() != null) {
-                conversationBuilder.setTeamId(KmDefaultSettingPreference.getInstance().getDefaultTeamId());
+            if(defaultSettingPreference.getDefaultTeamId() != null) {
+                conversationBuilder.setTeamId(defaultSettingPreference.getDefaultTeamId());
             }
             try {
                 startConversation(true, conversationBuilder,

--- a/kommunicate/src/main/java/io/kommunicate/KmSettings.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmSettings.java
@@ -11,13 +11,18 @@ import com.applozic.mobicommons.json.GsonUtils;
 import com.applozic.mobicommons.people.channel.Channel;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.kommunicate.async.KmAssigneeUpdateTask;
 import io.kommunicate.async.KmConversationInfoTask;
 import io.kommunicate.async.KmUpdateConversationTask;
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.callbacks.KmGetConversationInfoCallback;
+import io.kommunicate.preference.KmDefaultSettingPreference;
+import io.kommunicate.utils.KmAppSettingPreferences;
 
 public class KmSettings {
 
@@ -189,5 +194,29 @@ public class KmSettings {
         channelMetadata.put(KM_CONVERSATION_METADATA, GsonUtils.getJsonFromObject(conversationMetadata, Map.class));
 
         return channelMetadata;
+    }
+
+    public static void setDefaultBotIds(List<String> botIds) {
+        Set<String> hashSet = new HashSet<String>(botIds);
+        hashSet.addAll(botIds);
+        KmDefaultSettingPreference.getInstance().setDefaultBotIds(hashSet);
+    }
+
+    public static void setDefaultAgentIds(List<String> agentIds) {
+        Set<String> hashSet = new HashSet<String>(agentIds);
+        hashSet.addAll(agentIds);
+        KmDefaultSettingPreference.getInstance().setDefaultAgentIds(hashSet);
+    }
+
+    public static void setDefaultAssignee(String assigneeId) {
+        KmDefaultSettingPreference.getInstance().setDefaultAssignee(assigneeId);
+    }
+
+    public static void setDefaultTeamId(String teamId) {
+        KmDefaultSettingPreference.getInstance().setDefaultTeamId(teamId);
+    }
+
+    public static void clearDefaultSettings() {
+        KmDefaultSettingPreference.getInstance().clearSettings();
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/KmSettings.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmSettings.java
@@ -216,6 +216,10 @@ public class KmSettings {
         KmDefaultSettingPreference.getInstance().setDefaultTeamId(teamId);
     }
 
+    public static void setSkipRouting(boolean isSkipRouting) {
+        KmDefaultSettingPreference.getInstance().setSkipRouting(isSkipRouting);
+    }
+
     public static void clearDefaultSettings() {
         KmDefaultSettingPreference.getInstance().clearSettings();
     }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -61,6 +61,7 @@ import io.kommunicate.callbacks.KmPushNotificationHandler;
 import io.kommunicate.database.KmDatabaseHelper;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.models.KmPrechatInputModel;
+import io.kommunicate.preference.KmPreference;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;

--- a/kommunicate/src/main/java/io/kommunicate/async/KMHelpDocsKeyTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KMHelpDocsKeyTask.java
@@ -8,7 +8,7 @@ import com.applozic.mobicommons.json.GsonUtils;
 
 import java.lang.ref.WeakReference;
 
-import io.kommunicate.KmPreference;
+import io.kommunicate.preference.KmPreference;
 import io.kommunicate.callbacks.KmFaqTaskListener;
 import io.kommunicate.models.KmHelpDocKey;
 import io.kommunicate.services.KmUserService;

--- a/kommunicate/src/main/java/io/kommunicate/async/KmGetBotTypeTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmGetBotTypeTask.java
@@ -11,7 +11,7 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import io.kommunicate.KmBotPreference;
+import io.kommunicate.preference.KmBotPreference;
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.models.MessageTypeKmApiResponse;
 import io.kommunicate.services.KmUserService;

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmBotPreference.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmBotPreference.java
@@ -1,4 +1,4 @@
-package io.kommunicate;
+package io.kommunicate.preference;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmDefaultSettingPreference.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmDefaultSettingPreference.java
@@ -1,0 +1,69 @@
+package io.kommunicate.preference;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.applozic.mobicommons.ApplozicService;
+import com.applozic.mobicommons.json.GsonUtils;
+
+import java.util.Set;
+
+import io.kommunicate.KmConversationBuilder;
+
+public class KmDefaultSettingPreference {
+
+    public static final String DEFAULT_BOT_IDS = "DEFAULT_BOT_IDS";
+    public static final String DEFAULT_AGENT_IDS = "DEFAULT_AGENT_IDS";
+    public static final String DEFAULT_ASSIGNEE = "DEFAULT_ASSIGNEE";
+    public static final String DEFAUT_TEAM = "DEFAUT_TEAM";
+    private static SharedPreferences preferences;
+    private static KmDefaultSettingPreference kmPreference;
+    private static final String KM_DEFAULT_SETTING_PREFERENCE = "KOMMUNICATE_SETTING_PREFS";
+
+    private KmDefaultSettingPreference() {
+        preferences = ApplozicService.getAppContext().getSharedPreferences(KM_DEFAULT_SETTING_PREFERENCE, Context.MODE_PRIVATE);
+    }
+
+
+    public static KmDefaultSettingPreference getInstance() {
+        if (kmPreference == null) {
+            kmPreference = new KmDefaultSettingPreference();
+        }
+        return kmPreference;
+    }
+
+    public void clearSettings() {
+        preferences.edit().clear().apply();
+    }
+
+    public void setDefaultBotIds(Set<String> defaultBotIds) {
+        preferences.edit().putStringSet(DEFAULT_BOT_IDS, defaultBotIds).apply();
+    }
+
+    public Set<String> getDefaultBotIds() {
+        return preferences.getStringSet(DEFAULT_BOT_IDS, null);
+    }
+    public void setDefaultAgentIds(Set<String> defaultAgentIdsIds) {
+        preferences.edit().putStringSet(DEFAULT_AGENT_IDS, defaultAgentIdsIds).apply();
+    }
+
+    public Set<String> getDefaultAgentIds() {
+        return preferences.getStringSet(DEFAULT_AGENT_IDS, null);
+    }
+
+    public void setDefaultAssignee(String assignee) {
+        preferences.edit().putString(DEFAULT_ASSIGNEE, assignee).apply();
+    }
+
+    public String getDefaultAssignee() {
+        return preferences.getString(DEFAULT_ASSIGNEE, null);
+    }
+
+    public void setDefaultTeamId(String teamId) {
+        preferences.edit().putString(DEFAUT_TEAM, teamId).apply();
+    }
+
+    public String getDefaultTeamId() {
+        return preferences.getString(DEFAUT_TEAM, null);
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmDefaultSettingPreference.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmDefaultSettingPreference.java
@@ -16,6 +16,7 @@ public class KmDefaultSettingPreference {
     public static final String DEFAULT_AGENT_IDS = "DEFAULT_AGENT_IDS";
     public static final String DEFAULT_ASSIGNEE = "DEFAULT_ASSIGNEE";
     public static final String DEFAUT_TEAM = "DEFAUT_TEAM";
+    public static final String SKIP_ROUTING = "SKIP_ROUTING";
     private static SharedPreferences preferences;
     private static KmDefaultSettingPreference kmPreference;
     private static final String KM_DEFAULT_SETTING_PREFERENCE = "KOMMUNICATE_SETTING_PREFS";
@@ -66,4 +67,10 @@ public class KmDefaultSettingPreference {
     public String getDefaultTeamId() {
         return preferences.getString(DEFAUT_TEAM, null);
     }
+
+    public void setSkipRouting(boolean isSkipRouting) {
+        preferences.edit().putBoolean(SKIP_ROUTING,  isSkipRouting).apply();
+    }
+
+    public boolean isSkipRouting() { return preferences.getBoolean(SKIP_ROUTING, false);}
 }

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmPreference.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmPreference.java
@@ -1,10 +1,11 @@
-package io.kommunicate;
+package io.kommunicate.preference;
 
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.applozic.mobicommons.json.GsonUtils;
 
+import io.kommunicate.KmConversationBuilder;
 /**
  * Created by ashish on 21/04/18.
  */

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -192,7 +192,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import de.hdodenhof.circleimageview.CircleImageView;
-import io.kommunicate.KmBotPreference;
+import io.kommunicate.preference.KmBotPreference;
 import io.kommunicate.KmSettings;
 import io.kommunicate.Kommunicate;
 import io.kommunicate.async.AgentGetStatusTask;


### PR DESCRIPTION
## What do you want to achieve?
- To create a default conversation setting, which can be used with "Start new conversation" button on the conversation list page.
- Added these methods:
```java
KmSettings.setDefaultBotIds(List<String> botIds) 
KmSettings.setDefaultAgentIds(List<String> agentIds)
KmSettings.setDefaultAssignee(String assigneeId)
KmSettings.setDefaultTeamId(String teamId)
KmSettings.clearDefaultSettings()
```
- Saves the settings to KmDefaultSettingPreference. To clear the default data, `KmSettings.clearDefaultSettings()` can be used.
- Also, modified existing preference for better code structure.

