### PR TITLE
[CM-1327] - Hide User submitted message on form submission

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -675,7 +675,7 @@ public class Message extends JsonMarker {
     }
 
     public boolean hasHideKey() {
-        return GroupMessageMetaData.TRUE.getValue().equals(getMetaDataValueForKey(GroupMessageMetaData.HIDE_KEY.getValue())) || Message.ContentType.HIDDEN.getValue().equals(getContentType()) || hidden;
+        return GroupMessageMetaData.TRUE.getValue().equals(getMetaDataValueForKey(GroupMessageMetaData.HIDE_KEY.getValue())) || Message.ContentType.HIDDEN.getValue().equals(getContentType()) || hidden || Message.MetaDataType.HIDDEN.getValue().equals(getMetaDataValueForKey(Message.MetaDataType.KEY.getValue()));
     }
 
     public boolean isGroupMetaDataUpdated() {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
@@ -245,7 +245,7 @@ public class RichMessageActionProcessor implements KmRichMessageListener {
             return;
         }
         boolean postBackToBotPlatform = KmRMActionModel.SubmitButton.KM_POST_DATA_TO_BOT_PLATFORM.equals(submitButtonModel.getRequestType());
-        Map<String, String> metadata = handleMetaData(postBackToBotPlatform, getStringMap(submitButtonModel.getReplyMetadata()), dataMap, submitButtonModel.getFormData());
+        Map<String, String> metadata = handleMetaData(postBackToBotPlatform, getStringMap(submitButtonModel.getReplyMetadata()), dataMap, getStringMap(submitButtonModel.getMetadata()));
         Utils.printLog(context, TAG, "Submitting data : " + GsonUtils.getJsonFromObject(formStateModel != null ? dataMap : submitButtonModel.getFormData(), Map.class));
 
         if (submitButtonModel.getPostBackToKommunicate() != null && submitButtonModel.getPostBackToKommunicate().equalsIgnoreCase("true")) {
@@ -384,10 +384,13 @@ public class RichMessageActionProcessor implements KmRichMessageListener {
         }
     }
 
-    private Map<String, String> handleMetaData(boolean postBackToBotPlatform, Map<String, String> replyMetadata, Map<String, Object> formSelectedData, Map<String, String> formData) {
+    private Map<String, String> handleMetaData(boolean postBackToBotPlatform, Map<String, String> replyMetadata, Map<String, Object> formSelectedData, Map<String, String> messageMetadata) {
         Map<String, String> metadata = new HashMap<>();
         if (replyMetadata != null) {
             metadata.putAll(replyMetadata);
+        }
+        if(messageMetadata != null) {
+            metadata.putAll(messageMetadata);
         }
         if (formSelectedData != null && postBackToBotPlatform) {
             Map<String, String> formDataMap = new HashMap<>();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmRMActionModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmRMActionModel.java
@@ -54,6 +54,8 @@ public class KmRMActionModel<T> extends JsonMarker {
         private String requestType;
         private String postFormDataAsMessage;
         private String postBackToKommunicate;
+        private Map<String, Object> metadata;
+        private Map<String, Object> replyMetadata;
 
         public String getPostBackToKommunicate() {
             return postBackToKommunicate;
@@ -66,7 +68,6 @@ public class KmRMActionModel<T> extends JsonMarker {
             this.postFormDataAsMessage = postFormDataAsMessage;
         }
 
-        private Map<String, Object> replyMetadata;
 
         public String getMessage() {
             return message;
@@ -106,6 +107,13 @@ public class KmRMActionModel<T> extends JsonMarker {
 
         public void setReplyMetadata(Map<String, Object> replyMetadata) {
             this.replyMetadata = replyMetadata;
+        }
+        public Map<String, Object> getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added support to send hidden message
- Added support for metadata for Action Message on Form Template
- Added Support for hiding message on form submission based on metadata
- if metadata contains `  "category": "HIDDEN"` submission message will be hidden on user end. it will be visible on dashboard

## SS

### at user end
<img width="250" height="400"  src="https://user-images.githubusercontent.com/121423566/219374245-21bb04f7-25a4-4129-ac55-ed54ff3d8667.png">


### On dashboard


<img width="1440" alt="Screenshot 2023-02-16 at 5 34 09 PM" src="https://user-images.githubusercontent.com/121423566/219374349-d1ff8800-3a1a-4b52-b8e2-b8a8947bc2bb.png">


## Note:
 You can see` submitted my details` only visible at dashboard end not at user end
