### PR TITLE
[CM-1038] Crash Fix while calling getName() at KmDocumentView.java:352

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -350,7 +350,7 @@ public class KmDocumentView {
 
     public void playAudio() {
         final String mimeType;
-        if(message.getFileMetas() != null) {
+        if(message.getFileMetas() != null && message.getFileMetas().getName() != null) {
             mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
         }
         else {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -349,7 +349,13 @@ public class KmDocumentView {
     }
 
     public void playAudio() {
-        final String mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
+        final String mimeType;
+        if(message.getFileMetas() != null) {
+            mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
+        }
+        else {
+            mimeType = null;
+        }
         if (Utils.hasNougat()) {
             uri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
         } else {


### PR DESCRIPTION
Added a null check at KMDocumentView.java : 352 which removes the crashing