### PR TITLE
[CM-1238] - Show notification from Notification Test Page

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/MobiComPushReceiver.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/MobiComPushReceiver.java
@@ -172,7 +172,7 @@ MobiComPushReceiver {
                     deleteMessage = null, conversationReadResponse = null,
                     userBlockedResponse = null, userUnBlockedResponse = null, conversationReadForContact = null, conversationReadForChannel = null, conversationReadForSingleMessage = null,
                     userDetailChanged = null, userDeleteNotification = null, messageMetadataUpdate = null, mutedUserListResponse = null, contactSync = null, muteAllNotificationResponse = null,
-                    groupMuteNotificationResponse = null, userActivated = null, userDeactivated = null;
+                    groupMuteNotificationResponse = null, userActivated = null, userDeactivated = null, notificationTest = null;
             SyncCallService syncCallService = SyncCallService.getInstance(context);
 
             if (bundle != null) {
@@ -198,6 +198,7 @@ MobiComPushReceiver {
                 groupMuteNotificationResponse = bundle.getString(notificationKeyList.get(34));
                 userActivated = bundle.getString(notificationKeyList.get(17));
                 userDeactivated = bundle.getString(notificationKeyList.get(18));
+                notificationTest = data.get(notificationKeyList.get(23));
             } else if (data != null) {
                 deleteConversationForContact = data.get(notificationKeyList.get(5));
                 deleteMessage = data.get(notificationKeyList.get(4));
@@ -221,6 +222,7 @@ MobiComPushReceiver {
                 groupMuteNotificationResponse = data.get(notificationKeyList.get(34));
                 userActivated = data.get(notificationKeyList.get(17));
                 userDeactivated = data.get(notificationKeyList.get(18));
+                notificationTest = data.get(notificationKeyList.get(23));
             }
 
             if (!TextUtils.isEmpty(payloadForDelivered)) {
@@ -491,6 +493,16 @@ MobiComPushReceiver {
 
             if (!TextUtils.isEmpty(userDeactivated)) {
                 BroadcastService.sendUserActivatedBroadcast(context, AlMessageEvent.ActionType.USER_DEACTIVATED);
+            }
+            if(!TextUtils.isEmpty(notificationTest)) {
+
+                int notificationId = Utils.getLauncherIcon(context.getApplicationContext());
+                InstantMessageResponse messageResponse = (InstantMessageResponse) GsonUtils.getObjectFromJson(notificationTest, InstantMessageResponse.class);
+                if (messageResponse != null && !messageResponse.isSendAlert()) {
+                    return;
+                }
+                NotificationService notificationService = new NotificationService(notificationId, context, 0, 0, 0);
+                notificationService.sendTestNotification();
             }
 
         } catch (Throwable e) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/NotificationService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/notification/NotificationService.java
@@ -576,6 +576,17 @@ public class NotificationService {
         return !(notificationDisableThreshold == 0 || (notificationDisableThreshold > 0 && index < notificationDisableThreshold));
     }
 
+    public void sendTestNotification() {
+        Integer smallIconResourceId = Utils.getMetaDataValueForResources(context, NOTIFICATION_SMALL_ICON_METADATA) != null ? Utils.getMetaDataValueForResources(context, NOTIFICATION_SMALL_ICON_METADATA) : iconResourceId;
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, notificationChannels.getDefaultChannelId(false))
+                .setSmallIcon(smallIconResourceId)
+                .setContentTitle("Kommunicate")
+                .setContentText("Testing notification")
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT);
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        notificationManager.notify(123, builder.build());
+    }
+
     static class NotificationInfo {
         String title;
         Contact displayNameContact;

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/feed/InstantMessageResponse.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/feed/InstantMessageResponse.java
@@ -11,6 +11,7 @@ public class InstantMessageResponse extends JsonMarker {
     private String type;
     private String message;
     private boolean notifyUser;
+    private boolean sendAlert;
 
     public String getId() {
         return id;
@@ -44,6 +45,9 @@ public class InstantMessageResponse extends JsonMarker {
         this.notifyUser = notifyUser;
     }
 
+    public boolean isSendAlert() {
+        return sendAlert;
+    }
     @Override
     public String toString() {
         return "MqttMessageResponse{" +


### PR DESCRIPTION
## Summary
- Show notification when "Send notification alert to mobile devices" is enabled from notification test page

## Notification screenshot:
![notification](https://user-images.githubusercontent.com/121423566/210505077-f8885cb4-af0b-433e-abfb-9d7153cbc06b.jpg)