### PR TITLE
[CM-1307] Added customization for restart conversation button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Added customization for restart conversation button
+
 ## Kommunicate Android SDK 2.6.2
 1) Fixed agent app toolbar showing conversation assignee image instead of end user image
 2) Fixed notification for agents

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -163,5 +163,6 @@
   },
   "receiverNameTextColor": "#5C6677",
   "innerTimestampDesign": false,
-  "oneTimeRating": true
+  "oneTimeRating": true,
+  "restartConversationButtonVisibility": true
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -136,6 +136,11 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean restrictMessageTypingWithBots = false;
     private Map<String, Boolean> hidePostCTA;
     private boolean oneTimeRating;
+    private boolean restartConversationButtonVisibility = true;
+
+    public boolean isRestartConversationButtonVisibility() {
+        return restartConversationButtonVisibility;
+    }
 
     public Boolean getInnerTimestampDesign() {
         return innerTimestampDesign;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4428,7 +4428,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 TextView textViewRestartConversation = kmFeedbackView.findViewById(R.id.idFeedbackRestartConversation);
                 if(!alCustomizationSettings.isRestartConversationButtonVisibility()){
                     textViewRestartConversation.setVisibility(View.INVISIBLE);
+                    textViewRestartConversation.setPadding(0, 0, 0, 0);
                     restartConversationTextQuestion.setVisibility(View.INVISIBLE);
+                    restartConversationTextQuestion.setPadding(0, 0, 0, 0);
                 }
                 individualMessageSendLayout.setVisibility(View.GONE);
                 mainDivider.setVisibility(View.GONE);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4424,6 +4424,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (channel != null && !channel.isDeleted()) {
             if (display) {
                 kmFeedbackView.setVisibility(VISIBLE);
+                TextView restartConversationTextQuestion = kmFeedbackView.findViewById(R.id.idTextQuestion);
+                TextView textViewRestartConversation = kmFeedbackView.findViewById(R.id.idFeedbackRestartConversation);
+                if(!alCustomizationSettings.isRestartConversationButtonVisibility()){
+                    textViewRestartConversation.setVisibility(View.INVISIBLE);
+                    restartConversationTextQuestion.setVisibility(View.INVISIBLE);
+                }
                 individualMessageSendLayout.setVisibility(View.GONE);
                 mainDivider.setVisibility(View.GONE);
 


### PR DESCRIPTION
Added customization to hide/show restart conversation button in Android SDK where the user can set the value for `"restartConversationButtonVisibility"` in the `applozic-settings.json` file to change the visibility of the button

![Screenshot_2023-02-14-17-17-17-511_io kommunicate app~2](https://user-images.githubusercontent.com/90754518/218730289-d56e83fc-4a7b-4aa6-9be7-826d54a39b36.jpg)
![IMG_20230214_171658~2](https://user-images.githubusercontent.com/90754518/218730337-76f743a4-93ad-4000-bc30-1cc768759f35.jpg)
