### PR TITLE
[CM-1063] - Upgrade channel list API to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 1) Fixed showing empty body for the rich message having no text
 2) Fix for attachment sending empty message
 3) Sync Deleted Messages from dashboard
+4) Optimized Group list API
 
 ## Kommunicate Android SDK 2.4.3
 1) Add color customization for notification icon

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelClientService.java
@@ -32,7 +32,7 @@ import java.util.Set;
 public class ChannelClientService extends MobiComKitClientService {
     private static final String CHANNEL_INFO_URL = "/rest/ws/group/info";
     // private static final String CHANNEL_SYNC_URL = "/rest/ws/group/list";
-    private static final String CHANNEL_SYNC_URL = "/rest/ws/group/v3/list";
+    private static final String CHANNEL_SYNC_URL = "/rest/ws/group/v5/list";
     private static final String CREATE_CHANNEL_URL = "/rest/ws/group/v2.1/create";
     private static final String CREATE_MULTIPLE_CHANNEL_URL = "/rest/ws/group/create/multiple";
     private static final String ADD_MEMBER_TO_CHANNEL_URL = "/rest/ws/group/add/member";

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/sync/SyncChannelFeed.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/sync/SyncChannelFeed.java
@@ -2,6 +2,7 @@ package com.applozic.mobicomkit.sync;
 
 import com.applozic.mobicommons.json.JsonMarker;
 import com.applozic.mobicomkit.feed.ChannelFeed;
+import com.applozic.mobicommons.people.channel.Channel;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ public class SyncChannelFeed extends JsonMarker {
     private static final String SUCCESS = "success";
     private String status;
     private String generatedAt;
-    private List<ChannelFeed> response;
+    private groupPxys response;
     private String updatedAt;
 
     public String getStatus() {
@@ -34,10 +35,10 @@ public class SyncChannelFeed extends JsonMarker {
     }
 
     public List<ChannelFeed> getResponse() {
-        return response;
+        return response.getGroupPxys();
     }
 
-    public void setResponse(List<ChannelFeed> response) {
+    public void setResponse(groupPxys response) {
         this.response = response;
     }
 
@@ -61,5 +62,13 @@ public class SyncChannelFeed extends JsonMarker {
                 ", response=" + response +
                 ", updatedAt='" + updatedAt + '\'' +
                 '}';
+    }
+
+    public class groupPxys extends JsonMarker {
+        private List<ChannelFeed> groupPxys;
+
+        public List<ChannelFeed> getGroupPxys() {
+            return groupPxys;
+        }
     }
 }


### PR DESCRIPTION
List v3 API provides a lot of unnecessary data which are not required, because of which we are getting outOfMemoryError. 

To fix this, upgrade the list api to v5.

Schema is same, only difference is that v5 API does not give group member details for every group