### PR TITLE
Channel sync crash fix

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
@@ -29,6 +29,7 @@ import com.applozic.mobicomkit.feed.GroupInfoUpdate;
 import com.applozic.mobicomkit.listners.AlChannelListener;
 import com.applozic.mobicomkit.sync.SyncChannelFeed;
 import com.applozic.mobicommons.ApplozicService;
+import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.people.channel.Channel;
 import com.applozic.mobicommons.people.channel.ChannelUserMapper;
 import com.applozic.mobicommons.task.AlTask;
@@ -243,20 +244,23 @@ public class ChannelService {
     }
 
     public synchronized void syncChannels(boolean isMetadataUpdate) {
-        final MobiComUserPreference userpref = MobiComUserPreference.getInstance(context);
-        SyncChannelFeed syncChannelFeed = channelClientService.getChannelFeed(userpref
-                .getChannelSyncTime());
-        if (syncChannelFeed == null || syncChannelFeed.getResponse() == null) {
-            return;
-        }
-        if (syncChannelFeed.isSuccess()) {
-            processChannelList(syncChannelFeed.getResponse());
+        try {
+            final MobiComUserPreference userpref = MobiComUserPreference.getInstance(context);
+            SyncChannelFeed syncChannelFeed = channelClientService.getChannelFeed(userpref
+                    .getChannelSyncTime());
+            if (syncChannelFeed == null || syncChannelFeed.getResponse() == null) {
+                return;
+            }
+            if (syncChannelFeed.isSuccess()) {
+                processChannelList(syncChannelFeed.getResponse());
 
-            BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService
-                    .INTENT_ACTIONS.CHANNEL_SYNC.toString());
+                BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService
+                        .INTENT_ACTIONS.CHANNEL_SYNC.toString());
+            }
+            userpref.setChannelSyncTime(syncChannelFeed.getGeneratedAt());
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        userpref.setChannelSyncTime(syncChannelFeed.getGeneratedAt());
-
     }
 
     public synchronized void syncChannels() {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
@@ -248,10 +248,10 @@ public class ChannelService {
             final MobiComUserPreference userpref = MobiComUserPreference.getInstance(context);
             SyncChannelFeed syncChannelFeed = channelClientService.getChannelFeed(userpref
                     .getChannelSyncTime());
-            if (syncChannelFeed == null || syncChannelFeed.getResponse() == null) {
+            if (syncChannelFeed == null || !syncChannelFeed.isSuccess()) {
                 return;
             }
-            if (syncChannelFeed.isSuccess()) {
+            if (syncChannelFeed.getResponse() != null) {
                 processChannelList(syncChannelFeed.getResponse());
 
                 BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/channel/service/ChannelService.java
@@ -257,7 +257,9 @@ public class ChannelService {
                 BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService
                         .INTENT_ACTIONS.CHANNEL_SYNC.toString());
             }
-            userpref.setChannelSyncTime(syncChannelFeed.getGeneratedAt());
+            if(!TextUtils.isEmpty(syncChannelFeed.getGeneratedAt())) {
+                userpref.setChannelSyncTime(syncChannelFeed.getGeneratedAt());
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/sync/SyncChannelFeed.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/sync/SyncChannelFeed.java
@@ -35,7 +35,10 @@ public class SyncChannelFeed extends JsonMarker {
     }
 
     public List<ChannelFeed> getResponse() {
-        return response.getGroupPxys();
+        if(response != null) {
+            return response.getGroupPxys();
+        }
+        return null;
     }
 
     public void setResponse(groupPxys response) {


### PR DESCRIPTION
- Crash was happening when groupPxy was returned as null from server. 
- To fix, added a null check as well as try catch block