### PR TITLE
[CM-1371] - Add support to add top first message

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -169,6 +169,6 @@
   "restartConversationButtonVisibility": true,
   "hideChatInHelpcenter": true,
   "checkboxAsMultipleButton": true,
-  "staticTopMessage": "Messages in this chat are end-to-end encrypted. No one outside this chat can read them",
+  "staticTopMessage": "",
   "staticTopIcon": "km_lock"
 }

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -84,7 +84,7 @@
   "toolbarTitleColor": "#ffffff",
   "toolbarSubtitleColor": "#ffffff",
   "toolbarColor": "",
-  "statusBarColor": "",
+  "statusBarColor": "#ffffff",
   "richMessageThemeColor": "",
   "restrictMessageTypingWithBots": false,
   "enableFaqOption": [
@@ -168,5 +168,6 @@
   "javaScriptEnabled": true,
   "restartConversationButtonVisibility": true,
   "hideChatInHelpcenter": true,
-  "checkboxAsMultipleButton": true
+  "checkboxAsMultipleButton": true,
+  "staticTopMessage": true
 }

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -169,5 +169,6 @@
   "restartConversationButtonVisibility": true,
   "hideChatInHelpcenter": true,
   "checkboxAsMultipleButton": true,
-  "staticTopMessage": true
+  "staticTopMessage": "Messages in this chat are end-to-end encrypted. No one outside this chat can read them",
+  "staticTopIcon": "km_lock"
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -573,6 +573,12 @@ public class Message extends JsonMarker {
         return type.equals(MessageType.DATE_TEMP.value);
     }
 
+    public boolean isInitialFirstMessage() {
+        return type.equals(MessageType.INITIAL_FIRST_MESSAGE.value);
+    }
+    public void setInitialFirstMessage() {
+        this.type = MessageType.INITIAL_FIRST_MESSAGE.value;
+    }
     public void setTempDateType(short tempDateType) {
         this.type = tempDateType;
     }
@@ -804,7 +810,7 @@ public class Message extends JsonMarker {
         INBOX(Short.valueOf("0")), OUTBOX(Short.valueOf("1")), DRAFT(Short.valueOf("2")),
         OUTBOX_SENT_FROM_DEVICE(Short.valueOf("3")), MT_INBOX(Short.valueOf("4")),
         MT_OUTBOX(Short.valueOf("5")), CALL_INCOMING(Short.valueOf("6")), CALL_OUTGOING(Short.valueOf("7")),
-        DATE_TEMP(Short.valueOf("100"));
+        DATE_TEMP(Short.valueOf("100")), INITIAL_FIRST_MESSAGE(Short.valueOf("101"));
         private Short value;
 
         MessageType(Short c) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageListTask.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MessageListTask.java
@@ -80,7 +80,7 @@ public class MessageListTask extends AlAsyncTask<Void, List<Message>> {
                 List<Message> mergedList = new ArrayList<>();
 
                 if (messageList != null && !messageList.isEmpty()) {
-
+                    mergedList.add(getInitialTopMessage());
                     mergedList.add(getDateMessage(messageList.get(0)));
 
                     for (int i = 0; i < messageList.size(); i++) {
@@ -126,5 +126,11 @@ public class MessageListTask extends AlAsyncTask<Void, List<Message>> {
         firstDateMessage.setTempDateType(Short.valueOf("100"));
         firstDateMessage.setCreatedAtTime(message.getCreatedAtTime());
         return firstDateMessage;
+    }
+
+    private Message getInitialTopMessage() {
+        Message firstMessage = new Message();
+        firstMessage.setInitialFirstMessage();
+        return firstMessage;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -141,6 +141,11 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean javaScriptEnabled = true;
     private boolean hideChatInHelpcenter = true;
     private boolean checkboxAsMultipleButton = false;
+    private boolean staticTopMessage = true;
+
+    public boolean isStaticTopMessage() {
+        return staticTopMessage;
+    }
 
     public boolean isCheckboxAsMultipleButton() {
         return checkboxAsMultipleButton;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -141,10 +141,15 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean javaScriptEnabled = true;
     private boolean hideChatInHelpcenter = true;
     private boolean checkboxAsMultipleButton = false;
-    private boolean staticTopMessage = true;
+    private String staticTopMessage = "";
+    private String staticTopIcon = "";
 
-    public boolean isStaticTopMessage() {
+    public String getStaticTopMessage() {
         return staticTopMessage;
+    }
+
+    public String getStaticTopIcon() {
+        return staticTopIcon;
     }
 
     public boolean isCheckboxAsMultipleButton() {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -223,7 +223,6 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         this.contactService = new AppContactService(context);
         this.imageCache = ImageCache.getInstance(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         this.messageList = messageList;
-//        this.messageList.add(0, messageList.get(1));
         geoApiKey = Applozic.getInstance(context).getGeoApiKey();
         contactImageLoader = new ImageLoader(context, ImageUtils.getLargestScreenDimension((Activity) context)) {
             @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -16,6 +16,7 @@ import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.util.Pair;
 import android.util.TypedValue;
 import android.view.ContextMenu;
@@ -39,6 +40,7 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
@@ -221,6 +223,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         this.contactService = new AppContactService(context);
         this.imageCache = ImageCache.getInstance(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         this.messageList = messageList;
+//        this.messageList.add(0, messageList.get(1));
         geoApiKey = Applozic.getInstance(context).getGeoApiKey();
         contactImageLoader = new ImageLoader(context, ImageUtils.getLargestScreenDimension((Activity) context)) {
             @Override
@@ -306,6 +309,9 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                 mainThreadView = layoutInflater.inflate(R.layout.km_received_message_list_view, parent, false);
             }
             return new MyViewHolder(mainThreadView);
+        } else if(viewType == 7) {
+            View feedbackViewHolder = layoutInflater.inflate(R.layout.km_static_top_message, parent, false);
+            return new StaticMessageHolder(feedbackViewHolder);
         }
         if(useInnerTimeStampDesign) {
             view = layoutInflater.inflate(R.layout.mobicom_sent_message_list_view, parent, false);
@@ -322,7 +328,11 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         final Message message = getItem(position);
 
         try {
-            if (type == 2) {
+            if (type == 7) {
+                StaticMessageHolder messageHolder = (StaticMessageHolder) holder;
+
+                // static message
+            } else if (type == 2) {
                 MyViewHolder2 myViewHolder2 = (MyViewHolder2) holder;
                 SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MMM dd, yyyy");
                 SimpleDateFormat simpleDateFormatDay = new SimpleDateFormat("EEEE");
@@ -1472,6 +1482,9 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         if (message == null) {
             return 0;
         }
+        if(message.isInitialFirstMessage()) {
+            return 7;
+        }
         if (message.isTempDateType()) {
             return 2;
         }
@@ -1488,6 +1501,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         if (message.isVideoCallMessage()) {
             return 5;
         }
+
 
         return message.isTypeOutbox() ? 1 : 0;
     }
@@ -1807,6 +1821,20 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
             imageViewFeedbackRating = itemView.findViewById(R.id.idRatingImage);
             scrollViewFeedbackCommentWrap = itemView.findViewById(R.id.idCommentScrollView);
             textViewFeedbackText = itemView.findViewById(R.id.idFeedbackRateText);
+        }
+    }
+
+    static class StaticMessageHolder extends RecyclerView.ViewHolder {
+        TextView textViewFeedbackComment;
+        ImageView imageViewFeedbackRating;
+        ScrollView scrollViewFeedbackCommentWrap;
+        TextView textViewFeedbackText;
+        public StaticMessageHolder(@NonNull View itemView) {
+            super(itemView);
+//            textViewFeedbackComment = itemView.findViewById(R.id.idFeedbackComment);
+//            imageViewFeedbackRating = itemView.findViewById(R.id.idRatingImage);
+//            scrollViewFeedbackCommentWrap = itemView.findViewById(R.id.idCommentScrollView);
+//            textViewFeedbackText = itemView.findViewById(R.id.idFeedbackRateText);
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -330,8 +330,11 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         try {
             if (type == 7) {
                 StaticMessageHolder messageHolder = (StaticMessageHolder) holder;
+                messageHolder.topMessageTextView.setText(alCustomizationSettings.getStaticTopMessage());
+                if(!TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage())) {
+                    messageHolder.topMessageImageView.setImageResource(context.getResources().getIdentifier(alCustomizationSettings.getStaticTopIcon(), "drawable", context.getPackageName()));
+                }
 
-                // static message
             } else if (type == 2) {
                 MyViewHolder2 myViewHolder2 = (MyViewHolder2) holder;
                 SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MMM dd, yyyy");
@@ -1825,16 +1828,14 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     }
 
     static class StaticMessageHolder extends RecyclerView.ViewHolder {
-        TextView textViewFeedbackComment;
-        ImageView imageViewFeedbackRating;
-        ScrollView scrollViewFeedbackCommentWrap;
-        TextView textViewFeedbackText;
+        TextView topMessageTextView;
+        ImageView topMessageImageView;
+
         public StaticMessageHolder(@NonNull View itemView) {
             super(itemView);
-//            textViewFeedbackComment = itemView.findViewById(R.id.idFeedbackComment);
-//            imageViewFeedbackRating = itemView.findViewById(R.id.idRatingImage);
-//            scrollViewFeedbackCommentWrap = itemView.findViewById(R.id.idCommentScrollView);
-//            textViewFeedbackText = itemView.findViewById(R.id.idFeedbackRateText);
+            topMessageImageView = itemView.findViewById(R.id.top_message_image_view);
+            topMessageTextView = itemView.findViewById(R.id.top_message_text_view);
+
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3917,7 +3917,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         if (message.isTempDateType()) {
                             continue;
                         }
-                        endTime = messageList.get(alCustomizationSettings.isStaticTopMessage() ? 1 : 0).getCreatedAtTime();
+                        endTime = messageList.get(!TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage()) ? 1 : 0).getCreatedAtTime();
                         break;
                     }
                     nextMessageList = conversationService.getMessages(null, endTime, contact, channel, conversationId, false, !TextUtils.isEmpty(messageSearchString));
@@ -3934,10 +3934,10 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
                     Message firstMessage = new Message();
                     firstMessage.setInitialFirstMessage();
-                    if(initial && alCustomizationSettings.isStaticTopMessage() && !messageList.contains(firstMessage)) {
+                    if(initial && !TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage()) && !messageList.contains(firstMessage)) {
                         createAtMessage.add(firstMessage);
 //                        createAtMessage.add(firstMessage);
-                    } else if(!initial && alCustomizationSettings.isStaticTopMessage()) {
+                    } else if(!initial && !TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage())) {
                         createAtMessage.add(firstMessage);
                         messageList.remove(firstMessage);
                     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -29,7 +29,6 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.KeyEvent;
@@ -493,7 +492,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         recyclerViewPositionHelper = new RecyclerViewPositionHelper(recyclerView, linearLayoutManager);
         ((ConversationActivity) getActivity()).setChildFragmentLayoutBGToTransparent();
         messageList = new ArrayList<Message>();
-//        messageList.add(new Message());
         multimediaPopupGrid = (GridView) list.findViewById(R.id.mobicom_multimedia_options1);
         textViewCharLimitMessage = list.findViewById(R.id.botCharLimitTextView);
         loggedInUserRole = MobiComUserPreference.getInstance(ApplozicService.getContext(getContext())).getUserRoleType();
@@ -1959,14 +1957,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
 
         clearList();
-//        messageList.add(new Message());
         updateTitle(contact, channel);
         swipeLayout.setEnabled(true);
         loadMore = true;
         if (selfDestructMessageSpinner != null) {
             selfDestructMessageSpinner.setSelection(0);
         }
-        Log.e("detailedgg", String.valueOf(messageList.size()));
         recyclerDetailConversationAdapter = getConversationAdapter(getActivity(),
                 R.layout.mobicom_message_row_view, messageList, contact, channel, messageIntentClass, emojiIconHandler);
         recyclerDetailConversationAdapter.setAlCustomizationSettings(alCustomizationSettings);
@@ -3936,7 +3932,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     firstMessage.setInitialFirstMessage();
                     if(initial && !TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage()) && !messageList.contains(firstMessage)) {
                         createAtMessage.add(firstMessage);
-//                        createAtMessage.add(firstMessage);
                     } else if(!initial && !TextUtils.isEmpty(alCustomizationSettings.getStaticTopMessage())) {
                         createAtMessage.add(firstMessage);
                         messageList.remove(firstMessage);
@@ -4024,7 +4019,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 }
             } else if (!nextMessageList.isEmpty()) {
                 linearLayoutManager.setStackFromEnd(false);
-                // nextMessageList should be empty on refresh
                 messageList.addAll(0, nextMessageList);
                 linearLayoutManager.scrollToPositionWithOffset(nextMessageList.size() - 1, 0);
             }

--- a/kommunicateui/src/main/res/drawable/km_lock.xml
+++ b/kommunicateui/src/main/res/drawable/km_lock.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,8H17V6C17,3.24 14.76,1 12,1C9.24,1 7,3.24 7,6V8H6C4.9,8 4,8.9 4,10V20C4,21.1 4.9,22 6,22H18C19.1,22 20,21.1 20,20V10C20,8.9 19.1,8 18,8ZM12,17C10.9,17 10,16.1 10,15C10,13.9 10.9,13 12,13C13.1,13 14,13.9 14,15C14,16.1 13.1,17 12,17ZM9,8V6C9,4.34 10.34,3 12,3C13.66,3 15,4.34 15,6V8H9Z"
+      android:fillColor="#112222"/>
+</vector>

--- a/kommunicateui/src/main/res/drawable/km_top_first_message.xml
+++ b/kommunicateui/src/main/res/drawable/km_top_first_message.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-
-    <!-- view background color -->
     <solid android:color="#E7EAF2" />
-
-    <!-- view border color and width -->
     <stroke
         android:color="#E7EAF2" />
-
-    <!-- If you want to add some padding -->
-    <!-- Here is the corner radius -->
     <corners
         android:radius="8dp" />
 </shape>

--- a/kommunicateui/src/main/res/drawable/km_top_first_message.xml
+++ b/kommunicateui/src/main/res/drawable/km_top_first_message.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <!-- view background color -->
+    <solid android:color="#E7EAF2" />
+
+    <!-- view border color and width -->
+    <stroke
+        android:color="#E7EAF2" />
+
+    <!-- If you want to add some padding -->
+    <!-- Here is the corner radius -->
+    <corners
+        android:radius="8dp" />
+</shape>

--- a/kommunicateui/src/main/res/layout/km_static_top_message.xml
+++ b/kommunicateui/src/main/res/layout/km_static_top_message.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="10dp"
+    android:layout_marginStart="10dp"
+    android:layout_marginEnd="10dp"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/askEmailLinearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/km_top_first_message"
+        android:paddingBottom="10dp"
+        android:paddingTop="10dp"
+        android:visibility="visible"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        android:weightSum="2">
+
+        <ImageView
+            android:id="@+id/askEmailImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.7"
+            android:paddingStart="10dp"
+            android:paddingEnd="10dp"
+            app:srcCompat="@drawable/km_mail_default"/>
+
+        <TextView
+            android:id="@+id/askEmailTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:letterSpacing="0.05"
+            android:lineSpacingExtra="5dp"
+            android:paddingBottom="10dp"
+            android:paddingTop="8dp"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text="Messages in this chat are end-to-end encrypted. \nNo one outside this chat can read or listen to them."
+            android:textSize="14sp"
+            android:layout_weight="1.3"
+            android:visibility="visible" />
+
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/kommunicateui/src/main/res/layout/km_static_top_message.xml
+++ b/kommunicateui/src/main/res/layout/km_static_top_message.xml
@@ -2,16 +2,15 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="10dp"
-    android:layout_marginStart="10dp"
-    android:layout_marginEnd="10dp"
-    android:orientation="vertical">
+    android:layout_marginTop="15dp"
+    android:layout_marginStart="15dp"
+    android:layout_marginEnd="15dp"
+    android:orientation="horizontal">
 
     <LinearLayout
-        android:id="@+id/askEmailLinearLayout"
+        android:id="@+id/top_message_root_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/km_top_first_message"
@@ -20,20 +19,20 @@
         android:visibility="visible"
         android:paddingStart="5dp"
         android:paddingEnd="5dp"
+        android:orientation="horizontal"
         android:weightSum="2">
-
         <ImageView
-            android:id="@+id/askEmailImageView"
+            android:id="@+id/top_message_image_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1.5"
+            android:layout_weight="1.8"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
-
+            android:paddingTop="8dp"
+            android:paddingBottom="25dp"
             app:srcCompat="@drawable/km_lock"/>
-
         <TextView
-            android:id="@+id/askEmailTextView"
+            android:id="@+id/top_message_text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:letterSpacing="0.05"
@@ -44,10 +43,7 @@
             android:paddingEnd="5dp"
             android:text="Messages in this chat are end-to-end encrypted. \nNo one outside this chat can read or listen to them."
             android:textSize="14sp"
-            android:layout_weight="0.5"
+            android:layout_weight="0.2"
             android:visibility="visible" />
-
-
     </LinearLayout>
-
 </LinearLayout>

--- a/kommunicateui/src/main/res/layout/km_static_top_message.xml
+++ b/kommunicateui/src/main/res/layout/km_static_top_message.xml
@@ -24,12 +24,13 @@
 
         <ImageView
             android:id="@+id/askEmailImageView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="0.7"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1.5"
             android:paddingStart="10dp"
             android:paddingEnd="10dp"
-            app:srcCompat="@drawable/km_mail_default"/>
+
+            app:srcCompat="@drawable/km_lock"/>
 
         <TextView
             android:id="@+id/askEmailTextView"
@@ -43,7 +44,7 @@
             android:paddingEnd="5dp"
             android:text="Messages in this chat are end-to-end encrypted. \nNo one outside this chat can read or listen to them."
             android:textSize="14sp"
-            android:layout_weight="1.3"
+            android:layout_weight="0.5"
             android:visibility="visible" />
 
 


### PR DESCRIPTION
## Summary:
- To add a top message, which will be part of the recycler view, meaning it could be scrolled out of view

## How to implement?
- Add this to custom settings json file:
```json
"staticTopMessage": "Messages in this chat are encrypted. No one outside this chat can read them",
 "staticTopIcon": "km_lock"
```

- By default, the top message will not show

![image](https://user-images.githubusercontent.com/121423566/229163594-f504c8fd-5dd9-4714-8dcd-4c2e0d75311f.png)
