### PR TITLE
release changes for v2.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
 
-## Unreleased
+## Kommunicate Android SDK 2.6.6
 1) Added support to hide chat in helpcenter with "hideChatInHelpcenter" custom setting
 2) Fixed formData getting double stringified.
 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.6.5"
+        versionName "2.6.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.6.5"
+        versionName "2.6.6"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }
@@ -35,7 +35,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(':kommunicate')
-    //api 'io.kommunicate.sdk:kommunicate:2.6.0'
+    //api 'io.kommunicate.sdk:kommunicate:2.6.6'
     api 'com.google.firebase:firebase-messaging:20.1.0'
     api 'com.google.android.gms:play-services-maps:17.0.0'
     api 'com.google.android.gms:play-services-location:17.0.0'

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -16,7 +16,6 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.Pair;
 import android.util.TypedValue;
 import android.view.ContextMenu;
@@ -1581,7 +1580,6 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     public void refreshWebView() {
         if (webViews != null) {
             for(WebView webView : webViews) {
-                Log.e("webview", "load");
                 webView.reload();
             }
         }

--- a/migration/Migrate to 2.6.6.md
+++ b/migration/Migrate to 2.6.6.md
@@ -1,4 +1,4 @@
-## Migrating to 2.x.x
+## Migrating to 2.6.6
 
 - We have changed our formData format to match with the Web SDK. If you were using webhooks/inline code earlier with form submission, please check this migration guide:
 


### PR DESCRIPTION
## Kommunicate Android SDK 2.6.6
1) Added support to hide chat in helpcenter with "hideChatInHelpcenter" custom setting
2) Fixed formData getting double stringified.