### PR TITLE
[CM-1261] - Handle notifications with FCM payload

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/people/channel/Channel.java
@@ -314,6 +314,12 @@ public class Channel extends JsonMarker {
         return (GroupType.SUPPORT_GROUP.getValue().equals(getType()) && getMetadata() != null && !TextUtils.isEmpty(getMetadata().get(CONVERSATION_ASSIGNEE))) ? getMetadata().get(CONVERSATION_ASSIGNEE) : null;
     }
 
+    public void setConversationAssignee(String assignee) {
+        if(getMetadata() != null) {
+            getMetadata().put(CONVERSATION_ASSIGNEE, assignee);
+        }
+    }
+
     public String getTeamId() {
         return (GroupType.SUPPORT_GROUP.getValue().equals(getType()) && getMetadata() != null && !TextUtils.isEmpty(getMetadata().get(KM_TEAM_ID))) ? getMetadata().get(KM_TEAM_ID) : null;
     }


### PR DESCRIPTION
## Summary
- Whenever we received a FCM notification, we were not using the FCM payload to show notification. Rather, we were calling the sync message API which was called in background and notifications were shown with it.
- This was causing problems as Android OS sometimes does not allow background tasks to be executed to save memory. Due to this, notifications were not shown sometimes.

# Fix:
- Now, we are using FCM payload to directly show the notification, without calling the sync call API. 
- Sync call API will be called when we click the notification or when the app is opened, which will ensure that no messages are lost.
- We are calling "message/delivered" API in the background to send delivery report. Even if this API is not called by Android OS, delivery report will be sent when user clicks on the notification or when app is opened.
- We are using the FCM payload to also update the channel, which is required by Agent app to decide which notification to be shown.