### PR TITLE
[CM-1190 - Zendesk base integration

### DIFF
--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -5,6 +5,8 @@ rootProject.allprojects {
         maven {
             url 'https://kommunicate.jfrog.io/artifactory/kommunicate-android-sdk'
         }
+        maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
+
     }
 }
 android {
@@ -38,6 +40,8 @@ dependencies {
     api 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     api 'androidx.appcompat:appcompat:1.2.0'
     api 'com.google.code.gson:gson:2.8.6'
+    implementation group: 'com.zendesk', name: 'chat-providers', version: '3.3.0'
+
 }
 
 /*task sourcesJar(type: Jar) {

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -6,7 +6,6 @@ rootProject.allprojects {
             url 'https://kommunicate.jfrog.io/artifactory/kommunicate-android-sdk'
         }
         maven { url 'https://zendesk.jfrog.io/zendesk/repo' }
-
     }
 }
 android {
@@ -41,7 +40,6 @@ dependencies {
     api 'androidx.appcompat:appcompat:1.2.0'
     api 'com.google.code.gson:gson:2.8.6'
     implementation group: 'com.zendesk', name: 'chat-providers', version: '3.3.0'
-
 }
 
 /*task sourcesJar(type: Jar) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserLogoutTask.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserLogoutTask.java
@@ -7,6 +7,8 @@ import com.applozic.mobicommons.task.AlAsyncTask;
 
 import java.lang.ref.WeakReference;
 
+import io.kommunicate.services.KmZendeskClient;
+
 public class UserLogoutTask extends AlAsyncTask<Void, Boolean> {
 
     private TaskListener taskListener;
@@ -51,6 +53,7 @@ public class UserLogoutTask extends AlAsyncTask<Void, Boolean> {
         if (logoutHandler != null) {
             if (result) {
                 logoutHandler.onSuccess(context.get());
+                KmZendeskClient.getInstance(context.get()).endZendeskChat();
             } else {
                 logoutHandler.onFailure(mException);
             }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserLogoutTask.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/account/user/UserLogoutTask.java
@@ -7,7 +7,7 @@ import com.applozic.mobicommons.task.AlAsyncTask;
 
 import java.lang.ref.WeakReference;
 
-import io.kommunicate.services.KmZendeskClient;
+import io.kommunicate.zendesk.KmZendeskClient;
 
 public class UserLogoutTask extends AlAsyncTask<Void, Boolean> {
 

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageClientService.java
@@ -35,12 +35,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import io.kommunicate.zendesk.KmZendeskClient;
 
 
 /**
@@ -410,6 +413,9 @@ public class MessageClientService extends MobiComKitClientService {
             for (String filePath : message.getFilePaths()) {
                 try {
                     String fileMetaResponse = new FileClientService(context).uploadBlobImage(filePath, handler, oldMessageKey);
+
+                    //Send attachment to Zendesk as well
+                    KmZendeskClient.getInstance(context).sendZendeskAttachment(filePath);
                     if (TextUtils.isEmpty(fileMetaResponse)) {
                         if (skipMessage) {
                             return;

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -41,6 +41,7 @@ import io.kommunicate.callbacks.KmStartConversationHandler;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.preference.KmDefaultSettingPreference;
 import io.kommunicate.users.KMUser;
+import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
 
@@ -393,6 +394,15 @@ public class KmConversationHelper {
                 callback.onFailure(Utils.getString(null, R.string.km_conversation_builder_cannot_be_null));
             }
             return;
+        }
+        if(KmAppSettingPreferences.getInstance().getZendeskSdkKey() != null) {
+            if (conversationBuilder.getConversationInfo() != null) {
+                conversationBuilder.getConversationInfo().put(KmConstants.CONVERSATION_SOURCE, KmConstants.ZOPIM);
+            } else {
+                Map<String, String> sourceMap = new HashMap<>();
+                sourceMap.put(KmConstants.CONVERSATION_SOURCE, KmConstants.ZOPIM);
+                conversationBuilder.setConversationInfo(sourceMap);
+            }
         }
 
         if (conversationBuilder.getContext() == null) {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -61,6 +61,7 @@ import io.kommunicate.database.KmDatabaseHelper;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.models.KmPrechatInputModel;
 import io.kommunicate.preference.KmPreference;
+import io.kommunicate.services.KmZendeskClient;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
@@ -882,4 +883,55 @@ public class Kommunicate {
     public static void removeApplicationKey(Context context) {
         new SecureSharedPreferences(AlPrefSettings.AL_PREF_SETTING_KEY, ApplozicService.getContext(context)).edit().remove("APPLICATION_KEY").commit();
     }
+
+    public static void openZendeskChat(final Context context){
+        final KmZendeskClient kmZendeskClient = KmZendeskClient.getInstance(context);
+        kmZendeskClient.isChatGoingOn(new KmZendeskClient.ChatStatus() {
+            @Override
+            public void onChatGoingOn() {
+                final Integer conversationId = kmZendeskClient.getGroupId();
+                new KmConversationBuilder(context)
+                        .setSingleConversation(true)
+                        .setConversationId(String.valueOf(conversationId))
+                        .launchConversation(new KmCallback() {
+                            @Override
+                            public void onSuccess(Object message) {
+                                Utils.printLog(context, TAG, "Successfully launched Zendesk conversation Id:" + conversationId);
+                            }
+
+                            @Override
+                            public void onFailure(Object error) {
+                                Utils.printLog(context, TAG, "Failed to launch Zendesk conversation : " + error.toString());
+
+                            }
+                        });
+            }
+
+            @Override
+            public void onChatFinished() {
+               new KmConversationBuilder(context)
+                       .setSingleConversation(true)
+                       .setSkipConversationList(true)
+                       .launchConversation(new KmCallback() {
+                           @Override
+                           public void onSuccess(Object message) {
+                               Utils.printLog(context, TAG, "Successfully launched conversation : " + message.toString());
+
+                           }
+
+                           @Override
+                           public void onFailure(Object error) {
+                               Utils.printLog(context, TAG, "Failed to launch conversation : " + error.toString());
+
+                           }
+                       });
+            }
+
+            @Override
+            public void onChatError(String errorMessage) {
+
+            }
+        });
+    }
+
 }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -61,7 +61,7 @@ import io.kommunicate.database.KmDatabaseHelper;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.models.KmPrechatInputModel;
 import io.kommunicate.preference.KmPreference;
-import io.kommunicate.services.KmZendeskClient;
+import io.kommunicate.zendesk.KmZendeskClient;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
@@ -886,51 +886,7 @@ public class Kommunicate {
     }
 
     public static void openZendeskChat(final Context context) {
-        final KmZendeskClient kmZendeskClient = KmZendeskClient.getInstance(context);
-        kmZendeskClient.isChatGoingOn(new KmZendeskClient.ChatStatus() {
-            @Override
-            public void onChatGoingOn() {
-                final Integer conversationId = kmZendeskClient.getChannelKey();
-                new KmConversationBuilder(context)
-                        .setSingleConversation(true)
-                        .setConversationId(String.valueOf(conversationId))
-                        .launchConversation(new KmCallback() {
-                            @Override
-                            public void onSuccess(Object message) {
-                                Utils.printLog(context, TAG, "Successfully launched Zendesk conversation Id:" + conversationId);
-                            }
-
-                            @Override
-                            public void onFailure(Object error) {
-                                Utils.printLog(context, TAG, "Failed to launch Zendesk conversation : " + error.toString());
-                            }
-                        });
-            }
-
-            @Override
-            public void onChatFinished() {
-                new KmConversationBuilder(context)
-                        .setSingleConversation(true)
-                        .setSkipConversationList(true)
-                        .launchConversation(new KmCallback() {
-                            @Override
-                            public void onSuccess(Object message) {
-                                Utils.printLog(context, TAG, "Successfully launched conversation : " + message.toString());
-                            }
-
-                            @Override
-                            public void onFailure(Object error) {
-                                Utils.printLog(context, TAG, "Failed to launch conversation : " + error.toString());
-                            }
-                        });
-            }
-
-            @Override
-            public void onChatError(String errorMessage) {
-                Utils.printLog(context, TAG, "Failed to launch conversation : " + errorMessage);
-
-            }
-        });
+        KmZendeskClient kmZendeskClient = KmZendeskClient.getInstance(context);
+        kmZendeskClient.openZendeskChat();
     }
-
 }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -817,6 +817,7 @@ public class Kommunicate {
                             }
                         }
                     }
+
                     @Override
                     public void onFailure(Object error) {
 
@@ -884,12 +885,12 @@ public class Kommunicate {
         new SecureSharedPreferences(AlPrefSettings.AL_PREF_SETTING_KEY, ApplozicService.getContext(context)).edit().remove("APPLICATION_KEY").commit();
     }
 
-    public static void openZendeskChat(final Context context){
+    public static void openZendeskChat(final Context context) {
         final KmZendeskClient kmZendeskClient = KmZendeskClient.getInstance(context);
         kmZendeskClient.isChatGoingOn(new KmZendeskClient.ChatStatus() {
             @Override
             public void onChatGoingOn() {
-                final Integer conversationId = kmZendeskClient.getGroupId();
+                final Integer conversationId = kmZendeskClient.getChannelKey();
                 new KmConversationBuilder(context)
                         .setSingleConversation(true)
                         .setConversationId(String.valueOf(conversationId))
@@ -902,33 +903,31 @@ public class Kommunicate {
                             @Override
                             public void onFailure(Object error) {
                                 Utils.printLog(context, TAG, "Failed to launch Zendesk conversation : " + error.toString());
-
                             }
                         });
             }
 
             @Override
             public void onChatFinished() {
-               new KmConversationBuilder(context)
-                       .setSingleConversation(true)
-                       .setSkipConversationList(true)
-                       .launchConversation(new KmCallback() {
-                           @Override
-                           public void onSuccess(Object message) {
-                               Utils.printLog(context, TAG, "Successfully launched conversation : " + message.toString());
+                new KmConversationBuilder(context)
+                        .setSingleConversation(true)
+                        .setSkipConversationList(true)
+                        .launchConversation(new KmCallback() {
+                            @Override
+                            public void onSuccess(Object message) {
+                                Utils.printLog(context, TAG, "Successfully launched conversation : " + message.toString());
+                            }
 
-                           }
-
-                           @Override
-                           public void onFailure(Object error) {
-                               Utils.printLog(context, TAG, "Failed to launch conversation : " + error.toString());
-
-                           }
-                       });
+                            @Override
+                            public void onFailure(Object error) {
+                                Utils.printLog(context, TAG, "Failed to launch conversation : " + error.toString());
+                            }
+                        });
             }
 
             @Override
             public void onChatError(String errorMessage) {
+                Utils.printLog(context, TAG, "Failed to launch conversation : " + errorMessage);
 
             }
         });

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -130,6 +130,7 @@ public class KmAppSettingModel extends JsonMarker {
         private long sessionTimeout;
         private int botMessageDelayInterval;
         private boolean pseudonymsEnabled;
+        private String zendeskChatSdkKey;
 
         public String getPosition() {
             return position;
@@ -157,9 +158,9 @@ public class KmAppSettingModel extends JsonMarker {
             this.position = position;
         }
 
-
-
-
+        public String getZendeskChatSdkKey() {
+            return zendeskChatSdkKey;
+        }
 
         @SerializedName("isSingleThreaded")
         private boolean singleThreaded;

--- a/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
@@ -55,6 +55,7 @@ public class KmZendeskClient {
     }
 
     public void initializeZendesk(String accountKey, Integer channelKey, Contact contact, Channel channel ) {
+        Utils.printLog(context, TAG, "zendesk initialized");
         Chat.INSTANCE.init(context, accountKey);
         isZendeskInitialized = true;
         groupId = channelKey;
@@ -90,12 +91,12 @@ public class KmZendeskClient {
         Chat.INSTANCE.providers().profileProvider().setVisitorInfo(visitorInfo, new ZendeskCallback<Void>() {
             @Override
             public void onSuccess(Void unused) {
-                Log.e(TAG, "loginsuccess");
+                Utils.printLog(context, TAG, "loginsuccess");
             }
 
             @Override
             public void onError(ErrorResponse errorResponse) {
-                Log.e(TAG, "loginfailed");
+                Utils.printLog(context, TAG, "loginfailed");
             }
         });
     }
@@ -104,13 +105,13 @@ public class KmZendeskClient {
         Chat.INSTANCE.providers().chatProvider().observeChatState(observationScope, new Observer<ChatState>() {
             @Override
             public void update(ChatState chatState) {
-                Log.e(TAG, String.valueOf(chatState));
+                Utils.printLog(context, TAG, String.valueOf(chatState));
             }
         });
     }
 
     public void sendZendeskMessage(String message) {
-        Log.e(TAG, "sent message");
+        Utils.printLog(context, TAG, "sent message");
         Chat.INSTANCE.providers().chatProvider().sendMessage(message);
     }
 
@@ -156,12 +157,12 @@ public class KmZendeskClient {
         }).start();
 
 
-           // Log.e(TAG, String.valueOf(messageList));
+           // Utils.printLog(context, TAG, String.valueOf(messageList));
 
     }
 
     public String getMessageForTranscript(Message message) {
-        Log.e(TAG, "SENDING TRANSXEIPR");
+        Utils.printLog(context, TAG, "SENDING TRANSXEIPR");
         if(!TextUtils.isEmpty(message.getMessage())) {
             return message.getMessage();
         }

--- a/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
@@ -41,7 +41,6 @@ public class KmZendeskClient {
     private static String TAG = "KmZendeskClient";
     private static KmZendeskClient kmZendeskClient;
     private Integer channelKey;
-    private ProfileProvider profileProvider;
     private boolean isZendeskConnected;
     private boolean isZendeskInitialized;
     private Contact contact;
@@ -63,7 +62,7 @@ public class KmZendeskClient {
 
     //Initialize Zendesk with Zendesk Chat SDK Key
     public void initializeZendesk(String accountKey, Integer channelKey, Contact contact, Channel channel ) {
-        Utils.printLog(context, TAG, "zendesk initialized");
+        Utils.printLog(context, TAG, "Zendesk Initialized with account key : " + accountKey);
         this.contact = contact;
         this.channel = channel;
         this.channelKey = channelKey;
@@ -123,7 +122,7 @@ public class KmZendeskClient {
     }
 
     public void sendZendeskMessage(String message) {
-        Utils.printLog(context, TAG, "sent message");
+        Utils.printLog(context, TAG, "Sent Zendesk Message" + message);
         Chat.INSTANCE.providers().chatProvider().sendMessage(message);
     }
 
@@ -183,6 +182,9 @@ public class KmZendeskClient {
     public boolean isZendeskConnected() {
         return isZendeskConnected;
     }
+    public boolean isZendeskInitialized() {
+        return isZendeskInitialized;
+    }
 
     public void isChatGoingOn(final ChatStatus chatStatus) {
         if(!isZendeskInitialized) {
@@ -225,6 +227,10 @@ public class KmZendeskClient {
         });
         observationScope.cancel();
         kmZendeskClient = null;
+    }
+
+    public Integer getChannelKey() {
+        return channelKey;
     }
 
     public interface ChatStatus {

--- a/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmZendeskClient.java
@@ -1,0 +1,232 @@
+package io.kommunicate.services;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import com.applozic.mobicomkit.api.conversation.AlConversationResponse;
+import com.applozic.mobicomkit.api.conversation.Message;
+import com.applozic.mobicomkit.api.conversation.MessageClientService;
+import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
+import com.applozic.mobicomkit.contact.AppContactService;
+import com.applozic.mobicommons.commons.core.utils.Utils;
+import com.applozic.mobicommons.json.GsonUtils;
+import com.applozic.mobicommons.people.channel.Channel;
+import com.applozic.mobicommons.people.contact.Contact;
+import com.zendesk.service.ErrorResponse;
+import com.zendesk.service.ZendeskCallback;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.kommunicate.R;
+import zendesk.chat.Chat;
+import zendesk.chat.ChatInfo;
+import zendesk.chat.ChatState;
+import zendesk.chat.ConnectionStatus;
+import zendesk.chat.ObservationScope;
+import zendesk.chat.Observer;
+import zendesk.chat.ProfileProvider;
+import zendesk.chat.VisitorInfo;
+
+public class KmZendeskClient {
+
+    private static String TAG = "KmZendeskClient";
+    private static KmZendeskClient kmZendeskClient;
+    private Integer groupId;
+    private ProfileProvider profileProvider;
+    private boolean isZendeskConnected;
+    private boolean isZendeskInitialized;
+    private Contact contact;
+    private Channel channel;
+    private Context context;
+    private ObservationScope observationScope;
+
+    private KmZendeskClient(Context context) {
+        this.context = context;
+        observationScope = new ObservationScope();
+    }
+
+    public static KmZendeskClient getInstance(Context context) {
+        if(kmZendeskClient == null) {
+            kmZendeskClient = new KmZendeskClient(context);
+        }
+        return kmZendeskClient;
+    }
+
+    public void initializeZendesk(String accountKey, Integer channelKey, Contact contact, Channel channel ) {
+        Chat.INSTANCE.init(context, accountKey);
+        isZendeskInitialized = true;
+        groupId = channelKey;
+        this.contact = contact;
+        authenticateZendeskUser(contact);
+        this.channel = channel;
+        Chat.INSTANCE.providers().connectionProvider().observeConnectionStatus(observationScope, new Observer<ConnectionStatus>() {
+            @Override
+            public void update(ConnectionStatus connectionStatus) {
+                if(connectionStatus != ConnectionStatus.CONNECTED) {
+                    connectToZendeskSocket();
+                    return;
+                }
+                isZendeskConnected = true;
+                observeChatLogs();
+                sendZendeskChatTranscript();
+            }
+        });
+
+    }
+    private void connectToZendeskSocket() {
+        Chat.INSTANCE.providers().connectionProvider().connect();
+    }
+
+    public void authenticateZendeskUser(Contact contact) {
+       // Chat.INSTANCE.providers().
+
+        VisitorInfo visitorInfo = VisitorInfo.builder()
+                .withName(TextUtils.isEmpty(contact.getDisplayName()) ? "" : contact.getDisplayName())
+                .withEmail(TextUtils.isEmpty(contact.getEmailId()) ? "" : contact.getEmailId())
+                .withPhoneNumber(TextUtils.isEmpty(contact.getContactNumber()) ? "" : contact.getContactNumber()) // numeric string
+                .build();
+        Chat.INSTANCE.providers().profileProvider().setVisitorInfo(visitorInfo, new ZendeskCallback<Void>() {
+            @Override
+            public void onSuccess(Void unused) {
+                Log.e(TAG, "loginsuccess");
+            }
+
+            @Override
+            public void onError(ErrorResponse errorResponse) {
+                Log.e(TAG, "loginfailed");
+            }
+        });
+    }
+
+    private void observeChatLogs() {
+        Chat.INSTANCE.providers().chatProvider().observeChatState(observationScope, new Observer<ChatState>() {
+            @Override
+            public void update(ChatState chatState) {
+                Log.e(TAG, String.valueOf(chatState));
+            }
+        });
+    }
+
+    public void sendZendeskMessage(String message) {
+        Log.e(TAG, "sent message");
+        Chat.INSTANCE.providers().chatProvider().sendMessage(message);
+    }
+
+    public void sendZendeskChatTranscript() {
+        final StringBuilder transcriptString = new StringBuilder();
+        sendZendeskMessage(context.getString(R.string.km_zendesk_transcript_message, new KmClientService(context).getConversationShareUrl(), groupId));
+
+        MessageDatabaseService messageDatabaseService = new MessageDatabaseService(context);
+        //List<Message> messageList = messageDatabaseService.getMessages(null, null, contact, channel, groupId);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                AlConversationResponse kmConversationResponse = null;
+                Message messageList[];
+                List<Message> listOfMessage;
+                try {
+                    kmConversationResponse = (AlConversationResponse) GsonUtils.getObjectFromJson(new MessageClientService(context).getMessages(contact, channel, null, null, channel.getKey(), false), AlConversationResponse.class);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                if (kmConversationResponse != null) {
+                    listOfMessage = Arrays.asList(kmConversationResponse.getMessage());
+                    Collections.reverse(listOfMessage);
+                    for(Message message : listOfMessage) {
+                        String username;
+                        if(message.isHidden() || message.isChannelCustomMessage()) {
+                            continue;
+                        }
+                        if(message.getContactIds().equals(contact.getContactIds())) {
+                            username = "User";
+                        } else {
+                            username = new AppContactService(context).getContactById(message.getContactIds()).getDisplayName();
+                        }
+                        String messageString = getMessageForTranscript(message);
+                        if(TextUtils.isEmpty(messageString) || TextUtils.isEmpty(username)) {
+                            continue;
+                        }
+                        transcriptString.append(username).append(" : ").append(getMessageForTranscript(message)).append("\n");
+                    }
+                }
+                sendZendeskMessage(transcriptString.toString());
+            }
+        }).start();
+
+
+           // Log.e(TAG, String.valueOf(messageList));
+
+    }
+
+    public String getMessageForTranscript(Message message) {
+        Log.e(TAG, "SENDING TRANSXEIPR");
+        if(!TextUtils.isEmpty(message.getMessage())) {
+            return message.getMessage();
+        }
+        if(message.getFileMetas() != null && !TextUtils.isEmpty(message.getFileMetas().getBlobKeyString())) {
+            return "/rest/ws/attachment/" + message.getFileMetas().getBlobKeyString();
+        }
+        if (message.getMetadata() != null && !TextUtils.isEmpty(message.getMetadata().get("templateId"))) {
+            return "TemplateId: " + message.getMetadata().get("templateId");
+        }
+        return "";
+    }
+
+    public boolean isZendeskConnected() {
+        return isZendeskConnected;
+    }
+
+    public Integer getGroupId() {
+        return groupId;
+    }
+
+    public void isChatGoingOn(final ChatStatus chatStatus) {
+        if(!isZendeskInitialized) {
+            chatStatus.onChatFinished();
+            return;
+        }
+        try {
+                Chat.INSTANCE.providers().chatProvider().getChatInfo(new ZendeskCallback<ChatInfo>() {
+                    @Override
+                    public void onSuccess(ChatInfo chatInfo) {
+                        if (chatInfo.isChatting()) {
+                            chatStatus.onChatGoingOn();
+                        } else {
+                            chatStatus.onChatFinished();
+                        }
+                    }
+
+                    @Override
+                    public void onError(ErrorResponse errorResponse) {
+                        chatStatus.onChatError(errorResponse.getReason());
+                    }
+                });
+            } catch (NullPointerException e) {
+                e.printStackTrace();
+                chatStatus.onChatFinished();
+            }
+    }
+
+    public void endZendeskChat() {
+        Chat.INSTANCE.providers().chatProvider().endChat(new ZendeskCallback<Void>() {
+            @Override
+            public void onSuccess(Void unused) {
+                Utils.printLog(context, TAG, "Successfully ended Zendesk Chat");
+            }
+
+            @Override
+            public void onError(ErrorResponse errorResponse) {
+                Utils.printLog(context, TAG, errorResponse.getReason() + errorResponse.getResponseBody());
+            }
+        });
+        observationScope.cancel();
+        kmZendeskClient = null;
+    }
+    public interface ChatStatus {
+        void onChatGoingOn();
+        void onChatFinished();
+        void onChatError(String errorMessage);
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
@@ -171,7 +171,7 @@ public class KmAppSettingPreferences {
     }
 
     public String getZendeskSdkKey() {
-        return preferences.getString(ZENDESK_SDK_KEY, null);
+        return preferences.getString(ZENDESK_SDK_KEY, "");
     }
 
     public void clearInstance() {

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.java
@@ -27,6 +27,7 @@ public class KmAppSettingPreferences {
     private static final String LOGGED_IN_AT_TIME = "LOGGED_IN_AT_TIME";
     private static final String CHAT_SESSION_DELETE_TIME = "CHAT_SESSION_DELETE_TIME";
     private static final String HIDE_POST_CTA = "HIDE_POST_CTA";
+    private static final String ZENDESK_SDK_KEY = "ZENDESK_SDK_KEY";
 
     private KmAppSettingPreferences() {
         preferences = ApplozicService.getAppContext().getSharedPreferences(KM_THEME_PREFERENCES, Context.MODE_PRIVATE);
@@ -51,6 +52,7 @@ public class KmAppSettingPreferences {
                 setSecondaryColor(appSetting.getChatWidget().getSecondaryColor());
                 setKmBotMessageDelayInterval(appSetting.getChatWidget().getBotMessageDelayInterval());
                 setChatSessionDeleteTime(appSetting.getChatWidget().getSessionTimeout());
+                setZendeskChatSdkKey(appSetting.getChatWidget().getZendeskChatSdkKey());
             }
             if (appSetting.getResponse() != null) {
                 setCollectFeedback(appSetting.getResponse().isCollectFeedback());
@@ -162,6 +164,14 @@ public class KmAppSettingPreferences {
 
     public int getKmBotMessageDelayInterval() {
         return preferences.getInt(KM_BOT_MESSAGE_DELAY_INTERVAL, 0);
+    }
+
+    public void setZendeskChatSdkKey(String zendeskAccountKey) {
+        preferences.edit().putString(ZENDESK_SDK_KEY, zendeskAccountKey).apply();
+    }
+
+    public String getZendeskSdkKey() {
+        return preferences.getString(ZENDESK_SDK_KEY, null);
     }
 
     public void clearInstance() {

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -26,4 +26,6 @@ public class KmConstants {
     public static final int STATUS_CONNECTED = 1;
     public static final Long MESSAGE_CLUBBING_TIME_FRAME = 300000L;
     public static final String NOTIFICATION_TONE = "com.applozic.mobicomkit.notification.tone";
+    public static final String CONVERSATION_SOURCE = "source";
+    public static final String ZOPIM = "zopim";
 }

--- a/kommunicate/src/main/java/io/kommunicate/zendesk/KmZendeskClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/zendesk/KmZendeskClient.java
@@ -2,6 +2,7 @@ package io.kommunicate.zendesk;
 
 import android.content.Context;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.applozic.mobicomkit.api.conversation.AlConversationResponse;
 import com.applozic.mobicomkit.api.conversation.Message;
@@ -14,6 +15,7 @@ import com.applozic.mobicommons.people.contact.Contact;
 import com.zendesk.service.ErrorResponse;
 import com.zendesk.service.ZendeskCallback;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +28,7 @@ import zendesk.chat.Chat;
 import zendesk.chat.ChatInfo;
 import zendesk.chat.ChatState;
 import zendesk.chat.ConnectionStatus;
+import zendesk.chat.FileUploadListener;
 import zendesk.chat.ObservationScope;
 import zendesk.chat.Observer;
 import zendesk.chat.VisitorInfo;
@@ -123,8 +126,29 @@ public class KmZendeskClient {
     }
 
     public void sendZendeskMessage(String message) {
+        if(!isZendeskInitialized || TextUtils.isEmpty(message)) {
+            return;
+        }
         Utils.printLog(context, TAG, "Sent Zendesk Message" + message);
         Chat.INSTANCE.providers().chatProvider().sendMessage(message);
+    }
+
+    public void sendZendeskAttachment(String filePath) {
+        if(!isZendeskInitialized) {
+            return;
+        }
+        Chat.INSTANCE.providers().chatProvider().sendFile(new File(filePath), new FileUploadListener() {
+            @Override
+            public void onProgress(String s, long l, long l1) {
+                if(l1 == 0) {
+                    Utils.printLog(context, TAG, "Attachment upload in progress");
+                }
+                if(l == l1) {
+                    Utils.printLog(context, TAG, "Attachment uploaded successfully");
+
+                }
+            }
+        });
     }
 
     //fetches Chat list and send the chat transcript to Zendesk
@@ -172,7 +196,7 @@ public class KmZendeskClient {
             return message.getMessage();
         }
         if(message.getFileMetas() != null && !TextUtils.isEmpty(message.getFileMetas().getBlobKeyString())) {
-            return "/rest/ws/attachment/" + message.getFileMetas().getBlobKeyString();
+            return new KmClientService(context).getBaseUrl() + "/rest/ws/attachment/" + message.getFileMetas().getBlobKeyString();
         }
         if (message.getMetadata() != null && !TextUtils.isEmpty(message.getMetadata().get("templateId"))) {
             return "TemplateId: " + message.getMetadata().get("templateId");
@@ -262,6 +286,9 @@ public class KmZendeskClient {
     }
 
     public void endZendeskChat() {
+        if(!isZendeskInitialized) {
+            return;
+        }
         Chat.INSTANCE.providers().chatProvider().endChat(new ZendeskCallback<Void>() {
             @Override
             public void onSuccess(Void unused) {

--- a/kommunicate/src/main/res/values/strings.xml
+++ b/kommunicate/src/main/res/values/strings.xml
@@ -15,5 +15,5 @@
     <string name="km_ok_button">OK</string>
     <string name="km_set_app_id">You need to replace the &lt;Your-App-ID&gt; in the app level build.gradle file with your actual appId from Kommunicate dashboard</string>
     <string name="km_clear_app_data">You just changed the AppId, please clear the app data or logout/login the user again in Kommunicate for the new AppId to reflect</string>
-    <string name="km_zendesk_transcript_message">This chat is initiated from kommunicate widget, look for more here: %2$d</string>
+    <string name="km_zendesk_transcript_message">This chat is initiated from Kommunicate widget, look for more here: %2$d</string>
 </resources>

--- a/kommunicate/src/main/res/values/strings.xml
+++ b/kommunicate/src/main/res/values/strings.xml
@@ -15,5 +15,5 @@
     <string name="km_ok_button">OK</string>
     <string name="km_set_app_id">You need to replace the &lt;Your-App-ID&gt; in the app level build.gradle file with your actual appId from Kommunicate dashboard</string>
     <string name="km_clear_app_data">You just changed the AppId, please clear the app data or logout/login the user again in Kommunicate for the new AppId to reflect</string>
-    <string name="km_zendesk_transcript_message">This chat is initiated from Kommunicate widget, look for more here: %1$s %2$d</string>
+    <string name="km_zendesk_transcript_message">This chat is initiated from Kommunicate widget, look for more here: %1$s%2$d</string>
 </resources>

--- a/kommunicate/src/main/res/values/strings.xml
+++ b/kommunicate/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="km_ok_button">OK</string>
     <string name="km_set_app_id">You need to replace the &lt;Your-App-ID&gt; in the app level build.gradle file with your actual appId from Kommunicate dashboard</string>
     <string name="km_clear_app_data">You just changed the AppId, please clear the app data or logout/login the user again in Kommunicate for the new AppId to reflect</string>
+    <string name="km_zendesk_transcript_message">This chat is initiated from kommunicate widget, look for more here: %2$d</string>
 </resources>

--- a/kommunicate/src/main/res/values/strings.xml
+++ b/kommunicate/src/main/res/values/strings.xml
@@ -15,5 +15,5 @@
     <string name="km_ok_button">OK</string>
     <string name="km_set_app_id">You need to replace the &lt;Your-App-ID&gt; in the app level build.gradle file with your actual appId from Kommunicate dashboard</string>
     <string name="km_clear_app_data">You just changed the AppId, please clear the app data or logout/login the user again in Kommunicate for the new AppId to reflect</string>
-    <string name="km_zendesk_transcript_message">This chat is initiated from Kommunicate widget, look for more here: %2$d</string>
+    <string name="km_zendesk_transcript_message">This chat is initiated from Kommunicate widget, look for more here: %1$s %2$d</string>
 </resources>

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -216,7 +216,7 @@ import io.kommunicate.models.KmFeedback;
 import io.kommunicate.services.KmChannelService;
 import io.kommunicate.services.KmClientService;
 import io.kommunicate.services.KmService;
-import io.kommunicate.services.KmZendeskClient;
+import io.kommunicate.zendesk.KmZendeskClient;
 import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmInputTextLimitUtil;
 import io.kommunicate.utils.KmUtils;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1087,11 +1087,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (existingAssignee != null && !existingAssignee.equals(channel.getConversationAssignee())) {
             showAwayMessage(true, null);
         }
+
+        //If user has Integrated Zopim, initialize Zendesk Chat SDK
         Contact assigneeContact = appContactService.getContactById(channel.getConversationAssignee());
         String zendeskChatSdkKey = KmAppSettingPreferences.getInstance().getZendeskSdkKey();
-        if(assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) && zendeskChatSdkKey != null) {
-
-        KmZendeskClient.getInstance(getContext()).initializeZendesk(zendeskChatSdkKey, channel.getKey(), appContactService.getContactById(MobiComUserPreference.getInstance(getContext()).getUserId()), channel);
+        if(zendeskChatSdkKey != null && assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) ) {
+            KmZendeskClient.getInstance(getContext()).initializeZendesk(zendeskChatSdkKey, channel.getKey(), appContactService.getContactById(MobiComUserPreference.getInstance(getContext()).getUserId()), channel);
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1278,7 +1278,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     protected void processSendMessage() {
-        if(KmZendeskClient.getInstance(getContext()).isZendeskConnected()) {
+        if(KmZendeskClient.getInstance(getContext()).isZendeskInitialized()) {
             KmZendeskClient.getInstance(getContext()).sendZendeskMessage(messageEditText.getText().toString());
         }
         if (!TextUtils.isEmpty(messageEditText.getText().toString().trim()) || !TextUtils.isEmpty(filePath)) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1091,7 +1091,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         //If user has Integrated Zopim, initialize Zendesk Chat SDK
         Contact assigneeContact = appContactService.getContactById(channel.getConversationAssignee());
         String zendeskChatSdkKey = KmAppSettingPreferences.getInstance().getZendeskSdkKey();
-        if(zendeskChatSdkKey != null && assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) ) {
+        if(!TextUtils.isEmpty(zendeskChatSdkKey) && assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) ) {
             KmZendeskClient.getInstance(getContext()).initializeZendesk(zendeskChatSdkKey, channel.getKey(), appContactService.getContactById(MobiComUserPreference.getInstance(getContext()).getUserId()), channel);
         }
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -29,6 +29,7 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -216,6 +217,7 @@ import io.kommunicate.models.KmFeedback;
 import io.kommunicate.services.KmChannelService;
 import io.kommunicate.services.KmClientService;
 import io.kommunicate.services.KmService;
+import io.kommunicate.services.KmZendeskClient;
 import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmInputTextLimitUtil;
 import io.kommunicate.utils.KmUtils;
@@ -1086,6 +1088,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (existingAssignee != null && !existingAssignee.equals(channel.getConversationAssignee())) {
             showAwayMessage(true, null);
         }
+        Contact assigneeContact = appContactService.getContactById(channel.getConversationAssignee());
+        Log.e("zendeskassignee", String.valueOf(assigneeContact.getRoleType()));
+        String zendeskChatSdkKey = KmAppSettingPreferences.getInstance().getZendeskSdkKey();
+        if(assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) && zendeskChatSdkKey != null) {
+
+        KmZendeskClient.getInstance(getContext()).initializeZendesk(zendeskChatSdkKey, channel.getKey(), appContactService.getContactById(MobiComUserPreference.getInstance(getContext()).getUserId()), channel);
+        }
     }
 
     @Override
@@ -1270,6 +1279,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     protected void processSendMessage() {
+        if(KmZendeskClient.getInstance(getContext()).isZendeskConnected()) {
+            KmZendeskClient.getInstance(getContext()).sendZendeskMessage(messageEditText.getText().toString());
+        }
         if (!TextUtils.isEmpty(messageEditText.getText().toString().trim()) || !TextUtils.isEmpty(filePath)) {
             String inputMessage = messageEditText.getText().toString();
             String[] inputMsg = inputMessage.toLowerCase().split(" ");

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -29,7 +29,6 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -1089,7 +1088,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             showAwayMessage(true, null);
         }
         Contact assigneeContact = appContactService.getContactById(channel.getConversationAssignee());
-        Log.e("zendeskassignee", String.valueOf(assigneeContact.getRoleType()));
         String zendeskChatSdkKey = KmAppSettingPreferences.getInstance().getZendeskSdkKey();
         if(assigneeContact != null && User.RoleType.AGENT.getValue().equals(assigneeContact.getRoleType()) && zendeskChatSdkKey != null) {
 


### PR DESCRIPTION
## Summary
- To Support Zopim Integration in Android SDK, used Zendesk Chat SDK V2:
`implementation group: 'com.zendesk', name: 'chat-providers', version: '3.3.0'`

## Tasks completed:
- Identify Zendesk User and storing the Zendesk Account key in local storage
- Create new flow for opening Zendesk conversation - 
`Kommunicate.openZendeskChat(context)`
- Updating source of conversation for Zendesk user
- Send Chat Transcript to Zendesk when handoff happens