### PR TITLE
[CM-1036] Added a default last message body when last message of a conversation has an empty body

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -350,7 +350,7 @@ public class KmDocumentView {
 
     public void playAudio() {
         final String mimeType;
-        if(message.getFileMetas() != null) {
+        if(message.getFileMetas() != null && message.getFileMetas().getName() != null) {
             mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
         }
         else {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -349,7 +349,13 @@ public class KmDocumentView {
     }
 
     public void playAudio() {
-        final String mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
+        final String mimeType;
+        if(message.getFileMetas() != null) {
+            mimeType = FileUtils.getMimeType(message.getFileMetas().getName());
+        }
+        else {
+            mimeType = null;
+        }
         if (Utils.hasNougat()) {
             uri = FileProvider.getUriForFile(context, Utils.getMetaDataValue(context, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
         } else {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -12,6 +12,7 @@ import android.text.Html;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
+import android.util.Log;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -67,6 +68,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
     private static Map<Short, Integer> messageTypeColorMap = new HashMap<Short, Integer>();
     private static final String CONVERSATION_SOURCE = "source";
     private static final String SOURCE_FACEBOOK = "FACEBOOK";
+    private static final String DEFAULT_MSG_BODY = "Message";
 
     static {
         messageTypeColorMap.put(Message.MessageType.INBOX.getValue(), R.color.message_type_inbox);
@@ -249,6 +251,14 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                     myholder.messageTextView.setText(EmoticonUtils.getSmiledText(context, messageSubString, emojiconHandler));
                     showConversationSourceIcon(channel, myholder.attachmentIcon);
                 }
+
+                if(TextUtils.isEmpty(myholder.messageTextView.getText()))
+                {
+                    myholder.messageTextView.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_messageicon, 0, 0, 0);
+                    myholder.messageTextView.setCompoundDrawablePadding(20);
+                    myholder.messageTextView.setText(DEFAULT_MSG_BODY);
+                }
+                else myholder.messageTextView.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
 
                 if (myholder.sentOrReceived != null) {
                     if (message.isCall()) {

--- a/kommunicateui/src/main/res/drawable/ic_messageicon.xml
+++ b/kommunicateui/src/main/res/drawable/ic_messageicon.xml
@@ -1,0 +1,34 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="17dp"
+    android:height="17dp"
+    android:viewportWidth="23"
+    android:viewportHeight="22">
+  <path
+      android:pathData="M7.455,10m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:strokeAlpha="0.539"
+      android:fillColor="#000"
+      android:fillType="nonZero"
+      android:fillAlpha="0.539"/>
+  <path
+      android:pathData="M15.636,17h-1.045l-3.136,4 -3.137,-4L1.763,17C1.342,17 1,16.673 1,16.27L1,5.36a4.287,4.287 0,0 1,1.356 -3.091A4.69,4.69 0,0 1,5.6 0.999h15.546c0.421,0 0.763,0.328 0.763,0.731L21.909,17h-6.273z"
+      android:strokeAlpha="0.539"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#000"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.539"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11.455,10m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:strokeAlpha="0.539"
+      android:fillColor="#000"
+      android:fillType="nonZero"
+      android:fillAlpha="0.539"/>
+  <path
+      android:pathData="M15.455,10m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:strokeAlpha="0.539"
+      android:fillColor="#000"
+      android:fillType="nonZero"
+      android:fillAlpha="0.539"/>
+</vector>


### PR DESCRIPTION
Earlier ->

<img width="421" alt="Screenshot 2022-07-29 at 12 21 07 PM-20220729-065113 (1)" src="https://user-images.githubusercontent.com/90754518/182809488-90458048-f994-4ce2-ae77-40f0d54f7d34.png">

Now ->

![IMG_20220804_122528](https://user-images.githubusercontent.com/90754518/182803797-4ea8acee-4138-4400-945b-36ffb4ef23d3.jpg)

