### PR TITLE
Add support to close conversation screen from code

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -384,6 +384,16 @@ public class Kommunicate {
         Applozic.logoutUser(context, handler);
     }
 
+    public static void closeConversationScreen(Context context) {
+        try {
+            Intent intent = new Intent(context, KmUtils.getClassFromName(KmConstants.CONVERSATION_ACTIVITY_NAME));
+            intent.putExtra(KmConstants.CLOSE_CONVERSATION_SCREEN, true);
+            context.startActivity(intent);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
     public static void setDeviceToken(Context context, String deviceToken) {
         Applozic.getInstance(context).setDeviceRegistrationId(deviceToken);
     }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -26,4 +26,5 @@ public class KmConstants {
     public static final int STATUS_CONNECTED = 1;
     public static final Long MESSAGE_CLUBBING_TIME_FRAME = 300000L;
     public static final String NOTIFICATION_TONE = "com.applozic.mobicomkit.notification.tone";
+    public static final String CLOSE_CONVERSATION_SCREEN = "CLOSE_CONVERSATION_SCREEN";
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -491,6 +491,9 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         //setIntent(intent);
+        if(intent != null && intent.getBooleanExtra(KmConstants.CLOSE_CONVERSATION_SCREEN, false)) {
+            this.finish();
+        }
         if (!MobiComUserPreference.getInstance(this).isLoggedIn()) {
             //user is not logged in
             Utils.printLog(this, "AL", "user is not logged in yet.");


### PR DESCRIPTION
## Summary
- We need to expose a method to Hybrid platforms to close the application through code.
- If they use events to navigate their app, navigation will happen but our application will be shown on top. To fix this, we have added support to close our application, which can be exposed to Hybrid platforms.