### PR TITLE
[CM-994]- Fix Serialized Class crash - Message.java

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 
 public class Message extends JsonMarker {
 
+    private static final long serialVersionUID = 1990184800447349902L;
     private Long createdAtTime = new Date().getTime();
     private String to;
     private String message;


### PR DESCRIPTION
From the Serializable interface's [docs](http://docs.oracle.com/javase/7/docs/api/java/io/Serializable.html):

`If a serializable class does not explicitly declare a serialVersionUID, then the serialization runtime will calculate a default serialVersionUID value for that class based on various aspects of the class, as described in the Java(TM) Object Serialization Specification. However, it is strongly recommended that all serializable classes explicitly declare serialVersionUID values, since the default serialVersionUID computation is highly sensitive to class details that may vary depending on compiler implementations, and can thus result in unexpected InvalidClassExceptions during deserialization. Therefore, to guarantee a consistent serialVersionUID value across different java compiler implementations, a serializable class must declare an explicit serialVersionUID value. It is also strongly advised that explicit serialVersionUID declarations use the private modifier where possible, since such declarations apply only to the immediately declaring class--serialVersionUID fields are not useful as inherited members. Array classes cannot declare an explicit serialVersionUID, so they always have the default computed value, but the requirement for matching serialVersionUID values is waived for array classes.`