### PR TITLE
release changes for v2.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
-## Unreleased
+## Kommunicate Android SDK 2.6.5
 1) Added customization for restart conversation button
 2) Removed SQL injection vulnerability from the Android SDK
 3) Added support to set multiple Speech To Text language
 4) Added option to enable/disable JavaScript in WebView
 5) Restricted Zoom In / out on web view of FaqActivity
 6) Added option to rate conversation anytime from the conversation menu
-
+7) Metadata from form submission action payload to message replyMetadata
+8) Read and Write settings to local app file
 
 ## Kommunicate Android SDK 2.6.2
 1) Fixed agent app toolbar showing conversation assignee image instead of end user image

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.6.2"
+        versionName "2.6.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.6.2"
+        versionName "2.6.5"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Kommunicate Android SDK 2.6.5
1) Added customization for restart conversation button
2) Removed SQL injection vulnerability from the Android SDK
3) Added support to set multiple Speech To Text language
4) Added option to enable/disable JavaScript in WebView
5) Restricted Zoom In / out on web view of FaqActivity
6) Added option to rate conversation anytime from the conversation menu
7) Metadata from form submission action payload to message replyMetadata
8) Read and Write settings to local app file