### PR TITLE
[CM-1111] - fix for invalid agent/bot name

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3009,9 +3009,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
 
         StringBuilder titleBuilder = new StringBuilder();
-        if (contact != null) {
-            titleBuilder.append(contact.getDisplayName());
-        } else if (channel != null) {
+        if (channel != null) {
             if (Channel.GroupType.GROUPOFTWO.getValue().equals(channel.getType())) {
                 String userId = ChannelService.getInstance(getActivity()).getGroupOfTwoReceiverUserId(channel.getKey());
                 if (!TextUtils.isEmpty(userId)) {
@@ -3026,6 +3024,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             } else {
                 titleBuilder.append(ChannelUtils.getChannelTitleName(channel, loggedInUserId));
             }
+        } else if (contact != null) {
+            titleBuilder.append(contact.getDisplayName());
         }
         if (getActivity() != null) {
             setToolbarTitle(titleBuilder.toString());


### PR DESCRIPTION
## Issue: 
Toolbar was showing invalid name 

## Reason: 
The last message fetched was of Agent, but the conversation assignee was a bot. It was giving priority to the last message sent's contact rather than the assignee.

## Fix: 
Changed the priority of fetching name for toolbar. First, it would check for Channel Assignee. if that is null, then it would check for contact's name.

## Issue reproduced video:
https://user-images.githubusercontent.com/22256112/190099720-04e177d4-7671-4158-b21d-20d66df3a16f.mp4

