### PR TITLE
Create UI thread for events in MainLooper

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlEventManager.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlEventManager.java
@@ -2,6 +2,7 @@ package com.applozic.mobicomkit.broadcast;
 
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 
 import com.applozic.mobicomkit.feed.MqttMessageResponse;
@@ -13,6 +14,7 @@ import com.applozic.mobicommons.json.GsonUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
 import io.kommunicate.callbacks.KmPluginEventListener;
 
 /**
@@ -108,13 +110,13 @@ public class AlEventManager {
 
     private void initHandler() {
         if (uiHandler == null) {
-            uiHandler = new Handler(new Handler.Callback() {
+            uiHandler = new Handler(Looper.getMainLooper()) {
                 @Override
-                public boolean handleMessage(Message msg) {
+                public void handleMessage(@NonNull Message msg) {
                     handleState(msg);
-                    return false;
+                    super.handleMessage(msg);
                 }
-            });
+            };
         }
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1076,16 +1076,20 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             return;
         }
 
-        String existingAssignee = channel.getConversationAssignee();
-
+        final String existingAssignee = channel.getConversationAssignee();
         channel = ChannelService.getInstance(getActivity()).getChannelByChannelKey(channel.getKey());
         //conversation is open
         //if the conversation is opened from the dashboard while the feedback input fragment is open, the feedback fragment will be closed
-        setFeedbackDisplay(channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS && !KmUtils.isAgent(getContext()));
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                setFeedbackDisplay(channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS && !KmUtils.isAgent(getContext()));
+                if (existingAssignee != null && !existingAssignee.equals(channel.getConversationAssignee())) {
+                    showAwayMessage(true, null);
+                }
+            }
+        });
 
-        if (existingAssignee != null && !existingAssignee.equals(channel.getConversationAssignee())) {
-            showAwayMessage(true, null);
-        }
     }
 
     @Override


### PR DESCRIPTION
## Issue:
- React Native showing "Handler sending message to a Handler on a dead thread " when an event is triggered

## Doc says:
_Each Handler has a Looper, and a Looper is associated with a Thread (usually a HandlerThread). The general problem is when a Handler becomes associated with thread that stops running. If someone tries to use the Handler, it will fail with the message "sending message to a Handler on a dead thread"._

## Fix:
- Any easy fix is to construct your Handler like,

`Handler h = new Handler(Looper.getMainLooper());`
This associates the Handler with the main looper, or the main application thread which will never die (good for things like callbacks, but not for any blocking work obviously).