### PR TITLE
release changes for v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
 ## Unreleased
-1) Added platform flag
-2) Added logout option on conversation menu
-3) Stopped calling refresh token API when proper paramters are not passed .
+1) Added support to send platform flag for analytics
+2) Added logout option on conversation screen
+3) Stopped calling refresh token API when proper parameters are not passed.
+4) Send actual Notification from Notification test page
+5) Handle notification from FCM directly
+6) Add support to close Kommunicate Application through code
+7) Threads optimized for Hybrid platforms
+8) Multiple crash fixes
 
 ## Kommunicate Android SDK 2.5.3
 1) Auto Suggestion Button color customization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
-## Unreleased
+## Kommunicate Android SDK 2.6.0
 1) Added support to send platform flag for analytics
 2) Added logout option on conversation screen
 3) Stopped calling refresh token API when proper parameters are not passed.

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.5.3"
+        versionName "2.6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.5.3"
+        versionName "2.6.0"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }
@@ -35,7 +35,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(':kommunicate')
-    //api 'io.kommunicate.sdk:kommunicate:2.3.0'
+    //api 'io.kommunicate.sdk:kommunicate:2.6.0'
     api 'com.google.firebase:firebase-messaging:20.1.0'
     api 'com.google.android.gms:play-services-maps:17.0.0'
     api 'com.google.android.gms:play-services-location:17.0.0'


### PR DESCRIPTION
## Kommunicate Android SDK 2.6.0
1) Added support to send platform flag for analytics
2) Added logout option on conversation screen
3) Stopped calling refresh token API when proper parameters are not passed.
4) Send actual Notification from Notification test page
5) Handle notification from FCM directly
6) Add support to close Kommunicate Application through code
7) Threads optimized for Hybrid platforms
8) Multiple crash fixes