### PR TITLE
[CM-1072] - Replace execSQL and rawQuery with .query and .update

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/ConversationDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/ConversationDatabaseService.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
 
 import com.applozic.mobicomkit.database.MobiComDatabaseHelper;
@@ -180,15 +181,13 @@ public class ConversationDatabaseService {
 
     public boolean isConversationPresent(Integer conversationId) {
         SQLiteDatabase database = dbHelper.getWritableDatabase();
-        Cursor cursor = database.rawQuery(
-                "SELECT COUNT(*) FROM conversation WHERE key=?", new String[]{String.valueOf(conversationId)});
-        boolean present = false;
-        if (cursor.moveToFirst()) {
-            present = cursor.getInt(0) > 0;
-            cursor.close();
-        }
+        String sql = "SELECT COUNT(*) FROM conversation WHERE key = ?";
+        SQLiteStatement statement = database.compileStatement(sql);
+        statement.bindString(1, String.valueOf(conversationId));
+        long records = statement.simpleQueryForLong();
+
         dbHelper.close();
-        return present;
+        return records > 0;
     }
 
     public void updateConversation(Conversation conversation) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -1209,16 +1209,24 @@ public class MessageDatabaseService {
     public void updateContactUnreadCount(String userId) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
-            db.execSQL("UPDATE contact SET unreadCount = unreadCount + 1 WHERE userId =" + "'" + userId + "'");
+            int unreadCount = getUnreadMessageCountForContact(userId);
+            ContentValues values = new ContentValues();
+            values.put("unreadCount", unreadCount + 1);
+            db.update("contact", values, "userId = " + userId, null);
+            //db.execSQL("UPDATE contact SET unreadCount = unreadCount + 1 WHERE userId =" + "'" + userId + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public void updateChannelUnreadCount(Integer channelKey) {
+    public synchronized void updateChannelUnreadCount(Integer channelKey) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
-            db.execSQL("UPDATE channel SET unreadCount = unreadCount + 1 WHERE channelKey =" + "'" + channelKey + "'");
+            int unreadCount = getUnreadMessageCountForChannel(channelKey);
+            ContentValues values = new ContentValues();
+            values.put("unreadCount", unreadCount + 1);
+            db.update("channel", values, "channelKey = " + channelKey, null);
+            //db.execSQL("UPDATE channel SET unreadCount = unreadCount + 1 WHERE channelKey =" + "'" + channelKey + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1227,7 +1235,11 @@ public class MessageDatabaseService {
     public void decreaseChannelUnreadCount(Integer channelKey) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
-            db.execSQL("UPDATE channel SET unreadCount = unreadCount - 1 WHERE channelKey =" + "'" + channelKey + "' AND unreadCount > 0");
+            int unreadCount = getUnreadMessageCountForChannel(channelKey);
+            ContentValues values = new ContentValues();
+            values.put("unreadCount", unreadCount - 1);
+            db.update("channel", values, "channelKey =\" + \"'\" + channelKey + \"' AND unreadCount > 0\"", null);
+            //db.execSQL("UPDATE channel SET unreadCount = unreadCount - 1 WHERE channelKey =" + "'" + channelKey + "' AND unreadCount > 0");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1236,21 +1248,27 @@ public class MessageDatabaseService {
     public void updateChannelUnreadCountToZero(Integer channelKey) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
-            db.execSQL("UPDATE channel SET unreadCount = 0 WHERE channelKey =" + "'" + channelKey + "'");
+            ContentValues values = new ContentValues();
+            values.put("unreadCount", 0);
+            db.update("channel", values, "channelKey = " + channelKey, null);
+            //db.execSQL("UPDATE channel SET unreadCount = 0 WHERE channelKey =" + "'" + channelKey + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public void replaceExistingMessage(Message message) {
+    public synchronized void replaceExistingMessage(Message message) {
         deleteMessageFromDb(message);
         createMessage(message);
     }
 
-    public void updateContactUnreadCountToZero(String userId) {
+    public synchronized void updateContactUnreadCountToZero(String userId) {
         try {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
-            db.execSQL("UPDATE contact SET unreadCount = 0 WHERE userId =" + "'" + userId + "'");
+            ContentValues values = new ContentValues();
+            values.put("unreadCount", 0);
+            db.update("contact", values, "userId = " + userId, null);
+            //db.execSQL("UPDATE contact SET unreadCount = 0 WHERE userId =" + "'" + userId + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -856,7 +856,7 @@ public class MessageDatabaseService {
         }
         List<Message> messages = new ArrayList<Message>();
         SQLiteDatabase db = dbHelper.getReadableDatabase();
-        Cursor cursor = db.query("sms", null, clauseString, null, null, "createdAt desc", "1");
+        Cursor cursor = db.query("sms", null, clauseString, null, null, null, "createdAt desc", "1");
         try {
             if (cursor.moveToFirst()) {
                 messages = MessageDatabaseService.getMessageList(cursor);
@@ -1205,7 +1205,7 @@ public class MessageDatabaseService {
             int unreadCount = getUnreadMessageCountForContact(userId);
             ContentValues values = new ContentValues();
             values.put("unreadCount", unreadCount + 1);
-            db.update("contact", values, "userId = " + userId, null);
+            db.update("contact", values, "userId = ?", new String[]{userId});
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1217,7 +1217,7 @@ public class MessageDatabaseService {
             int unreadCount = getUnreadMessageCountForChannel(channelKey);
             ContentValues values = new ContentValues();
             values.put("unreadCount", unreadCount + 1);
-            db.update("channel", values, "channelKey = " + channelKey, null);
+            db.update("channel", values, "channelKey = ?", new String[]{String.valueOf(channelKey)});
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -289,7 +289,7 @@ public class MessageDatabaseService {
             return null;
         }
         try {
-            Cursor cursor = dbHelper.getReadableDatabase().query("sms", null, "channelKey = ? and metadata like % ? % ", new String[]{String.valueOf(channelKey), Message.CONVERSATION_STATUS}, null, null, "createdAt DESC", "1");
+            Cursor cursor = dbHelper.getReadableDatabase().query("sms", null, "channelKey = ? and metadata like ?", new String[]{String.valueOf(channelKey), "%" + Message.CONVERSATION_STATUS + "%"}, null, null, "createdAt DESC", "1");
             if (cursor.getCount() > 0) {
                 cursor.moveToFirst();
                 return getMessage(cursor);

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -1206,7 +1206,6 @@ public class MessageDatabaseService {
             ContentValues values = new ContentValues();
             values.put("unreadCount", unreadCount + 1);
             db.update("contact", values, "userId = " + userId, null);
-            //db.execSQL("UPDATE contact SET unreadCount = unreadCount + 1 WHERE userId =" + "'" + userId + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1219,7 +1218,6 @@ public class MessageDatabaseService {
             ContentValues values = new ContentValues();
             values.put("unreadCount", unreadCount + 1);
             db.update("channel", values, "channelKey = " + channelKey, null);
-            //db.execSQL("UPDATE channel SET unreadCount = unreadCount + 1 WHERE channelKey =" + "'" + channelKey + "'");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1231,8 +1229,7 @@ public class MessageDatabaseService {
             int unreadCount = getUnreadMessageCountForChannel(channelKey);
             ContentValues values = new ContentValues();
             values.put("unreadCount", unreadCount - 1);
-            db.update("channel", values, "channelKey =\" + \"'\" + channelKey + \"' AND unreadCount > 0\"", null);
-            //db.execSQL("UPDATE channel SET unreadCount = unreadCount - 1 WHERE channelKey =" + "'" + channelKey + "' AND unreadCount > 0");
+            db.update("channel", values, "channelKey = ? AND unreadCount > 0", new String[]{String.valueOf(channelKey)});
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1243,8 +1240,7 @@ public class MessageDatabaseService {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
             ContentValues values = new ContentValues();
             values.put("unreadCount", 0);
-            db.update("channel", values, "channelKey = " + channelKey, null);
-            //db.execSQL("UPDATE channel SET unreadCount = 0 WHERE channelKey =" + "'" + channelKey + "'");
+            db.update("channel", values, "channelKey = ?", new String[]{String.valueOf(channelKey)});
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1260,8 +1256,7 @@ public class MessageDatabaseService {
             SQLiteDatabase db = dbHelper.getWritableDatabase();
             ContentValues values = new ContentValues();
             values.put("unreadCount", 0);
-            db.update("contact", values, "userId = " + userId, null);
-            //db.execSQL("UPDATE contact SET unreadCount = 0 WHERE userId =" + "'" + userId + "'");
+            db.update("contact", values, "userId = ?", new String[]{userId});
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/contact/database/ContactDatabase.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/contact/database/ContactDatabase.java
@@ -4,6 +4,7 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
 
 import androidx.loader.content.CursorLoader;
@@ -365,15 +366,12 @@ public class ContactDatabase {
         Cursor cursor = null;
         try {
             SQLiteDatabase database = dbHelper.getReadableDatabase();
-            cursor = database.rawQuery(
-                    "SELECT COUNT(*) FROM contact WHERE userId = ?",
-                    new String[]{userId});
-            cursor.moveToFirst();
-            return cursor.getInt(0) > 0;
+
+            String sql = "SELECT COUNT(*) FROM contact WHERE userId = ?";
+            SQLiteStatement sqLiteStatement = database.compileStatement(sql);
+            sqLiteStatement.bindString(1, userId);
+            return sqLiteStatement.simpleQueryForLong() > 0;
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
             dbHelper.close();
         }
     }
@@ -410,19 +408,12 @@ public class ContactDatabase {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
-            cursor = db.rawQuery("SELECT COUNT(DISTINCT (userId)) FROM contact WHERE unreadCount > 0 ", null);
-            cursor.moveToFirst();
-            int chatCount = 0;
-            if (cursor.getCount() > 0) {
-                chatCount = cursor.getInt(0);
-            }
-            return chatCount;
+            String sql = "SELECT COUNT(DISTINCT (userId)) FROM contact WHERE unreadCount > 0 ";
+            SQLiteStatement sqLiteStatement = db.compileStatement(sql);
+            return (int) sqLiteStatement.simpleQueryForLong();
         } catch (Exception ex) {
             ex.printStackTrace();
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
             dbHelper.close();
         }
         return 0;
@@ -432,13 +423,9 @@ public class ContactDatabase {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
-            cursor = db.rawQuery("SELECT COUNT(DISTINCT (channelKey)) FROM channel WHERE unreadCount > 0 ", null);
-            cursor.moveToFirst();
-            int groupCount = 0;
-            if (cursor.getCount() > 0) {
-                groupCount = cursor.getInt(0);
-            }
-            return groupCount;
+            String sql = "SELECT COUNT(DISTINCT (channelKey)) FROM channel WHERE unreadCount > 0 ";
+            SQLiteStatement sqLiteStatement = db.compileStatement(sql);
+            return (int) sqLiteStatement.simpleQueryForLong();
         } catch (Exception ex) {
             ex.printStackTrace();
         } finally {

--- a/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/DBUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/DBUtils.java
@@ -13,7 +13,8 @@ public class DBUtils {
     private static final String TAG = "DBUtils";
 
     public static boolean isTableExists(SQLiteDatabase database, String tableName) {
-        Cursor cursor = database.rawQuery("select DISTINCT tbl_name from sqlite_master where tbl_name = '" + tableName + "'", null);
+        Cursor cursor = database.query(true, "sqlite_master", new String[]{"tbl_name"}, "tbl_name = ?", new String[]{String.valueOf(tableName)}, null, null, null, null);
+
         if (cursor != null) {
             if (cursor.getCount() > 0) {
                 cursor.close();
@@ -28,8 +29,7 @@ public class DBUtils {
         Cursor mCursor = null;
         try {
             //query 1 row
-            mCursor = inDatabase.rawQuery("SELECT * FROM " + inTable + " LIMIT 0", null);
-
+            mCursor = inDatabase.query(inTable, null, "LIMIT 0", null, null, null, null);
             //getColumnIndex gives us the index (0 to ...) of the column - otherwise we get a -1
             return mCursor.getColumnIndex(columnToCheck) != -1;
         } catch (Exception exp) {

--- a/kommunicate/src/main/java/io/kommunicate/services/KmChannelService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmChannelService.java
@@ -34,9 +34,7 @@ public class KmChannelService {
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
 
-            String query = "select * from " + CHANNEL_USER_X + " where channelKey = " + String.valueOf(channelKey) + " and role = " + String.valueOf(3);
-
-            Cursor cursor = db.rawQuery(query, null);
+            Cursor cursor = db.query(CHANNEL_USER_X, null, "channelKey = ? and role = ?", new String[]{String.valueOf(channelKey), String.valueOf(3)}, null, null, null);
             List<ChannelUserMapper> channelUserMappers = getListOfUsers(cursor);
 
             cursor.close();
@@ -57,8 +55,8 @@ public class KmChannelService {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
-            String query = "select * from " + CHANNEL_USER_X + " where channelKey = " + String.valueOf(channelKey) + " and role = " + String.valueOf(role);
-            cursor = db.rawQuery(query, null);
+            cursor = db.query(CHANNEL_USER_X, null, "channelKey = ? and role = ?", new String[]{String.valueOf(channelKey), String.valueOf(3)}, null, null, null);
+
             return getListOfUserIds(cursor);
         } catch (Exception e) {
             e.printStackTrace();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -792,13 +792,11 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
                         public void run() {
                             final Channel clickedChannel = ChannelService.getInstance(ConversationActivity.this).getChannelByChannelKey(message.getGroupId());
                             clickedChannel.setGroupUsers(ChannelService.getInstance(ConversationActivity.this).getListOfUsersFromChannelUserMapper(clickedChannel.getKey()));
-                            final Contact clickedContact = new ContactDatabase(ConversationActivity.this).getContactById(channel == null ? message.getContactIds() : null);
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
                                     channel = clickedChannel;
-                                    contact = clickedContact;
-                                    conversation = ConversationUIService.getConversationFragment(ConversationActivity.this, contact, channel, conversationId, searchString, null, null);
+                                    conversation = ConversationUIService.getConversationFragment(ConversationActivity.this, null, channel, conversationId, searchString, null, null);
                                     addFragment(ConversationActivity.this, conversation, ConversationUIService.CONVERSATION_FRAGMENT);
                                 }
                             });


### PR DESCRIPTION
## Issue:
- execSQL and rawQuery methods are vulnerable to SQL Injection. For customers who require good security, this needs to be updated.
- Concatenated queries with values are vulnerable to SQL Injection. For example:  `db.rawQuery("SELECT unreadCount FROM contact WHERE userId = " + "'" + userId + "'", null);` should be updated to `db.query("contact", new String[]{"unreadCount"}, "userId = ?", new String[]{userId}, null, null, null);`

## Fix: 
Changed the above methods to .update and .query which uses Arguments[] as values, rather than concatenating the query with values. These arguments are sanitized by Android SDK to prevent SQL injection.

## How is the code tested?
- Created a method to update/query methods which were changed and compared using old and new value.
### Old data:
```
2022-09-14 15:09:48.860 12780-30859/io.kommunicate.app E/DBisConversationPresent: false
2022-09-14 15:09:48.861 12780-30859/io.kommunicate.app E/DBupdateCOntactUnread: 0
2022-09-14 15:09:48.861 12780-30859/io.kommunicate.app E/DBupdateCOntactUnread: 1
2022-09-14 15:09:48.863 12780-30859/io.kommunicate.app E/DBUpdateChannelUnread: 0
2022-09-14 15:09:48.864 12780-30859/io.kommunicate.app E/DBUpdateChannelUnread: 1
2022-09-14 15:09:48.865 12780-30859/io.kommunicate.app E/DBUpdateTotalUnread: 17
2022-09-14 15:09:48.866 12780-30859/io.kommunicate.app E/DBQueryLatestMessage: Message{createdAtTime=1660904722751, to='aman', message='Status changed to Open', key='5-76014771-1660904722748', deviceKey='null', userKey='null', emailIds='null', shared=false, sent=false, delivered=true, type=5, storeOnDevice=false, contactIds='aman', groupId=76014771, sendToDevice=false, scheduledAt=null, source=1, timeToLive=null, sentToServer=true, fileMetaKey='null', filePaths=null, pairedMessageKey='null', sentMessageTimeAtServer=0, canceled=false, clientGroupId='76014771', fileMeta=null, messageId=78, read=true, attDownloadInProgress=false, applicationId='null', conversationId=null, topicId='null', connected=false, contentType=10, metadata={LOCALIZATION_KEY=STATUS_TO_OPEN, NO_ALERT=false, skipBot=true, KM_STATUS=open, category=ARCHIVE, BADGE_COUNT=false}, status=5, hidden=true, replyMessage=0}
2022-09-14 15:09:48.867 12780-30859/io.kommunicate.app E/DBQueryLatestMessageforChannel: [Message{createdAtTime=1662982750044, to='aman.toppo@kommunicate.io', message='https://stackoverflow.com/questions/15874117/how-to-set-delay-in-android', key='5-76014771-1662982750016', deviceKey='null', userKey='null', emailIds='null', shared=false, sent=false, delivered=false, type=4, storeOnDevice=false, contactIds='aman.toppo@kommunicate.io', groupId=76014771, sendToDevice=false, scheduledAt=null, source=1, timeToLive=null, sentToServer=true, fileMetaKey='null', filePaths=null, pairedMessageKey='null', sentMessageTimeAtServer=0, canceled=false, clientGroupId='76014771', fileMeta=null, messageId=227, read=true, attDownloadInProgress=false, applicationId='null', conversationId=null, topicId='null', connected=false, contentType=0, metadata={skipBot=true}, status=1, hidden=false, replyMessage=0}]

```

### New data:
```
2022-09-14 15:35:14.526 31261-6893/io.kommunicate.app E/DBisConversationPresent: false
2022-09-14 15:35:14.526 31261-6893/io.kommunicate.app E/DBupdateCOntactUnread: 0
2022-09-14 15:35:14.532 31261-6893/io.kommunicate.app E/DBupdateCOntactUnread: 1
2022-09-14 15:35:14.533 31261-6893/io.kommunicate.app E/DBUpdateChannelUnread: 0
2022-09-14 15:35:14.534 31261-6893/io.kommunicate.app E/DBUpdateChannelUnread: 1
2022-09-14 15:35:14.535 31261-6893/io.kommunicate.app E/DBUpdateTotalUnread: 17
2022-09-14 15:35:14.536 31261-6893/io.kommunicate.app E/DBQueryLatestMessage: Message{createdAtTime=1660904722751, to='aman', message='Status changed to Open', key='5-76014771-1660904722748', deviceKey='null', userKey='null', emailIds='null', shared=false, sent=false, delivered=true, type=5, storeOnDevice=false, contactIds='aman', groupId=76014771, sendToDevice=false, scheduledAt=null, source=1, timeToLive=null, sentToServer=true, fileMetaKey='null', filePaths=null, pairedMessageKey='null', sentMessageTimeAtServer=0, canceled=false, clientGroupId='76014771', fileMeta=null, messageId=78, read=true, attDownloadInProgress=false, applicationId='null', conversationId=null, topicId='null', connected=false, contentType=10, metadata={LOCALIZATION_KEY=STATUS_TO_OPEN, NO_ALERT=false, skipBot=true, KM_STATUS=open, category=ARCHIVE, BADGE_COUNT=false}, status=5, hidden=true, replyMessage=0}
2022-09-14 15:35:14.537 31261-6893/io.kommunicate.app E/DBQueryLatestMessageforChannel: [Message{createdAtTime=1663148736426, to='aman.toppo@kommunicate.io', message='hey', key='5-76014771-1663148736421', deviceKey='null', userKey='null', emailIds='null', shared=false, sent=false, delivered=true, type=4, storeOnDevice=false, contactIds='aman.toppo@kommunicate.io', groupId=76014771, sendToDevice=false, scheduledAt=null, source=1, timeToLive=null, sentToServer=true, fileMetaKey='null', filePaths=null, pairedMessageKey='null', sentMessageTimeAtServer=0, canceled=false, clientGroupId='76014771', fileMeta=null, messageId=310, read=true, attDownloadInProgress=false, applicationId='null', conversationId=null, topicId='null', connected=false, contentType=0, metadata={skipBot=true}, status=1, hidden=false, replyMessage=0}]
```
- More queries will be tested by QA