### PR TITLE
[CM-1363] - Match formData with web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 
 ## Unreleased
 1) Added support to hide chat in helpcenter with "hideChatInHelpcenter" custom setting
-
+2) Fixed formData getting double stringified.
 
 ## Kommunicate Android SDK 2.6.5
 1) Added customization for restart conversation button

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
@@ -30,6 +30,8 @@ import com.applozic.mobicommons.json.GsonUtils;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -393,9 +395,9 @@ public class RichMessageActionProcessor implements KmRichMessageListener {
             metadata.putAll(messageMetadata);
         }
         if (formSelectedData != null && postBackToBotPlatform) {
-            Map<String, String> formDataMap = new HashMap<>();
-            formDataMap.put(KmFormPayloadModel.KM_FORM_DATA, GsonUtils.getJsonFromObject(getStringMap(formSelectedData), Map.class));
-            metadata.put(Kommunicate.KM_CHAT_CONTEXT, GsonUtils.getJsonFromObject(formDataMap, Map.class));
+            Map<String, Object> formDataMap = new HashMap<>();
+            formDataMap.put(KmFormPayloadModel.KM_FORM_DATA, new JSONObject(formSelectedData));
+            metadata.put(Kommunicate.KM_CHAT_CONTEXT,    String.valueOf(new JSONObject(formDataMap)));
         }
         return metadata;
     }

--- a/migration/Migrate to 2.X.X.md
+++ b/migration/Migrate to 2.X.X.md
@@ -1,0 +1,9 @@
+## Migrating to 2.x.x
+
+- We have changed our formData format to match with the Web SDK. If you were using webhooks/inline code earlier with form submission, please check this migration guide:
+
+- Previous versions:
+    "formData" was stringified twice. To get data, you will have to parse the Message string and then "formData" key again.
+
+- Current version:
+    formData is not stringified. Parsing the whole message body will give you the json value of "formData"


### PR DESCRIPTION
## Summary:
- FormData was stringified twice. First, just the "formData" object was stringified. Second, the whole message body was stringified
- Because of this, formData was getting stringified twice.
- Fixed this by storing the formData as an object