### PR TITLE
[CM-1353] - Added support to delete conversation for end-user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+
+## Unreleased
+1) Added support to hide chat in helpcenter with "hideChatInHelpcenter" custom setting
+
+
 ## Kommunicate Android SDK 2.6.5
 1) Added customization for restart conversation button
 2) Removed SQL injection vulnerability from the Android SDK

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -166,5 +166,6 @@
   "oneTimeRating": true,
   "rateConversationMenuOption" : true,
   "javaScriptEnabled": true,
-  "restartConversationButtonVisibility": true
+  "restartConversationButtonVisibility": true,
+  "hideChatInHelpcenter": true
 }

--- a/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
@@ -109,11 +109,11 @@ public class KmClientService extends MobiComKitClientService {
         return httpRequestUtils.getResponse(getAppSettingUrl() + appId, "application/json", "application/json");
     }
 
-    public String getHelpCenterUrl() {
+    public String getHelpCenterUrl(boolean hideChat) {
         if(faqPageName!=null)
-            return getKmMappedUrl(KM_HELPCENTER) + FAQ_PAGE_ENDPOINT + faqPageName+ HELCENTER_APPID_ENDPOINT + MobiComKitClientService.getApplicationKey(context);
+            return getKmMappedUrl(KM_HELPCENTER) + FAQ_PAGE_ENDPOINT + faqPageName+ HELCENTER_APPID_ENDPOINT + MobiComKitClientService.getApplicationKey(context) + (hideChat ? "&hideChat=true" : "");
         else
-            return getKmMappedUrl(KM_HELPCENTER) + HELCENTER_APPID_ENDPOINT + MobiComKitClientService.getApplicationKey(context);
+            return getKmMappedUrl(KM_HELPCENTER) + HELCENTER_APPID_ENDPOINT + MobiComKitClientService.getApplicationKey(context) + (hideChat ? "&hideChat=true" : "");
     }
 
     public String getKmMappedUrl(String urlMapper) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -139,6 +139,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean restartConversationButtonVisibility = true;
     private boolean rateConversationMenuOption;
     private boolean javaScriptEnabled;
+    private boolean hideChatInHelpcenter = true;
 
     public boolean isRateConversationMenuOption() {
         return rateConversationMenuOption;
@@ -729,6 +730,10 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public Map<String, Boolean> isHidePostCTA() {
         return hidePostCTA;
+    }
+
+    public boolean isHideChatInHelpcenter() {
+        return hideChatInHelpcenter;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -9,6 +9,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -58,6 +59,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.kommunicate.async.KmDeleteConversationTask;
+import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.services.KmChannelService;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
@@ -253,13 +256,22 @@ public class ConversationUIService {
         }
     }
 
-    public void deleteConversationThread(final Contact contact, final Channel channel) {
+    public void deleteConversationThread(final Context context, final Channel channel) {
         AlertDialog.Builder alertDialog = new AlertDialog.Builder(fragmentActivity).
                 setPositiveButton(R.string.delete_conversation, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        new DeleteConversationAsyncTask(new MobiComConversationService(fragmentActivity), contact, channel, null, fragmentActivity).execute();
-
+                        new KmDeleteConversationTask(context, channel.getKey(), true, new KmCallback() {
+                            @Override
+                            public void onSuccess(Object message) {
+                                KmToast.success(context, R.string.conversation_deleted, Toast.LENGTH_SHORT).show();
+                            }
+                            @Override
+                            public void onFailure(Object error) {
+                                KmToast.error(context, "Conversation failed to delete", Toast.LENGTH_SHORT).show();
+                                Utils.printLog(context, TAG, error.toString());
+                            }
+                        }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                     }
                 });
         alertDialog.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -267,22 +279,8 @@ public class ConversationUIService {
             public void onClick(DialogInterface dialogInterface, int i) {
             }
         });
-        String name = "";
-        if (channel != null) {
-            if (Channel.GroupType.GROUPOFTWO.getValue().equals(channel.getType())) {
-                String userId = ChannelService.getInstance(fragmentActivity).getGroupOfTwoReceiverUserId(channel.getKey());
-                if (!TextUtils.isEmpty(userId)) {
-                    Contact withUserContact = baseContactService.getContactById(userId);
-                    name = withUserContact.getDisplayName();
-                }
-            } else {
-                name = ChannelUtils.getChannelTitleName(channel, MobiComUserPreference.getInstance(fragmentActivity).getUserId());
-            }
-        } else {
-            name = contact.getDisplayName();
-        }
-        alertDialog.setTitle(fragmentActivity.getString(R.string.dialog_delete_conversation_title).replace("[name]", name));
-        alertDialog.setMessage(fragmentActivity.getString(R.string.dialog_delete_conversation_confir).replace("[name]", name));
+        alertDialog.setTitle(fragmentActivity.getString(R.string.dialog_delete_conversation_title));
+        alertDialog.setMessage(fragmentActivity.getString(R.string.delete_confirm));
         alertDialog.setCancelable(true);
         alertDialog.create().show();
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -485,7 +485,6 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                 return;
             }
             Message message = messageList.get(position);
-            menu.setHeaderTitle(R.string.conversation_options);
 
             String[] menuItems = context.getResources().getStringArray(R.array.conversation_options_menu);
 
@@ -546,10 +545,8 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
 
                 switch (item.getItemId()) {
                     case 0:
-                        if (channel != null && channel.isDeleted()) {
-                            conversationUIService.deleteGroupConversation(channel);
-                        } else {
-                            conversationUIService.deleteConversationThread(contact, channel);
+                        if(channel != null) {
+                            conversationUIService.deleteConversationThread(context, channel);
                         }
                         break;
                     case 1:

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -536,7 +536,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     faqOption.setOnClickListener(new View.OnClickListener() {
                         @Override
                         public void onClick(View v) {
-                            String FaqUrl = new KmClientService(getContext(), Kommunicate.getFaqPageName()).getHelpCenterUrl();
+                            String FaqUrl = new KmClientService(getContext(), Kommunicate.getFaqPageName()).getHelpCenterUrl(alCustomizationSettings.isHideChatInHelpcenter());
                             AlEventManager.getInstance().sendOnFaqClick(FaqUrl);
                             ConversationActivity.openFaq(getActivity(), FaqUrl);
                         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
@@ -146,8 +146,10 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
                 textView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        String FaqUrl = new KmClientService(getContext(), Kommunicate.getFaqPageName()).getHelpCenterUrl();
+                        String FaqUrl = new KmClientService(getContext(), Kommunicate.getFaqPageName()).getHelpCenterUrl(alCustomizationSettings.isHideChatInHelpcenter());
                         AlEventManager.getInstance().sendOnFaqClick(FaqUrl);
+                        Log.e("help", FaqUrl);
+
                         ConversationActivity.openFaq(getActivity(), FaqUrl);
                     }
                 });

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -291,4 +291,6 @@
     <string name="invalid_email">Enter a valid email</string>
     <string name="select_language">Select a language</string>
     <string name="changed_language_to">Changed language to %1$s</string>
+    <string name="delete_confirm">Are you sure you want to delete this conversation?</string>
+    <string name="conversation_deleted">Conversation Deleted</string>
 </resources>


### PR DESCRIPTION
## Summary:
- To delete a conversation, a conversation should be long pressed. A "Delete conversation" option will show.
- API call used: `"rest/ws/group/delete"`
- By default, delete option is disabled. to enable, add `"deleteOption": true` in kommunicate-settings.json file
- Conversation will be deleted from both end-user and dashboard


## Screenshot:
![image](https://user-images.githubusercontent.com/121423566/222740770-71ded706-a6ee-4316-967b-2068d2854eff.png)
