### PR TITLE
[CM-1161] - Added support for storage permissions in API 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+### [UnReleased]
+1) Added support for API 33
 
 ## Kommunicate Android SDK 2.4.8
 1) Typing Indicator Design Changes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "io.kommunicate.app"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="29"
+        android:maxSdkVersion="32"
         tools:ignore="ScopedStorage"
         tools:node="merge" />
     <uses-permission

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,13 +14,22 @@
         <uses-permission
             android:name="android.permission.CAMERA"
             tools:node="merge" />
-        <uses-permission
-            android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-            tools:ignore="ScopedStorage"
-            tools:node="merge" />
-        <uses-permission
-            android:name="android.permission.READ_EXTERNAL_STORAGE"
-            tools:node="merge" />
+
+    <!--Storage Permission required for API >= 33 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
+    
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"
+        tools:ignore="ScopedStorage"
+        tools:node="merge" />
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"
+        tools:node="merge" />
         <uses-permission
             android:name="android.permission.RECORD_AUDIO"
             tools:node="merge" />

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -8,7 +8,7 @@ rootProject.allprojects {
     }
 }
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         abortOnError false
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "2.4.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
@@ -4,6 +4,9 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -21,11 +24,18 @@ public class PermissionsUtils {
     public static final int REQUEST_STORAGE_FOR_PROFILE_PHOTO = 8;
     public static final int REQUEST_CAMERA_AUDIO = 9;
     public static String[] PERMISSIONS_LOCATION = {Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION};
-    public static String[] PERMISSIONS_STORAGE = {Manifest.permission.WRITE_EXTERNAL_STORAGE,
-            Manifest.permission.READ_EXTERNAL_STORAGE};
+    public static String[] PERMISSIONS_STORAGE = getStoragePermission();
     public static String[] PERMISSIONS_RECORD_AUDIO = {Manifest.permission.RECORD_AUDIO};
     public static String[] PERMISSION_CAMERA = {Manifest.permission.CAMERA};
 
+
+    private static String[] getStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO};
+        } else {
+            return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        }
+    }
     public static boolean verifyPermissions(int[] grantResults) {
         if (grantResults.length < 1) {
             return false;
@@ -53,10 +63,19 @@ public class PermissionsUtils {
 
 
     public static boolean shouldShowRequestForStoragePermission(Activity activity) {
-        return (ActivityCompat.shouldShowRequestPermissionRationale(activity,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                || ActivityCompat.shouldShowRequestPermissionRationale(activity,
-                Manifest.permission.READ_EXTERNAL_STORAGE));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_MEDIA_IMAGES)
+                    || ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_MEDIA_VIDEO)
+                     || ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_MEDIA_AUDIO));
+        } else {
+            return (ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    || ActivityCompat.shouldShowRequestPermissionRationale(activity,
+                    Manifest.permission.READ_EXTERNAL_STORAGE));
+        }
     }
 
     public static boolean shouldShowRequestForCameraPermission(Activity activity) {
@@ -65,10 +84,21 @@ public class PermissionsUtils {
     }
 
     public static boolean checkSelfForStoragePermission(Activity activity) {
-        return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED
-                || ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
+                    != PackageManager.PERMISSION_GRANTED)
+                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_VIDEO)
+                    != PackageManager.PERMISSION_GRANTED)
+                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_AUDIO)
+                    != PackageManager.PERMISSION_GRANTED);
+        }
+        else {
+            return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                    != PackageManager.PERMISSION_GRANTED
+                    || ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+                    != PackageManager.PERMISSION_GRANTED);
+        }
+
     }
 
 

--- a/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
@@ -5,8 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
-
-import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -98,9 +96,7 @@ public class PermissionsUtils {
                     || ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
                     != PackageManager.PERMISSION_GRANTED);
         }
-
     }
-
 
     public static boolean checkSelfPermissionForLocation(Activity activity) {
         return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -8,7 +8,7 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     buildToolsVersion '28.0.3'
 
     lintOptions {
@@ -16,7 +16,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "2.4.8"
         consumerProguardFiles 'proguard-rules.txt'


### PR DESCRIPTION
## Issue
<html>
<body>
<!--StartFragment--><p style="box-sizing: inherit; margin: 16px 0px; padding: 0px; color: rgb(32, 33, 36); font-family: Roboto, &quot;Noto Sans&quot;, &quot;Noto Sans JP&quot;, &quot;Noto Sans KR&quot;, &quot;Noto Naskh Arabic&quot;, &quot;Noto Sans Thai&quot;, &quot;Noto Sans Hebrew&quot;, &quot;Noto Sans Bengali&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">If your app targets Android 13 or higher and needs to<span> </span><a href="https://developer.android.com/training/data-storage/shared/media#storage-permission" style="box-sizing: inherit; color: var(--devsite-link-color); outline: 0px; text-decoration: var(--devsite-link-text-decoration,none); word-break: break-word;">access media files that other apps have created</a>, you must request one or more of the following granular media permissions instead of the<span> </span><a href="https://developer.android.com/reference/android/Manifest.permission#READ_EXTERNAL_STORAGE" style="box-sizing: inherit; color: var(--devsite-link-color); outline: 0px; text-decoration: var(--devsite-link-text-decoration,none); word-break: break-word;"><code translate="no" dir="ltr" style="box-sizing: inherit; background: var(--devsite-code-background); color: var(--devsite-contrast-link-color); font: 500 90%/1 var(--devsite-code-font-family); padding: var(--devsite-inline-code-padding,1px 4px); direction: ltr !important; text-align: left !important; border: var(--devsite-inline-code-border,0); border-radius: var(--devsite-inline-code-border-radius,0); word-break: break-word;">READ_EXTERNAL_STORAGE</code></a><span> </span>permission:</p><div class="devsite-table-wrapper" style="box-sizing: inherit; margin: var(--devsite-table-margin,16px 0); padding: 0px; overflow: auto; color: rgb(32, 33, 36); font-family: Roboto, &quot;Noto Sans&quot;, &quot;Noto Sans JP&quot;, &quot;Noto Sans KR&quot;, &quot;Noto Naskh Arabic&quot;, &quot;Noto Sans Thai&quot;, &quot;Noto Sans Hebrew&quot;, &quot;Noto Sans Bengali&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Type of media | Permission to request
-- | --
Images and photos | READ_MEDIA_IMAGES
Videos | READ_MEDIA_VIDEO
Audio files | READ_MEDIA_AUDIO

</div><!--EndFragment-->
</body>
</html>


## Fix:
- Separated permissions required for API 33 

Customers need to add this to their Manifest:

```xml
 <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />

    
    <uses-permission
        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
        android:maxSdkVersion="29"
        tools:ignore="ScopedStorage"
        tools:node="merge" />
    <uses-permission
        android:name="android.permission.READ_EXTERNAL_STORAGE"
        android:maxSdkVersion="32"
        tools:node="merge" />
```






