### PR TITLE
[CM-1368] - Support for custom toolbar subtitle

### DIFF
--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -33,6 +33,7 @@ import io.kommunicate.KmConversationHelper;
 import io.kommunicate.KmException;
 import io.kommunicate.app.BuildConfig;
 import io.kommunicate.callbacks.KmCallback;
+import io.kommunicate.preference.KmConversationInfoSetting;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.Kommunicate;
 import io.kommunicate.app.R;
@@ -197,6 +198,7 @@ public class MainActivity extends AppCompatActivity {
         Kommunicate.login(MainActivity.this, user, new KMLoginHandler() {
             @Override
             public void onSuccess(RegistrationResponse registrationResponse, Context context) {
+
                 if (KMUser.RoleType.USER_ROLE.getValue().equals(registrationResponse.getRoleType())) {
                     ApplozicClient.getInstance(context).hideActionMessages(true).setMessageMetaData(null);
                 } else {
@@ -204,6 +206,13 @@ public class MainActivity extends AppCompatActivity {
                     metadata.put("skipBot", "true");
                     ApplozicClient.getInstance(context).hideActionMessages(false).setMessageMetaData(metadata);
                 }
+
+                //To enable the new Custom toolbar Design
+                KmConversationInfoSetting.getInstance(getApplicationContext()).enableCustomToolbarSubtitleDesign(true);
+                //Setting up the agent experience
+                KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarAgentExperience("16 years of experience");
+                //Setting up the agent rating
+                KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarSubtitleRating((float) 3.5);
 
                 try {
                     KmConversationHelper.openConversation(context, true, null, new KmCallback() {

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -207,13 +207,6 @@ public class MainActivity extends AppCompatActivity {
                     ApplozicClient.getInstance(context).hideActionMessages(false).setMessageMetaData(metadata);
                 }
 
-                //To enable the new Custom toolbar Design
-                KmConversationInfoSetting.getInstance(getApplicationContext()).enableCustomToolbarSubtitleDesign(true);
-                //Setting up the agent experience
-                KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarAgentExperience("16 years of experience");
-                //Setting up the agent rating
-                KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarSubtitleRating((float) 3.5);
-
                 try {
                     KmConversationHelper.openConversation(context, true, null, new KmCallback() {
                         @Override

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -194,11 +194,9 @@ public class MainActivity extends AppCompatActivity {
         if (!TextUtils.isEmpty(password)) {
             user.setPassword(password);
         }
-
         Kommunicate.login(MainActivity.this, user, new KMLoginHandler() {
             @Override
             public void onSuccess(RegistrationResponse registrationResponse, Context context) {
-
                 if (KMUser.RoleType.USER_ROLE.getValue().equals(registrationResponse.getRoleType())) {
                     ApplozicClient.getInstance(context).hideActionMessages(true).setMessageMetaData(null);
                 } else {

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
@@ -18,12 +18,9 @@ public class KmConversationInfoSetting {
     private static final String TRAILING_IMAGE = "TRAILING_IMAGE";
     private static final String CONVERSATION_INFO_BACKGROUND_COLOR = "CONVERSATION_INFO_BACKGROUND_COLOR";
     private static final String CONVERSATION_INFO_CONTENT_COLOR = "CONVERSATION_INFO_CONTENT_COLOR";
-
     private static final String AGENT_EXPERIENCE = "AGENT_EXPERIENCE";
     private static final String AGENT_RATING = "AGENT_RATING";
     private static final String NEW_TOOLBAR_ENABLED = "NEW_TOOLBAR_ENABLED";
-
-
     private KmConversationInfoSetting(Context context) {
         sharedPreferences = context.getSharedPreferences(MobiComUserPreference.AL_USER_PREF_KEY, Context.MODE_PRIVATE);
     }

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
@@ -19,6 +19,11 @@ public class KmConversationInfoSetting {
     private static final String CONVERSATION_INFO_BACKGROUND_COLOR = "CONVERSATION_INFO_BACKGROUND_COLOR";
     private static final String CONVERSATION_INFO_CONTENT_COLOR = "CONVERSATION_INFO_CONTENT_COLOR";
 
+    private static final String AGENT_EXPERIENCE = "AGENT_EXPERIENCE";
+    private static final String AGENT_RATING = "AGENT_RATING";
+    private static final String NEW_TOOLBAR_ENABLED = "NEW_TOOLBAR_ENABLED";
+
+
     private KmConversationInfoSetting(Context context) {
         sharedPreferences = context.getSharedPreferences(MobiComUserPreference.AL_USER_PREF_KEY, Context.MODE_PRIVATE);
     }
@@ -102,6 +107,49 @@ public class KmConversationInfoSetting {
     public String getContentColo() {
         if(sharedPreferences != null) {
             return sharedPreferences.getString(CONVERSATION_INFO_CONTENT_COLOR, "");
+        }
+        return null;
+    }
+
+    public KmConversationInfoSetting enableCustomToolbarSubtitleDesign(boolean enable){
+        if(sharedPreferences != null){
+            sharedPreferences.edit().putBoolean(NEW_TOOLBAR_ENABLED,enable).commit();
+        }
+        return this;
+    }
+
+    public boolean isCustomToolbarSubtitleDesign(){
+        if(sharedPreferences != null ){
+            return sharedPreferences.getBoolean(NEW_TOOLBAR_ENABLED, false);
+
+        }
+        return false;
+    }
+
+    public KmConversationInfoSetting setToolbarAgentExperience(String experience){
+        if(sharedPreferences != null ){
+            sharedPreferences.edit().putString(AGENT_EXPERIENCE,experience).commit();
+        }
+        return this;
+    }
+
+    public String getToolbarAgentExperience() {
+        if (sharedPreferences != null) {
+            return sharedPreferences.getString(AGENT_EXPERIENCE, null);
+        }
+        return null;
+    }
+
+    public KmConversationInfoSetting setToolbarSubtitleRating(Float rating){
+        if(sharedPreferences != null){
+            sharedPreferences.edit().putFloat(AGENT_RATING,rating).commit();
+        }
+        return this;
+    }
+
+    public Float getToolbarSubtitleRating(){
+        if (sharedPreferences != null){
+            return sharedPreferences.getFloat(AGENT_RATING,0.0F);
         }
         return null;
     }

--- a/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
+++ b/kommunicate/src/main/java/io/kommunicate/preference/KmConversationInfoSetting.java
@@ -132,7 +132,7 @@ public class KmConversationInfoSetting {
 
     public String getToolbarAgentExperience() {
         if (sharedPreferences != null) {
-            return sharedPreferences.getString(AGENT_EXPERIENCE, null);
+            return sharedPreferences.getString(AGENT_EXPERIENCE, "");
         }
         return null;
     }
@@ -146,7 +146,7 @@ public class KmConversationInfoSetting {
 
     public Float getToolbarSubtitleRating(){
         if (sharedPreferences != null){
-            return sharedPreferences.getFloat(AGENT_RATING,0.0F);
+            return sharedPreferences.getFloat(AGENT_RATING,-1.0F);
         }
         return null;
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -56,7 +56,6 @@ import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.api.conversation.Message;
 import com.applozic.mobicomkit.api.conversation.MessageIntentService;
 import com.applozic.mobicomkit.api.conversation.MobiComMessageService;
-import com.applozic.mobicomkit.api.conversation.SyncCallService;
 import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
 import com.applozic.mobicomkit.api.conversation.service.ConversationService;
 import com.applozic.mobicomkit.api.people.UserIntentService;
@@ -66,7 +65,6 @@ import com.applozic.mobicomkit.broadcast.ConnectivityReceiver;
 import com.applozic.mobicomkit.channel.service.ChannelService;
 import com.applozic.mobicomkit.contact.AppContactService;
 import com.applozic.mobicomkit.contact.BaseContactService;
-import com.applozic.mobicomkit.contact.database.ContactDatabase;
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.KommunicateSetting;
 import com.applozic.mobicomkit.uiwidgets.R;
@@ -428,6 +426,8 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
         mActionBar.setDisplayHomeAsUpEnabled(true);
         mActionBar.setHomeButtonEnabled(true);
+        //To change the color of home button in action bar by setting up the custom drawable
+        mActionBar.setHomeAsUpIndicator(R.drawable.km_home);
 
         kmAttachmentsController = new KmAttachmentsController(this);
 
@@ -802,7 +802,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
             }
         }
         else if(id == android.R.id.home) {
-                AlEventManager.getInstance().sendOnBackButtonClicked(getSupportFragmentManager().getBackStackEntryCount() > 1);
+            AlEventManager.getInstance().sendOnBackButtonClicked(getSupportFragmentManager().getBackStackEntryCount() > 1);
         }
         return false;
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1008,17 +1008,16 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             starDrawable.setBounds(0,0,40,40);
             ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
             String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience();
-            String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
+            Float agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating();
             if(!TextUtils.isEmpty(experienceText)){
                 experienceTextview.setVisibility(VISIBLE);
                 StringBuilder stringBuilder = new StringBuilder(experienceText.trim());
-                stringBuilder.append(" | ");
-                experienceText = stringBuilder.toString();
-                experienceTextview.setText(experienceText);
+                stringBuilder.append(agentRating == -1.0F ? "" : " | ");
+                experienceTextview.setText(stringBuilder);
             }
-            if(!TextUtils.isEmpty(agentRating)){
+            if(agentRating != -1.0F){
                 ratingTextview.setVisibility(VISIBLE);
-                ratingTextview.setText(agentRating);
+                ratingTextview.setText(agentRating.toString());
             }
         }
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -999,7 +999,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     public void newCustomToolbarDesign(){
-
         isCustomToolbarSubtitleDesign = KmConversationInfoSetting.getInstance(getContext()).isCustomToolbarSubtitleDesign();
 
         if(isCustomToolbarSubtitleDesign){
@@ -1007,7 +1006,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             TextView experienceTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_experience);
             ratingTextview.setVisibility(VISIBLE);
             experienceTextview.setVisibility(VISIBLE);
-
             Drawable starDrawable = getResources().getDrawable(R.drawable.star);
             starDrawable.setBounds(0,0,40,40);
             ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
@@ -1017,7 +1015,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             experienceText = stringBuilder.toString();
             if(!TextUtils.isEmpty(experienceText)){
                 experienceTextview.setText(experienceText);
-
             }
             String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
             ratingTextview.setText(agentRating);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -381,7 +381,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     public static final int STANDARD_HEX_COLOR_CODE_LENGTH = 7;
     public static final int STANDARD_HEX_COLOR_CODE_WITH_OPACITY_LENGTH = 9;
 
-
+    protected boolean isCustomToolbarSubtitleDesign;
     public void setEmojiIconHandler(EmojiconHandler emojiIconHandler) {
         this.emojiIconHandler = emojiIconHandler;
     }
@@ -522,6 +522,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             customToolbarLayout.setVisibility(View.GONE);
             toolbarImageView = customToolbarLayout.findViewById(R.id.conversation_contact_photo);
             toolbarSubtitleText = customToolbarLayout.findViewById(R.id.toolbar_subtitle);
+
+            isCustomToolbarSubtitleDesign = KmConversationInfoSetting.getInstance(getContext()).isCustomToolbarSubtitleDesign();
+            if(isCustomToolbarSubtitleDesign){
+                newCustomToolbarDesign();
+            }
+
+
             if (fontManager != null && fontManager.getToolbarSubtitleFont() != null) {
                 toolbarSubtitleText.setTypeface(fontManager.getToolbarSubtitleFont());
             }
@@ -996,6 +1003,25 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         };
 
         return list;
+    }
+
+    public void newCustomToolbarDesign(){
+
+        TextView ratingTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_rating);
+        TextView experienceTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_experience);
+        ratingTextview.setVisibility(VISIBLE);
+        experienceTextview.setVisibility(VISIBLE);
+
+        Drawable starDrawable = getResources().getDrawable(R.drawable.star);
+        starDrawable.setBounds(0,0,33,33);
+        ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
+        String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience().trim();
+            if(!TextUtils.isEmpty(experienceText)){
+        experienceTextview.setText(experienceText);
+        experienceTextview.append(" | ");
+            }
+        String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
+        ratingTextview.setText(agentRating);
     }
 
     public void handleSendAndRecordButtonView(boolean isSendButtonVisible) {
@@ -3385,7 +3411,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             }
             if (User.RoleType.BOT.getValue().equals(contact.getRoleType())) {
                 toolbarSubtitleText.setText(ApplozicService.getContext(getContext()).getString(R.string.online));
-                toolbarSubtitleText.setVisibility(VISIBLE);
+                toolbarSubtitleText.setVisibility(isCustomToolbarSubtitleDesign ? View.GONE : View.VISIBLE);
                 setStatusDots(true, true);
                 return;
             }
@@ -3395,19 +3421,19 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 } else {
                     toolbarSubtitleText.setText(R.string.away);
                 }
-                toolbarSubtitleText.setVisibility(VISIBLE);
+                toolbarSubtitleText.setVisibility(isCustomToolbarSubtitleDesign ? View.GONE : View.VISIBLE);
             } else {
                 if (User.RoleType.USER_ROLE.getValue().equals(contact.getRoleType())) {
                     if (contact.getLastSeenAt() > 0) {
                         if (getActivity() != null) {
-                            toolbarSubtitleText.setVisibility(VISIBLE);
+                            toolbarSubtitleText.setVisibility(isCustomToolbarSubtitleDesign ? View.GONE : View.VISIBLE);
                             toolbarSubtitleText.setText(ApplozicService.getContext(getContext()).getString(R.string.subtitle_last_seen_at_time) + " " + DateUtils.getDateAndTimeForLastSeen(ApplozicService.getContext(getContext()), contact.getLastSeenAt(), R.string.JUST_NOW, R.plurals.MINUTES_AGO, R.plurals.HOURS_AGO, R.string.YESTERDAY));
                         }
                     } else {
                         toolbarSubtitleText.setVisibility(View.GONE);
                     }
                 } else {
-                    toolbarSubtitleText.setVisibility(View.VISIBLE);
+                    toolbarSubtitleText.setVisibility(isCustomToolbarSubtitleDesign ? View.GONE : View.VISIBLE);
                     toolbarSubtitleText.setText(R.string.offline);
                 }
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1004,23 +1004,24 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if(isCustomToolbarSubtitleDesign){
             TextView ratingTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_rating);
             TextView experienceTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_experience);
-            ratingTextview.setVisibility(VISIBLE);
-            experienceTextview.setVisibility(VISIBLE);
             Drawable starDrawable = getResources().getDrawable(R.drawable.star);
             starDrawable.setBounds(0,0,40,40);
             ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
-            String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience().trim();
-            StringBuilder stringBuilder = new StringBuilder(experienceText);
-            stringBuilder.append(" | ");
-            experienceText = stringBuilder.toString();
+            String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience();
+            String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
             if(!TextUtils.isEmpty(experienceText)){
+                experienceTextview.setVisibility(VISIBLE);
+                StringBuilder stringBuilder = new StringBuilder(experienceText.trim());
+                stringBuilder.append(" | ");
+                experienceText = stringBuilder.toString();
                 experienceTextview.setText(experienceText);
             }
-            String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
-            ratingTextview.setText(agentRating);
+            if(!TextUtils.isEmpty(agentRating)){
+                ratingTextview.setVisibility(VISIBLE);
+                ratingTextview.setText(agentRating);
+            }
         }
     }
-
     public void handleSendAndRecordButtonView(boolean isSendButtonVisible) {
         boolean showRecordButton = (alCustomizationSettings != null
                 && alCustomizationSettings.getAttachmentOptions() != null

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -1009,12 +1009,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             experienceTextview.setVisibility(VISIBLE);
 
             Drawable starDrawable = getResources().getDrawable(R.drawable.star);
-            starDrawable.setBounds(0,0,33,33);
+            starDrawable.setBounds(0,0,40,40);
             ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
             String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience().trim();
+            StringBuilder stringBuilder = new StringBuilder(experienceText);
+            stringBuilder.append(" | ");
+            experienceText = stringBuilder.toString();
             if(!TextUtils.isEmpty(experienceText)){
                 experienceTextview.setText(experienceText);
-                experienceTextview.append(" | ");
+
             }
             String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
             ratingTextview.setText(agentRating);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -377,11 +377,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     protected boolean isUserGivingEmail;
     protected RelativeLayout conversationRootLayout;
     protected KmConversationInfoView kmConversationInfoView;
-
     public static final int STANDARD_HEX_COLOR_CODE_LENGTH = 7;
     public static final int STANDARD_HEX_COLOR_CODE_WITH_OPACITY_LENGTH = 9;
-
-    protected boolean isCustomToolbarSubtitleDesign;
+    public boolean isCustomToolbarSubtitleDesign;
     public void setEmojiIconHandler(EmojiconHandler emojiIconHandler) {
         this.emojiIconHandler = emojiIconHandler;
     }
@@ -522,13 +520,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             customToolbarLayout.setVisibility(View.GONE);
             toolbarImageView = customToolbarLayout.findViewById(R.id.conversation_contact_photo);
             toolbarSubtitleText = customToolbarLayout.findViewById(R.id.toolbar_subtitle);
-
-            isCustomToolbarSubtitleDesign = KmConversationInfoSetting.getInstance(getContext()).isCustomToolbarSubtitleDesign();
-            if(isCustomToolbarSubtitleDesign){
-                newCustomToolbarDesign();
-            }
-
-
+            //To set new custom toolbar design
+            newCustomToolbarDesign();
             if (fontManager != null && fontManager.getToolbarSubtitleFont() != null) {
                 toolbarSubtitleText.setTypeface(fontManager.getToolbarSubtitleFont());
             }
@@ -1007,21 +1000,25 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
     public void newCustomToolbarDesign(){
 
-        TextView ratingTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_rating);
-        TextView experienceTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_experience);
-        ratingTextview.setVisibility(VISIBLE);
-        experienceTextview.setVisibility(VISIBLE);
+        isCustomToolbarSubtitleDesign = KmConversationInfoSetting.getInstance(getContext()).isCustomToolbarSubtitleDesign();
 
-        Drawable starDrawable = getResources().getDrawable(R.drawable.star);
-        starDrawable.setBounds(0,0,33,33);
-        ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
-        String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience().trim();
+        if(isCustomToolbarSubtitleDesign){
+            TextView ratingTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_rating);
+            TextView experienceTextview = customToolbarLayout.findViewById(R.id.toolbar_agent_experience);
+            ratingTextview.setVisibility(VISIBLE);
+            experienceTextview.setVisibility(VISIBLE);
+
+            Drawable starDrawable = getResources().getDrawable(R.drawable.star);
+            starDrawable.setBounds(0,0,33,33);
+            ratingTextview.setCompoundDrawables(starDrawable,null,null,null);
+            String experienceText  = KmConversationInfoSetting.getInstance(getContext()).getToolbarAgentExperience().trim();
             if(!TextUtils.isEmpty(experienceText)){
-        experienceTextview.setText(experienceText);
-        experienceTextview.append(" | ");
+                experienceTextview.setText(experienceText);
+                experienceTextview.append(" | ");
             }
-        String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
-        ratingTextview.setText(agentRating);
+            String agentRating = KmConversationInfoSetting.getInstance(getContext()).getToolbarSubtitleRating().toString();
+            ratingTextview.setText(agentRating);
+        }
     }
 
     public void handleSendAndRecordButtonView(boolean isSendButtonVisible) {

--- a/kommunicateui/src/main/res/drawable/km_home.xml
+++ b/kommunicateui/src/main/res/drawable/km_home.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/km_back_button_colour"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M17.77,3.77l-1.77,-1.77l-10,10l10,10l1.77,-1.77l-8.23,-8.23z"/>
+</vector>

--- a/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
@@ -127,7 +127,7 @@
                 android:id="@+id/toolbar_agent_experience"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="2 year of experience  "
+                android:text="@string/agent_experience"
                 android:fontFamily="sans-serif-light"
                 android:textColor="@color/km_white_color"
                 android:textSize="12sp"
@@ -137,15 +137,13 @@
                 android:id="@+id/toolbar_agent_rating"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="4.5"
+                android:text="@string/agent_rating"
                 android:fontFamily="sans-serif-light"
                 android:textColor="@color/km_white_color"
                 android:textSize="12sp"
                 android:textStyle="normal"
                 android:drawablePadding="2dp"
                 android:visibility="gone"
-
-
                 />
         </LinearLayout>
 

--- a/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
@@ -117,6 +117,38 @@
             android:textColor="@color/km_white_color"
             android:textSize="12sp"
             android:textStyle="normal" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/toolbar_agent_experience"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="2 year of experience  "
+                android:fontFamily="sans-serif-light"
+                android:textColor="@color/km_white_color"
+                android:textSize="12sp"
+                android:textStyle="normal"
+                android:visibility="gone"/>
+            <TextView
+                android:id="@+id/toolbar_agent_rating"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="4.5"
+                android:fontFamily="sans-serif-light"
+                android:textColor="@color/km_white_color"
+                android:textSize="12sp"
+                android:textStyle="normal"
+                android:drawablePadding="2dp"
+                android:visibility="gone"
+
+
+                />
+        </LinearLayout>
+
     </LinearLayout>
 
     <TextView

--- a/kommunicateui/src/main/res/values/colors.xml
+++ b/kommunicateui/src/main/res/values/colors.xml
@@ -90,4 +90,7 @@
     <color name="km_multiple_select_text_color">#00A4BF</color>
     <color name="km_multiple_select_border_color">#00A4BF</color>
     <color name="km_multiple_select_selected_background_color">#D4F3F8</color>
+
+    <!--Action Bar Back Button color-->
+    <color name="km_back_button_colour">#FFFFFF</color>
 </resources>

--- a/kommunicateui/src/main/res/values/mobicom_themes.xml
+++ b/kommunicateui/src/main/res/values/mobicom_themes.xml
@@ -10,6 +10,7 @@
         <item name="colorPrimaryDark">@color/primary_dark_color</item>
         <item name="colorAccent">@color/holo_blue</item>
 
+
         <!--
                 <item name="android:actionDropDownStyle">@style/actionDropDownStyle</item>
                 <item name="actionDropDownStyle">@style/actionDropDownStyle</item> -->
@@ -36,6 +37,7 @@
     </style>
 
     <style name="ToolBarStyle" parent="Widget.AppCompat.Toolbar">
+
         <item name="android:textColorPrimary">@android:color/white</item>
         <item name="android:textColorSecondary">@android:color/white</item>
         <item name="actionMenuTextColor">@android:color/black</item>
@@ -44,7 +46,6 @@
     </style>
 
     <style name="Applozic.People.Theme" parent="Theme.AppCompat.Light.NoActionBar">
-
         <item name="colorPrimary">@color/applozic_theme_color_primary</item>
         <!-- colorPrimaryDark is used for the status bar -->
         <item name="colorPrimaryDark">@color/applozic_theme_color_primary_dark</item>
@@ -55,7 +56,8 @@
 
         <!-- You can also set colorControlNormal, colorControlActivated
              colorControlHighlight & colorSwitchThumbNormal. -->
-        <!-- <item name="colorControlNormal">#c5c5c5</item>-->
+
+
         <item name="colorControlActivated">@color/applozic_theme_color_control_activated</item>
         <item name="colorControlHighlight">@color/applozic_theme_color_control_highlight</item>
         <item name="android:textColorPrimary">@color/white</item>
@@ -77,6 +79,7 @@
     <style name="ApplozicTheme.ActionBarStyle" parent="@android:style/Widget.Holo.Light.ActionBar.Solid.Inverse">
         <item name="android:subtitleTextStyle">@style/ApplozicTheme.ActionBar.TitleTextStyle</item>
         <item name="android:windowContentOverlay">@null</item>
+
     </style>
 
     <style name="ApplozicTheme.ActionBar.TitleTextStyle" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Subtitle">
@@ -89,6 +92,8 @@
     </style>
 
     <style name="ApplozicTheme_ActionButtonStyle" parent="@android:style/Widget.Holo.Light.ActionButton">
+
+
         <item name="android:width">20dp</item>
         <item name="android:paddingLeft">0dp</item>
         <item name="android:paddingRight">0dp</item>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -293,4 +293,6 @@
     <string name="invalid_email">Enter a valid email</string>
     <string name="select_language">Select a language</string>
     <string name="changed_language_to">Changed language to %1$s</string>
+    <string name="agent_experience">2 year of experience</string>
+    <string name="agent_rating">4.5</string>
 </resources>


### PR DESCRIPTION
## Summary:
-Added support for custom toolbar in which user can set agent experience and agent rating
-Added support to change colour of back button

## How to implement?
- Add this code into MainActivity.java in the Kommunicate login method:
```
 //To enable the new Custom toolbar Design
   KmConversationInfoSetting.getInstance(getApplicationContext()).enableCustomToolbarSubtitleDesign(true);
 //Setting up the agent experience
   KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarAgentExperience("<agent_experience>");     
 //Setting up the agent rating
   KmConversationInfoSetting.getInstance(getApplicationContext()).setToolbarSubtitleRating((float) <agent_rating>);
```



![image](https://user-images.githubusercontent.com/128575315/230348832-1a44ec24-7adc-427b-ab26-354fdc285af4.png)


- To change colour of back button add this code to 'colors.xml':
```
 <color name="km_back_button_colour">#03A9F4</color>
```