### PR TITLE
[CM-1139] - Remove Permissions from SDK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,29 @@
         android:name="io.kommunicate.app.permission.MAPS_RECEIVE"
         android:protectionLevel="signature" />
 
+
+
+        <!--Permissions to be used when using these features-->
+        <uses-permission
+            android:name="android.permission.CAMERA"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+            tools:ignore="ScopedStorage"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.READ_EXTERNAL_STORAGE"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.RECORD_AUDIO"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.ACCESS_COARSE_LOCATION"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.ACCESS_FINE_LOCATION"
+            tools:node="merge" />
+
     <application
         android:name="kommunicate.io.sample.KommunicateApplication"
         android:allowBackup="true"

--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -2,31 +2,11 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="io.kommunicate">
 
-    <!--Permissions to be used when using these features-->
-    <uses-permission
-        android:name="android.permission.CAMERA"
-        tools:node="merge" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        tools:ignore="ScopedStorage"
-        tools:node="merge" />
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        tools:node="merge" />
-    <uses-permission
-        android:name="android.permission.RECORD_AUDIO"
-        tools:node="merge" />
-
     <!--Mandatory permissions-->
     <uses-permission
         android:name="android.permission.VIBRATE"
         tools:node="merge" />
-    <uses-permission
-        android:name="android.permission.ACCESS_COARSE_LOCATION"
-        tools:node="merge" />
-    <uses-permission
-        android:name="android.permission.ACCESS_FINE_LOCATION"
-        tools:node="merge" />
+
     <uses-permission
         android:name="android.permission.INTERNET"
         tools:node="merge" />

--- a/kommunicate/src/main/AndroidManifest.xml
+++ b/kommunicate/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:name="android.permission.RECEIVE_BOOT_COMPLETED"
         tools:node="merge" />
 
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmAudioRecordManager.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmAudioRecordManager.java
@@ -87,11 +87,7 @@ public class KmAudioRecordManager implements MediaRecorder.OnInfoListener, Media
                 createRecordingThread();
                 recordingThread.start();
             } else {
-                if (ActivityCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
-                        != PackageManager.PERMISSION_GRANTED) {
-                    ActivityCompat.requestPermissions(context, new String[]{Manifest.permission.RECORD_AUDIO},
-                            10);
-                }
+                PermissionsUtils.requestPermissions(context, PermissionsUtils.PERMISSIONS_RECORD_AUDIO, PermissionsUtils.REQUEST_AUDIO_RECORD);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
@@ -26,6 +26,7 @@ import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.animators.KmAnimationHelper;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.animators.OnBasketAnimationEndListener;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmOnRecordListener;
+import com.applozic.mobicommons.commons.core.utils.PermissionsUtils;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 
 import java.io.IOException;
@@ -183,6 +184,9 @@ public class KmRecordView extends FrameLayout {
     protected void onActionDown(KmRecordButton recordBtn) {
         if (recordListener != null) {
             recordListener.onRecordStart();
+        }
+        if(!PermissionsUtils.isAudioRecordingPermissionGranted(context)) {
+            return;
         }
 
         animationHelper.setStartRecorded(true);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmRecordView.java
@@ -209,7 +209,7 @@ public class KmRecordView extends FrameLayout {
     }
 
     protected void onActionMove(KmRecordButton recordBtn, MotionEvent motionEvent) {
-        if (isSpeechToTextEnabled) {
+        if (isSpeechToTextEnabled  || !PermissionsUtils.isAudioRecordingPermissionGranted(context)) {
             return;
         }
         long time = System.currentTimeMillis() - startTime;
@@ -297,7 +297,7 @@ public class KmRecordView extends FrameLayout {
     }
 
     protected void onActionUp(KmRecordButton recordBtn) {
-        if (isSpeechToTextEnabled) {
+        if (isSpeechToTextEnabled  || !PermissionsUtils.isAudioRecordingPermissionGranted(context)) {
             return;
         }
 

--- a/migration/Migrate to 2.5.0.md
+++ b/migration/Migrate to 2.5.0.md
@@ -4,25 +4,32 @@
 - Add these to your AndroidManifest.xml:
 
 - For Camera:
+```xml
 <uses-permission
             android:name="android.permission.CAMERA"
             tools:node="merge" />
+```
 
 - For Audio:
+```xml
 <uses-permission
             android:name="android.permission.RECORD_AUDIO"
             tools:node="merge" />
+```
             
 
 - For Location:
+```xml
  <uses-permission
             android:name="android.permission.ACCESS_COARSE_LOCATION"
             tools:node="merge" />
         <uses-permission
             android:name="android.permission.ACCESS_FINE_LOCATION"
             tools:node="merge" />
+```
 
 - For accessing gallery/storage:
+```xml
 <uses-permission
             android:name="android.permission.WRITE_EXTERNAL_STORAGE"
             tools:ignore="ScopedStorage"
@@ -30,3 +37,4 @@
         <uses-permission
             android:name="android.permission.READ_EXTERNAL_STORAGE"
             tools:node="merge" />
+```

--- a/migration/Migrate to 2.5.0.md
+++ b/migration/Migrate to 2.5.0.md
@@ -1,0 +1,32 @@
+## Migrating to 2.5.0
+
+- We have removed permissions permissions from our SDK. Now if you do not require Camera permissions in your chat app, then it will not show up in Permissions Required.
+- Add these to your AndroidManifest.xml:
+
+- For Camera:
+<uses-permission
+            android:name="android.permission.CAMERA"
+            tools:node="merge" />
+
+- For Audio:
+<uses-permission
+            android:name="android.permission.RECORD_AUDIO"
+            tools:node="merge" />
+            
+
+- For Location:
+ <uses-permission
+            android:name="android.permission.ACCESS_COARSE_LOCATION"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.ACCESS_FINE_LOCATION"
+            tools:node="merge" />
+
+- For accessing gallery/storage:
+<uses-permission
+            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+            tools:ignore="ScopedStorage"
+            tools:node="merge" />
+        <uses-permission
+            android:name="android.permission.READ_EXTERNAL_STORAGE"
+            tools:node="merge" />

--- a/migration/Migrate to 2.5.0.md
+++ b/migration/Migrate to 2.5.0.md
@@ -1,6 +1,6 @@
 ## Migrating to 2.5.0
 
-- We have removed permissions permissions from our SDK. Now if you do not require Camera permissions in your chat app, then it will not show up in Permissions Required.
+- We have removed permissions from our SDK. Now if you do not require Camera, Audio, Location and Storage permissions in your chat app, then it will not show up in Permissions Required.
 - Add these to your AndroidManifest.xml:
 
 - For Camera:


### PR DESCRIPTION
## Issue:
- We had permissions for Camera, Microphone, Location and External Storage in SDK. Due to this, even if a customer who does not require these feature, would show these permissions in Google Play as well as App Settings.

## Fix
- Removed these permissions from SDK and  moved them to Project level
- Written a migration documentation