### PR TITLE
[CM-1005] - Sync deleted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 ## [UnReleased]
 1) Fixed showing empty body for the rich message having no text
 2) Fix for attachment sending empty message
+3) Sync Deleted Messages from dashboard
 
 ## Kommunicate Android SDK 2.4.3
 1) Add color customization for notification icon

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -652,7 +652,7 @@ public class Message extends JsonMarker {
 
     public boolean isConsideredForCount() {
         return (!Message.ContentType.HIDDEN.getValue().equals(getContentType()) &&
-                !ContentType.VIDEO_CALL_NOTIFICATION_MSG.getValue().equals(getContentType()) && !isReadStatus() && !hasHideKey());
+                !ContentType.VIDEO_CALL_NOTIFICATION_MSG.getValue().equals(getContentType()) && !isReadStatus() && !hasHideKey() && !isDeletedForAll());
     }
 
     public boolean hasHideKey() {
@@ -691,7 +691,7 @@ public class Message extends JsonMarker {
 
 
     public boolean isActionMessage() {
-        return getMetadata() != null && (getMetadata().containsKey(BOT_ASSIGN) || getMetadata().containsKey(KM_ASSIGN_TO) || getMetadata().containsKey(KM_ASSIGN_TEAM) || getMetadata().containsKey(CONVERSATION_STATUS));
+        return getMetadata() != null && (getMetadata().containsKey(BOT_ASSIGN) || getMetadata().containsKey(KM_ASSIGN_TO) || getMetadata().containsKey(KM_ASSIGN_TEAM) || getMetadata().containsKey(CONVERSATION_STATUS) || getMetadata().containsKey(AL_DELETE_MESSAGE_FOR_ALL_KEY));
     }
 
     public boolean isFeedbackMessage() {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.text.TextUtils;
-
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitConstants;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -322,6 +321,14 @@ public class MobiComMessageService {
             List<Message> messageList = syncMessageFeed.getMessages();
             for (final Message message : messageList) {
                 if (message != null) {
+                    if(message.isDeletedForAll()) {
+                        if(message.getGroupId() != null) {
+                            messageDatabaseService.decreaseChannelUnreadCount(message.getGroupId());
+                        }
+                        messageDatabaseService.deleteMessage(message, null);
+                        BroadcastService.sendMessageDeleteBroadcast(context, BroadcastService.INTENT_ACTIONS.DELETE_MESSAGE.toString(), message.getKeyString(), null, message);
+                        continue;
+                    }
                     messageDatabaseService.replaceExistingMessage(message);
                     BroadcastService.updateMessageMetadata(context, message.getKeyString(), BroadcastService.INTENT_ACTIONS.MESSAGE_METADATA_UPDATE.toString(), message.getGroupId() == null ? message.getTo() : null, message.getGroupId(), false, message.getMetadata());
                 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/SyncCallService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/SyncCallService.java
@@ -117,6 +117,17 @@ public class SyncCallService {
         }
     }
 
+    public synchronized void syncMessageMetadata() {
+        if (Utils.isDeviceInIdleState(context)) {
+            new ConversationRunnables(context, null, false, false, true);
+        } else {
+            Utils.printLog(context, TAG, "Syncing message metadata");
+            Intent intent = new Intent(context, ConversationIntentService.class);
+            intent.putExtra(ConversationIntentService.MESSAGE_METADATA_UPDATE, true);
+            ConversationIntentService.enqueueWork(context, intent);
+        }
+    }
+
     public synchronized void syncMessageMetadataUpdate(String key, boolean isFromFcm, Message message) {
         Integer groupId = null;
         if (message != null) {
@@ -194,8 +205,11 @@ public class SyncCallService {
         refreshView = true;
     }
 
-    public synchronized void deleteMessage(String messageKey) {
+    public synchronized void deleteMessage(String messageKey, Integer channelKey) {
         mobiComConversationService.deleteMessageFromDevice(messageKey, null);
+        if(channelKey != null) {
+            messageDatabaseService.decreaseChannelUnreadCount(channelKey);
+        }
         refreshView = true;
     }
 

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -1224,6 +1224,15 @@ public class MessageDatabaseService {
         }
     }
 
+    public synchronized void decreaseChannelUnreadCount(Integer channelKey) {
+        try {
+            SQLiteDatabase db = dbHelper.getWritableDatabase();
+            db.execSQL("UPDATE channel SET unreadCount = unreadCount - 1 WHERE channelKey =" + "'" + channelKey + "' AND unreadCount > 0");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public synchronized void updateChannelUnreadCountToZero(Integer channelKey) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/selfdestruct/DisappearingMessageTask.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/selfdestruct/DisappearingMessageTask.java
@@ -27,6 +27,6 @@ public class DisappearingMessageTask extends TimerTask {
         String smsKeyString = message.getKeyString();
         Log.i(TAG, "Self deleting message for keyString: " + smsKeyString);
         conversationService.deleteMessage(message);
-        BroadcastService.sendMessageDeleteBroadcast(context, BroadcastService.INTENT_ACTIONS.DELETE_MESSAGE.toString(), smsKeyString, message.getContactIds());
+        BroadcastService.sendMessageDeleteBroadcast(context, BroadcastService.INTENT_ACTIONS.DELETE_MESSAGE.toString(), smsKeyString, message.getContactIds(), message);
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/MobiComPushReceiver.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/MobiComPushReceiver.java
@@ -300,7 +300,7 @@ MobiComPushReceiver {
                 addPushNotificationId(deleteSingleMessageResponse.getId());
                 String deleteMessageKeyAndUserId = deleteSingleMessageResponse.getMessage().toString();
                 //String contactNumbers = deleteMessageKeyAndUserId.split(",").length > 1 ? deleteMessageKeyAndUserId.split(",")[1] : null;
-                syncCallService.deleteMessage(deleteMessageKeyAndUserId.split(",")[0]);
+                syncCallService.deleteMessage(deleteMessageKeyAndUserId.split(",")[0], null);
             }
 
             if (!TextUtils.isEmpty(messageSent)) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -117,7 +117,7 @@ public class BroadcastService {
         sendBroadcast(context, intentUpdate);
     }
 
-    public static void sendMessageDeleteBroadcast(Context context, String action, String keyString, String contactNumbers) {
+    public static void sendMessageDeleteBroadcast(Context context, String action, String keyString, String contactNumbers, Message message) {
         postEventData(context, new AlMessageEvent().setAction(AlMessageEvent.ActionType.MESSAGE_DELETED).setMessageKey(keyString).setUserId(contactNumbers));
 
         Utils.printLog(context, TAG, "Sending message delete broadcast for " + action);
@@ -125,6 +125,8 @@ public class BroadcastService {
         intentDelete.setAction(action);
         intentDelete.putExtra("keyString", keyString);
         intentDelete.putExtra("contactNumbers", contactNumbers);
+        intentDelete.putExtra(MobiComKitConstants.MESSAGE_JSON_INTENT, GsonUtils.getJsonFromObject(message, Message.class));
+
         intentDelete.addCategory(Intent.CATEGORY_DEFAULT);
         sendBroadcast(context, intentDelete);
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -463,10 +463,13 @@ public class ConversationUIService {
         }
     }
 
-    public void deleteMessage(String keyString, String userId) {
+    public void deleteMessage(String keyString, String userId, Message message) {
         updateLastMessage(keyString, userId);
         if (BroadcastService.isIndividual()) {
             getConversationFragment().deleteMessageFromDeviceList(keyString);
+        }
+        if(BroadcastService.isQuick()) {
+            getQuickConversationFragment().deleteMessage(message, userId);
         }
     }
 
@@ -630,7 +633,9 @@ public class ConversationUIService {
     }
 
     public void updateMessageMetadata(String keyString) {
-        getConversationFragment().updateMessageMetadata(keyString);
+        if(BroadcastService.isIndividual()) {
+            getConversationFragment().updateMessageMetadata(keyString);
+        }
     }
 
     public void muteUserChat(boolean mute, String userId) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -82,7 +82,7 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
             conversationUIService.syncMessages(message, keyString);
         } else if (BroadcastService.INTENT_ACTIONS.DELETE_MESSAGE.toString().equals(intent.getAction())) {
             userId = intent.getStringExtra("contactNumbers");
-            conversationUIService.deleteMessage(keyString, userId);
+            conversationUIService.deleteMessage(keyString, userId, message);
         } else if (BroadcastService.INTENT_ACTIONS.MESSAGE_DELIVERY.toString().equals(action) ||
                 BroadcastService.INTENT_ACTIONS.MESSAGE_READ_AND_DELIVERED.toString().equals(action)) {
             conversationUIService.updateDeliveryStatus(message, userId);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -276,6 +276,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
     protected void syncMessages() {
         SyncCallService.getInstance(this).syncMessages(null);
+        SyncCallService.getInstance(this).syncMessageMetadata();
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1494,6 +1494,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (i != -1) {
             messageList.get(i).setMetadata(messageDatabaseService.getMessage(keyString).getMetadata());
             if (conversationAdapter != null) {
+                if(messageList.get(i).isDeletedForAll()) {
+                    messageList.remove(i);
+                }
                 conversationAdapter.notifyDataSetChanged();
             }
             if (messageList.get(messageList.size() - 1).getMetadata().containsKey("isDoneWithClicking")) {


### PR DESCRIPTION
## Issue:
- Messages which are deleted from dashboard were not handled by SDK.

## What do you want to achieve?
- Getting deleted message event from MQTT and API: `/rest/ws/message/sync/metadataUpdate`
- Deleting message from database and updating the UI 
- Decreasing the unread count whenever a message is deleted

https://user-images.githubusercontent.com/22256112/184812967-ac1f02ba-c5c1-4159-8af9-dc8c945b4e61.mp4


