### PR TITLE
[CM-961] Blank message if handover option is added

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -72,6 +72,9 @@ public class Message extends JsonMarker {
     public static final String LOCATION = "location";
     public static final String OTHER = "other";
     public static final String BOT_ASSIGN = "KM_ASSIGN";
+    public static final String KM_ASSIGN_TO = "KM_ASSIGN_TO";
+    public static final String KM_ASSIGN_TEAM = "KM_ASSIGN_TEAM";
+
     public static final String CONVERSATION_STATUS = "KM_STATUS";
     public static final String FEEDBACK_METADATA_KEY = "feedback";
     public static final String SKIP_BOT = "skipBot";
@@ -689,7 +692,7 @@ public class Message extends JsonMarker {
 
 
     public boolean isActionMessage() {
-        return getMetadata() != null && (getMetadata().containsKey(BOT_ASSIGN) || getMetadata().containsKey(CONVERSATION_STATUS));
+        return getMetadata() != null && (getMetadata().containsKey(BOT_ASSIGN) || getMetadata().containsKey(KM_ASSIGN_TO) || getMetadata().containsKey(KM_ASSIGN_TEAM) || getMetadata().containsKey(CONVERSATION_STATUS));
     }
 
     public boolean isFeedbackMessage() {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -74,7 +74,6 @@ public class Message extends JsonMarker {
     public static final String BOT_ASSIGN = "KM_ASSIGN";
     public static final String KM_ASSIGN_TO = "KM_ASSIGN_TO";
     public static final String KM_ASSIGN_TEAM = "KM_ASSIGN_TEAM";
-
     public static final String CONVERSATION_STATUS = "KM_STATUS";
     public static final String FEEDBACK_METADATA_KEY = "feedback";
     public static final String SKIP_BOT = "skipBot";

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComConversationService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComConversationService.java
@@ -245,7 +245,7 @@ public class MobiComConversationService {
                 if (message.getMetadata() != null && Message.GroupMessageMetaData.TRUE.getValue().equals(message.getMetadata().get(Message.GroupMessageMetaData.HIDE_KEY.getValue()))) {
                     continue;
                 }
-                if (isHideActionMessage && message.isActionMessage()) {
+                if ((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) {
                     message.setHidden(true);
                 }
                 messageList.add(message);
@@ -318,7 +318,7 @@ public class MobiComConversationService {
                 if (message.getMetadata() != null && Message.GroupMessageMetaData.TRUE.getValue().equals(message.getMetadata().get(Message.GroupMessageMetaData.HIDE_KEY.getValue()))) {
                     continue;
                 }
-                if (isHideActionMessage && message.isActionMessage()) {
+                if ((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) {
                     message.setHidden(true);
                 }
                 messageList.add(message);
@@ -439,7 +439,7 @@ public class MobiComConversationService {
                         continue;
                     }
 
-                    message.setHidden(isHideActionMessage && message.isActionMessage());
+                    message.setHidden((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage())));
 
                     if (messageDatabaseService.isMessagePresent(message.getKeyString(), Message.ReplyMessage.HIDE_MESSAGE.getValue())) {
                         messageDatabaseService.updateMessageReplyType(message.getKeyString(), Message.ReplyMessage.NON_HIDDEN.getValue());
@@ -627,7 +627,7 @@ public class MobiComConversationService {
                         continue;
                     }
 
-                    message.setHidden(isHideActionMessage && message.isActionMessage());
+                    message.setHidden((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage())));
 
                     if (messageDatabaseService.isMessagePresent(message.getKeyString(), Message.ReplyMessage.HIDE_MESSAGE.getValue())) {
                         messageDatabaseService.updateMessageReplyType(message.getKeyString(), Message.ReplyMessage.NON_HIDDEN.getValue());
@@ -797,7 +797,7 @@ public class MobiComConversationService {
                     if (Message.MetaDataType.HIDDEN.getValue().equals(message.getMetaDataValueForKey(Message.MetaDataType.KEY.getValue())) || Message.MetaDataType.PUSHNOTIFICATION.getValue().equals(message.getMetaDataValueForKey(Message.MetaDataType.KEY.getValue()))) {
                         continue;
                     }
-                    if (isHideActionMessage && message.isActionMessage()) {
+                    if ((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) {
                         message.setHidden(true);
                     }
                     if (messageDatabaseService.isMessagePresent(message.getKeyString(), Message.ReplyMessage.HIDE_MESSAGE.getValue())) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
@@ -183,7 +183,7 @@ public class MobiComMessageService {
         }
 
         //Hide action message for customer, show for agents
-        if (isHideActionMessage && message.isActionMessage()) {
+        if ((isHideActionMessage && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) {
             message.setHidden(true);
         }
 

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -593,7 +593,7 @@ public class MessageDatabaseService {
             values.put(MobiComDatabaseHelper.CONVERSATION_ID, message.getConversationId());
             values.put(MobiComDatabaseHelper.TOPIC_ID, message.getTopicId());
             values.put(MobiComDatabaseHelper.HIDDEN, message.hasHideKey());
-            boolean hidden = (hideActionMessages && message.isActionMessage()) || message.hasHideKey();
+            boolean hidden = ((hideActionMessages && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) || message.hasHideKey();
             values.put(MobiComDatabaseHelper.HIDDEN, hidden);
             if (message.getGroupId() != null) {
                 values.put(MobiComDatabaseHelper.CHANNEL_KEY, message.getGroupId());

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelClientService.java
@@ -33,7 +33,7 @@ public class ChannelClientService extends MobiComKitClientService {
     private static final String CHANNEL_INFO_URL = "/rest/ws/group/info";
     // private static final String CHANNEL_SYNC_URL = "/rest/ws/group/list";
     private static final String CHANNEL_SYNC_URL = "/rest/ws/group/v3/list";
-    private static final String CREATE_CHANNEL_URL = "/rest/ws/group/create";
+    private static final String CREATE_CHANNEL_URL = "/rest/ws/group/v2.1/create";
     private static final String CREATE_MULTIPLE_CHANNEL_URL = "/rest/ws/group/create/multiple";
     private static final String ADD_MEMBER_TO_CHANNEL_URL = "/rest/ws/group/add/member";
     private static final String REMOVE_MEMBER_FROM_CHANNEL_URL = "/rest/ws/group/remove/member";

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -46,7 +46,7 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
             message = (Message) GsonUtils.getObjectFromJson(messageJson, Message.class);
 
             if (message != null) {
-                if (hideActionMessages && message.isActionMessage()) {
+                if ((hideActionMessages && message.isActionMessage()) || (message.isActionMessage() && TextUtils.isEmpty(message.getMessage()))) {
                     message.setHidden(true);
                 }
             }


### PR DESCRIPTION
## Summary
- Empty Message is coming if handover option is added in welcome message.
<img width="385" alt="Screenshot 2022-06-15 at 5 01 54 PM" src="https://user-images.githubusercontent.com/61688116/174246415-3ea4a9c1-2d18-41a3-93b3-e63c32738007.jpeg">

## RootCause
- Extra message object is been added with only having metadata of `"KM_ASSIGN_TO" : "id"`.thatswhy empty message in showing on device side
- deviceside create new channel endpoint is older version when comparing to chat widget's

## Solution
- added `KM_ASSIGN_TO,KM_ASSIGN_TEAM` flags to Action Message category & removing messages.
- updated the create channel endpoint same as web chat widget

## Motivation
- Web chat widget following the same way of handling

## After fix

<img src = "https://user-images.githubusercontent.com/61688116/174246423-aaca038c-3d3f-475e-a834-e85a20b81009.jpeg" width = 250 height = 400 />
