### PR TITLE
[CM-1365] - add support to show conversation info view below topbar

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlEventManager.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlEventManager.java
@@ -8,6 +8,7 @@ import android.os.Message;
 import com.applozic.mobicomkit.feed.MqttMessageResponse;
 import com.applozic.mobicomkit.listners.AlMqttListener;
 import com.applozic.mobicomkit.listners.ApplozicUIListener;
+import com.applozic.mobicomkit.listners.KmConversationInfoListener;
 import com.applozic.mobicomkit.listners.KmStatusListener;
 import com.applozic.mobicommons.json.GsonUtils;
 
@@ -28,6 +29,7 @@ public class AlEventManager {
     private Map<String, AlMqttListener> mqttListenerMap;
     private Map<String, KmStatusListener> statusListenerMap;
     private KmPluginEventListener kmPluginEventListener;
+    private KmConversationInfoListener kmConversationInfoListener;
     private Handler uiHandler;
 
     public static AlEventManager getInstance() {
@@ -106,6 +108,16 @@ public class AlEventManager {
     public void registerPluginEventListener(KmPluginEventListener kmPluginEventListener) {
         this.kmPluginEventListener = kmPluginEventListener;
         initHandler();
+    }
+
+    public void registerConversationInfoListener(KmConversationInfoListener kmConversationInfoListener) {
+        this.kmConversationInfoListener = kmConversationInfoListener;
+    }
+
+    public void sendOnConversationInfoClicked() {
+        if(kmConversationInfoListener != null) {
+            kmConversationInfoListener.onConversationInfoClicked();
+        }
     }
 
     private void initHandler() {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/listners/KmConversationInfoListener.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/listners/KmConversationInfoListener.java
@@ -1,0 +1,5 @@
+package com.applozic.mobicomkit.listners;
+
+public interface KmConversationInfoListener {
+    void onConversationInfoClicked();
+}

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
@@ -1,0 +1,108 @@
+package io.kommunicate.preference;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
+import com.applozic.mobicommons.ApplozicService;
+import com.applozic.mobicommons.json.GsonUtils;
+
+import java.util.Map;
+
+public class KmConversationInfoSetting {
+    private static KmConversationInfoSetting kmConversationInfoSetting;
+    private static SharedPreferences sharedPreferences;
+    private static final String ENABLE_KM_CONVERSATION_INFO_VIEW = "ENABLE_KM_CONVERSATION_INFO_VIEW";
+    private static final String INFO_CONTENT = "INFO_CONTENT";
+    private static final String LEADING_IMAGE = "LEADING_IMAGE";
+    private static final String TRAILING_IMAGE = "TRAILING_IMAGE";
+    private static final String CONVERSATION_INFO_BACKGROUND_COLOR = "CONVERSATION_INFO_BACKGROUND_COLOR";
+    private static final String CONVERSATION_INFO_CONTENT_COLOR = "CONVERSATION_INFO_CONTENT_COLOR";
+
+    private KmConversationInfoSetting(Context context) {
+        sharedPreferences = context.getSharedPreferences(MobiComUserPreference.AL_USER_PREF_KEY, Context.MODE_PRIVATE);
+    }
+
+    public static KmConversationInfoSetting getInstance(Context context) {
+        if (kmConversationInfoSetting == null) {
+            kmConversationInfoSetting = new KmConversationInfoSetting(ApplozicService.getContext(context));
+        } else {
+            sharedPreferences = context.getSharedPreferences(MobiComUserPreference.AL_USER_PREF_KEY, Context.MODE_PRIVATE);
+        }
+        return kmConversationInfoSetting;
+    }
+
+    public KmConversationInfoSetting setInfoContent(String content) {
+        if(sharedPreferences != null) {
+            sharedPreferences.edit().putString(INFO_CONTENT, content).apply();
+        }
+        return this;
+    }
+    public String getInfoContent() {
+        if(sharedPreferences != null) {
+            return sharedPreferences.getString(INFO_CONTENT, "");
+        }
+        return null;
+    }
+
+    public KmConversationInfoSetting enableKmConversationInfo(boolean enable) {
+        if (sharedPreferences != null) {
+            sharedPreferences.edit().putBoolean(ENABLE_KM_CONVERSATION_INFO_VIEW, enable).apply();
+        }
+        return this;
+    }
+    public boolean isKmConversationInfoEnabled() {
+        if (sharedPreferences != null) {
+            return sharedPreferences.getBoolean(ENABLE_KM_CONVERSATION_INFO_VIEW, false);
+        }
+        return false;
+    }
+    public KmConversationInfoSetting setLeadingImageIcon(String iconName) {
+        if (sharedPreferences != null) {
+            sharedPreferences.edit().putString(LEADING_IMAGE, iconName).apply();
+        }
+        return this;
+    }
+    public String getLeadingImageIcon() {
+        if(sharedPreferences != null) {
+            return sharedPreferences.getString(LEADING_IMAGE, "");
+        }
+        return null;
+    }
+    public KmConversationInfoSetting setTrailingImageIcon(String iconName) {
+        if (sharedPreferences != null) {
+            sharedPreferences.edit().putString(TRAILING_IMAGE, iconName).apply();
+        }
+        return this;
+    }
+    public String getTrailingImageIcon() {
+        if(sharedPreferences != null) {
+            return sharedPreferences.getString(TRAILING_IMAGE, "");
+        }
+        return null;
+    }
+    public KmConversationInfoSetting setBackgroundColor(String backgroundColor) {
+        if (sharedPreferences != null) {
+            sharedPreferences.edit().putString(CONVERSATION_INFO_BACKGROUND_COLOR, backgroundColor).apply();
+        }
+        return this;
+    }
+    public String getBackgroundColor() {
+        if(sharedPreferences != null) {
+            return sharedPreferences.getString(CONVERSATION_INFO_BACKGROUND_COLOR, "");
+        }
+        return null;
+    }
+    public KmConversationInfoSetting setContentColor(String contentColor) {
+        if (sharedPreferences != null) {
+            sharedPreferences.edit().putString(CONVERSATION_INFO_CONTENT_COLOR, contentColor).apply();
+        }
+        return this;
+    }
+    public String getContentColo() {
+        if(sharedPreferences != null) {
+            return sharedPreferences.getString(CONVERSATION_INFO_CONTENT_COLOR, "");
+        }
+        return null;
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -148,6 +148,7 @@ import com.applozic.mobicomkit.uiwidgets.kommunicate.settings.KmSpeechToTextSett
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.DimensionsUtils;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmAwayView;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmConversationInfoView;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmFeedbackView;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmLanguageSlideView;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmRecordButton;
@@ -214,6 +215,7 @@ import io.kommunicate.callbacks.KmRemoveMemberCallback;
 import io.kommunicate.database.KmAutoSuggestionDatabase;
 import io.kommunicate.models.KmApiResponse;
 import io.kommunicate.models.KmFeedback;
+import io.kommunicate.preference.KmConversationInfoSetting;
 import io.kommunicate.services.KmClientService;
 import io.kommunicate.services.KmService;
 import io.kommunicate.utils.KmAppSettingPreferences;
@@ -374,6 +376,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     protected boolean isRecordOptionEnabled;
     protected boolean isUserGivingEmail;
     protected RelativeLayout conversationRootLayout;
+    protected KmConversationInfoView kmConversationInfoView;
 
     public static final int STANDARD_HEX_COLOR_CODE_LENGTH = 7;
     public static final int STANDARD_HEX_COLOR_CODE_WITH_OPACITY_LENGTH = 9;
@@ -507,7 +510,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (faqButtonLayout != null) {
             faqButtonLayout.setVisibility(View.GONE);
         }
-
+        //Conversation Info screen to show below Topbar
+        kmConversationInfoView = list.findViewById(R.id.km_conversation_info_view);
+        KmConversationInfoSetting infoSetting = KmConversationInfoSetting.getInstance(getContext());
+        if(infoSetting.isKmConversationInfoEnabled()) {
+            kmConversationInfoView.setVisibility(VISIBLE);
+            kmConversationInfoView.setupView(infoSetting.getInfoContent(), infoSetting.getContentColo(), infoSetting.getBackgroundColor(), infoSetting.getLeadingImageIcon(), infoSetting.getTrailingImageIcon());
+        }
 
         if (customToolbarLayout != null) {
             customToolbarLayout.setVisibility(View.GONE);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmConversationInfoView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmConversationInfoView.java
@@ -1,0 +1,75 @@
+package com.applozic.mobicomkit.uiwidgets.kommunicate.views;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.applozic.mobicomkit.broadcast.AlEventManager;
+import com.applozic.mobicomkit.uiwidgets.R;
+
+import androidx.annotation.Nullable;
+
+public class KmConversationInfoView extends LinearLayout {
+    private static final String TAG = "KmConversationInfoView";
+    private LinearLayout rootLinearLayout;
+    private Context context;
+    private ImageView leadingImageView;
+    private ImageView trailingImageView;
+    private TextView kmConversationInfoTextView;
+
+    public KmConversationInfoView(Context context) {
+        super(context);
+        init(inflateView(context));
+    }
+
+    public KmConversationInfoView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(inflateView(context));
+    }
+
+    public KmConversationInfoView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(inflateView(context));
+    }
+
+    public LinearLayout inflateView(Context context) {
+        this.context = context;
+        LayoutInflater layoutInflater = LayoutInflater.from(context);
+        rootLinearLayout = (LinearLayout) layoutInflater.inflate(R.layout.km_conversation_info_layout, this, true);
+        return rootLinearLayout;
+    }
+    private void init(View view) {
+        leadingImageView = view.findViewById(R.id.km_conversation_leading_image_view);
+        trailingImageView = view.findViewById(R.id.km_conversation_trailing_image_view);
+        kmConversationInfoTextView = view.findViewById(R.id.km_conversation_text_view);
+        setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                AlEventManager.getInstance().sendOnConversationInfoClicked();
+            }
+        });
+    }
+    public void setupView(String infoContent, String contentColor, String backgroundColor, String leadingImageIcon, String trailingImageIcon) {
+        if(!TextUtils.isEmpty(infoContent)) {
+            kmConversationInfoTextView.setText(infoContent);
+        }
+        if(!TextUtils.isEmpty(contentColor)) {
+            kmConversationInfoTextView.setTextColor(Color.parseColor(contentColor));
+        }
+        if(!TextUtils.isEmpty(backgroundColor)) {
+            rootLinearLayout.setBackgroundColor(Color.parseColor(backgroundColor));
+        }
+        if(!TextUtils.isEmpty(leadingImageIcon)) {
+            leadingImageView.setImageResource(getResources().getIdentifier(leadingImageIcon, "drawable", context.getPackageName()));
+        }
+        if(!TextUtils.isEmpty(trailingImageIcon)) {
+            trailingImageView.setImageResource(getResources().getIdentifier(trailingImageIcon, "drawable", context.getPackageName()));
+        }
+    }
+}

--- a/kommunicateui/src/main/res/drawable/km_files.xml
+++ b/kommunicateui/src/main/res/drawable/km_files.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14.59,2.59C14.21,2.21 13.7,2 13.17,2H6C4.9,2 4,2.9 4,4V20C4,21.1 4.89,22 5.99,22H18C19.1,22 20,21.1 20,20V8.83C20,8.3 19.79,7.79 19.41,7.42L14.59,2.59ZM15,18H9C8.45,18 8,17.55 8,17C8,16.45 8.45,16 9,16H15C15.55,16 16,16.45 16,17C16,17.55 15.55,18 15,18ZM15,14H9C8.45,14 8,13.55 8,13C8,12.45 8.45,12 9,12H15C15.55,12 16,12.45 16,13C16,13.55 15.55,14 15,14ZM13,8V3.5L18.5,9H14C13.45,9 13,8.55 13,8Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/kommunicateui/src/main/res/drawable/km_next.xml
+++ b/kommunicateui/src/main/res/drawable/km_next.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5.418,12.99L16.587,12.99L11.708,17.87C11.318,18.26 11.318,18.9 11.708,19.29C12.097,19.68 12.727,19.68 13.118,19.29L19.708,12.7C20.097,12.31 20.097,11.68 19.708,11.29L13.118,4.7C12.727,4.31 12.097,4.31 11.708,4.7C11.318,5.09 11.318,5.72 11.708,6.11L16.587,10.99L5.418,10.99C4.867,10.99 4.418,11.44 4.418,11.99C4.418,12.54 4.867,12.99 5.418,12.99Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/kommunicateui/src/main/res/layout/km_conversation_info_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_conversation_info_layout.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="fill_parent"
+    android:layout_height="50dp"
+    android:orientation="horizontal"
+    android:weightSum="3">
+
+        <ImageView
+            android:id="@+id/km_conversation_leading_image_view"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_weight="0.4"
+            app:srcCompat="@drawable/km_files"
+            android:layout_marginTop="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginBottom="10dp"/>
+
+        <TextView
+            android:id="@+id/km_conversation_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:letterSpacing="0.05"
+            android:layout_marginTop="10dp"
+            android:paddingBottom="10dp"
+            android:paddingTop="8dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text=""
+            android:textStyle="bold"
+            android:textSize="14sp"
+            android:layout_weight="2.2"
+            android:visibility="visible" />
+
+        <ImageView
+            android:id="@+id/km_conversation_trailing_image_view"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_weight="0.4"
+            app:srcCompat="@drawable/km_next"
+            android:layout_marginRight="10dp"
+            android:layout_marginEnd="10dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginStart="10dp"
+            android:layout_marginBottom="10dp"/>
+</LinearLayout>

--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -44,6 +44,12 @@
                 android:drawSelectorOnTop="true" />
         </FrameLayout>
 
+            <com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmConversationInfoView
+                android:id="@+id/km_conversation_info_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"/>
+
         <RelativeLayout
             android:layout_width="fill_parent"
             android:layout_height="0dp"


### PR DESCRIPTION
## Summary
- Added Support for conversation info view which will be added below to the navigation bar on conversation screen
- Added Event for conversation info tap action
- Added customisation for conversation info view

### Sample code to configure
``` java
KmConversationInfoSetting.getInstance(SplashScreenActivity.this)
                .setInfoContent("Check out your ITR Summary")
                .setContentColor("#FFFFFF")
                .setBackgroundColor("#05A3BF")
                .setTrailingImageIcon("km_next")
                .setLeadingImageIcon("km_files")
                .enableKmConversationInfo(true);
```


## Sample Images
<img src="https://user-images.githubusercontent.com/121423566/226895287-6bc8a896-f478-4075-9da4-64d7709d3683.png" width = 250 height = 450 />
