### PR TITLE
[CM-1309] Fixed agent app toolbar showing conversation assignee image instead of end user image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed agent app toolbar showing conversation assignee image instead of end user image
+
 ## Kommunicate Android SDK 2.6.0
 1) Added support to send platform flag for analytics
 2) Added logout option on conversation screen

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3232,7 +3232,10 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     public void updateSupportGroupTitleAndImageAndHideSubtitle(Channel channel) {
         toolbarAlphabeticImage.setVisibility(VISIBLE);
         toolbarImageView.setVisibility(GONE);
-        if (channel != null && channel.getConversationAssignee() != null) {
+        if(alCustomizationSettings.isAgentApp() && channel != null && !TextUtils.isEmpty(channel.getImageUrl())) {
+            KmViewHelper.loadImage(getContext(), toolbarImageView, toolbarAlphabeticImage, channel.getImageUrl(), R.drawable.km_ic_contact_picture_holo_light);
+        }
+        else if (!alCustomizationSettings.isAgentApp() && channel != null && channel.getConversationAssignee() != null) {
             Contact withUserContact = appContactService.getContactById(channel.getConversationAssignee());
 
             KmViewHelper.loadContactImage(getContext(), toolbarImageView, toolbarAlphabeticImage, withUserContact, R.drawable.km_ic_contact_picture_holo_light);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/utils/KmViewHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/utils/KmViewHelper.java
@@ -55,7 +55,7 @@ public class KmViewHelper {
         }
     }
 
-    private static void loadImage(Context context, final CircleImageView imageView, final TextView textImage, String imageUrl, int placeholderImage) {
+    public static void loadImage(Context context, final CircleImageView imageView, final TextView textImage, String imageUrl, int placeholderImage) {
         RequestOptions options = new RequestOptions()
                 .centerCrop()
                 .placeholder(placeholderImage)


### PR DESCRIPTION
Previously inside the `updateSupportGroupTitleAndImageAndHideSubtitle` function there was no separate case for agent app so even when the toolbar was of agent app it was working as a toolbar of SDK which is fixed now