### PR TITLE
[CM-1037] - fix for attachment not sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 
 ## [UnReleased]
 1) Fixed showing empty body for the rich message having no text
+2) Fix for attachment sending empty message
 
 ## Kommunicate Android SDK 2.4.3
 1) Add color customization for notification icon

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/attachment/FileClientService.java
@@ -250,17 +250,18 @@ public class FileClientService extends MobiComKitClientService {
         return null;
     }
 
-    public String uploadBlobImage(String path, Handler handler, String oldMessageKey) throws
-            UnsupportedEncodingException {
+    public String uploadBlobImage(String path, Handler handler, String oldMessageKey) throws Exception {
+        String uploadResponse = null;
         try {
-
             ApplozicMultipartUtility multipart = new ApplozicMultipartUtility(getUploadURL(), "UTF-8", context);
             multipart.addFilePart("file", new File(path), handler, oldMessageKey);
-            return multipart.getResponse();
+            uploadResponse = multipart.getResponse();
+           // return multipart.getResponse();
         } catch (Exception e) {
             e.printStackTrace();
+            throw e;
         }
-        return null;
+        return uploadResponse;
     }
 
     public String getUploadURL() {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
@@ -410,7 +410,7 @@ public class MessageClientService extends MobiComKitClientService {
             for (String filePath : message.getFilePaths()) {
                 try {
                     String fileMetaResponse = new FileClientService(context).uploadBlobImage(filePath, handler, oldMessageKey);
-                    if (fileMetaResponse == null) {
+                    if (TextUtils.isEmpty(fileMetaResponse)) {
                         if (skipMessage) {
                             return;
                         }
@@ -426,8 +426,7 @@ public class MessageClientService extends MobiComKitClientService {
                         }
                         BroadcastService.sendMessageUpdateBroadcast(context, BroadcastService.INTENT_ACTIONS.UPLOAD_ATTACHMENT_FAILED.toString(), message);
                         return;
-                    }
-                        if (!TextUtils.isEmpty(fileMetaResponse)) {
+                    } else if (!TextUtils.isEmpty(fileMetaResponse)) {
                             message.setFileMetas((FileMeta) GsonUtils.getObjectFromJson(fileMetaResponse, FileMeta.class));
                             if (handler != null) {
                                 android.os.Message msg = handler.obtainMessage();

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
@@ -426,16 +426,15 @@ public class MessageClientService extends MobiComKitClientService {
                         }
                         BroadcastService.sendMessageUpdateBroadcast(context, BroadcastService.INTENT_ACTIONS.UPLOAD_ATTACHMENT_FAILED.toString(), message);
                         return;
-                    } else if (!TextUtils.isEmpty(fileMetaResponse)) {
-                            message.setFileMetas((FileMeta) GsonUtils.getObjectFromJson(fileMetaResponse, FileMeta.class));
-                            if (handler != null) {
-                                android.os.Message msg = handler.obtainMessage();
-                                msg.what = MobiComConversationService.UPLOAD_COMPLETED;
-                                msg.getData().putString(MobiComKitConstants.OLD_MESSAGE_KEY_INTENT_EXTRA, oldMessageKey);
-                                msg.getData().putString("error", null);
-                                msg.sendToTarget();
-                            }
-                        }
+                    }
+                    message.setFileMetas((FileMeta) GsonUtils.getObjectFromJson(fileMetaResponse, FileMeta.class));
+                    if (handler != null) {
+                        android.os.Message msg = handler.obtainMessage();
+                        msg.what = MobiComConversationService.UPLOAD_COMPLETED;
+                        msg.getData().putString(MobiComKitConstants.OLD_MESSAGE_KEY_INTENT_EXTRA, oldMessageKey);
+                        msg.getData().putString("error", null);
+                        msg.sendToTarget();
+                    }
                 } catch (Exception ex) {
                     Utils.printLog(context, TAG, "Error uploading file to server: " + filePath);
                     if (handler != null) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
@@ -121,7 +121,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
                 message = (Message) GsonUtils.getObjectFromJson(messageJson, Message.class);
             }
 
-            if (message != null && message.getFilePaths() != null && !message.getFilePaths().isEmpty()) {
+            if (message != null && message.getFilePaths() != null && !message.getFilePaths().isEmpty() && message.getFileMetas() != null) {
                 try {
                     if(message.getFileMetas().getContentType().contains("gif")) {
                         Glide.with(this)

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1495,6 +1495,10 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         try {
             final String mimeType = FileUtils.getMimeType(smListItem.getFilePaths().get(0));
             if (mimeType != null) {
+                if(smListItem.getFileMetas() == null) {
+                    KmToast.error(context, "File not uploaded, please retry", Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 if (mimeType.startsWith("image")) {
                     Intent intent = new Intent(context, FullScreenImageActivity.class);
                     intent.putExtra(MobiComKitConstants.MESSAGE_JSON_INTENT, GsonUtils.getJsonFromObject(smListItem, Message.class));


### PR DESCRIPTION
## Issue:
- Happens only with slow internet: If you send multiple attachments at once, sometimes server gives 502 response code. This response code was not handled by device and message was being sent as empty message.
- Empty message in dashboard:
![image](https://user-images.githubusercontent.com/22256112/183392922-b0febe7e-677c-4d60-99a4-bd4295d4d10f.png)


## Fix:
- Exception will be caught when any other response comes, other than 200. This will be handled by showing retry option in attachment. When you click retry, attachments are sent.
- Retry option: 
![image](https://user-images.githubusercontent.com/22256112/183393305-1d4c55e2-07e5-405a-b3e3-0df44a4a72df.png)
