### PR TITLE
[CM-1146] Updated the api key for sample app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,8 +35,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyAv1wf5eMyErPaU3l8EnMUmOsoYJ2joC70" />
-
+            android:value="AIzaSyDHQzh-cDfo-aY9_Q1fZFiZtaurg57eY7k" />
 
         <service
             android:name="kommunicate.io.sample.pushnotification.FcmListenerService"


### PR DESCRIPTION
## Summary
- This Sample app is using old api key & it was causing issue in location preview

## Note
- It won't affect anything in sdk side. We are not setting any default google api key for sdk. This configuration needs to be done from client side. Doc: https://docs.kommunicate.io/docs/reactnative-customization#hidingshowing-media-attachment-and-location-sharing-options

## Before Fix:

<img src ="https://user-images.githubusercontent.com/61688116/194503797-bfc82946-9f51-493f-859c-0c9f222d03ee.jpg" width = 250 height = 400/>

## After Fix:
<img src ="https://user-images.githubusercontent.com/61688116/194503782-91884890-bfc5-40b8-b152-c09e1a4da15d.jpg" width = 250 height = 400/>
