### PR TITLE
[CM-1373] - Changed Recycler View layout to Top to Bottom 

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -579,6 +579,12 @@ public class Message extends JsonMarker {
     public void setInitialFirstMessage() {
         this.type = MessageType.INITIAL_FIRST_MESSAGE.value;
     }
+    public boolean isTypingMessage() {
+        return type != null && type.equals(MessageType.TYPING_MESSAGE.value);
+    }
+    public void setTypingMessage() {
+        this.type = MessageType.TYPING_MESSAGE.value;
+    }
     public void setTempDateType(short tempDateType) {
         this.type = tempDateType;
     }
@@ -810,7 +816,7 @@ public class Message extends JsonMarker {
         INBOX(Short.valueOf("0")), OUTBOX(Short.valueOf("1")), DRAFT(Short.valueOf("2")),
         OUTBOX_SENT_FROM_DEVICE(Short.valueOf("3")), MT_INBOX(Short.valueOf("4")),
         MT_OUTBOX(Short.valueOf("5")), CALL_INCOMING(Short.valueOf("6")), CALL_OUTGOING(Short.valueOf("7")),
-        DATE_TEMP(Short.valueOf("100")), INITIAL_FIRST_MESSAGE(Short.valueOf("101"));
+        DATE_TEMP(Short.valueOf("100")), INITIAL_FIRST_MESSAGE(Short.valueOf("101")), TYPING_MESSAGE(Short.valueOf("102"));
         private Short value;
 
         MessageType(Short c) {

--- a/kommunicateui/src/main/res/drawable/km_blinking_dot.xml
+++ b/kommunicateui/src/main/res/drawable/km_blinking_dot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/km_typing_dot_color" />
+    <solid android:color="@color/km_typing_dot_color_first" />
     <corners android:radius="1000dp" />
 </shape>

--- a/kommunicateui/src/main/res/drawable/km_blinking_dot.xml
+++ b/kommunicateui/src/main/res/drawable/km_blinking_dot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/black" />
+    <solid android:color="@color/km_typing_dot_color" />
     <corners android:radius="1000dp" />
 </shape>

--- a/kommunicateui/src/main/res/layout/km_typing_indicator_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_typing_indicator_layout.xml
@@ -4,9 +4,11 @@
     android:layout_height="wrap_content"
     android:layout_marginTop="3dp"
     android:layout_marginStart="50dp"
+    android:layout_marginLeft="50dp"
     android:layout_marginBottom="8dp"
     android:layout_alignParentBottom="true"
-    android:gravity="start">
+    android:gravity="start"
+    >
 
     <LinearLayout
         android:id="@+id/typing_linear_layout"

--- a/kommunicateui/src/main/res/layout/km_typing_indicator_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_typing_indicator_layout.xml
@@ -27,7 +27,7 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="0.3"
             android:layout_margin="5dp"
-
+            android:backgroundTint="@color/km_typing_dot_color_first"
             android:background="@drawable/km_blinking_dot"/>
 
         <TextView
@@ -37,6 +37,7 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="0.3"
             android:layout_margin="5dp"
+            android:backgroundTint="@color/km_typing_dot_color_second"
             android:background="@drawable/km_blinking_dot"/>
 
 
@@ -47,6 +48,7 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="0.3"
             android:layout_margin="5dp"
+            android:backgroundTint="@color/km_typing_dot_color_third"
             android:background="@drawable/km_blinking_dot"/>
 
     </LinearLayout>

--- a/kommunicateui/src/main/res/values/colors.xml
+++ b/kommunicateui/src/main/res/values/colors.xml
@@ -93,6 +93,6 @@
 
     <!--Typing Indicator dots-->
     <color name="km_typing_dot_color_first">#000000</color>
-    <color name="km_typing_dot_color_second">#00A4BF</color>
-    <color name="km_typing_dot_color_third">#686464</color>
+    <color name="km_typing_dot_color_second">#000000</color>
+    <color name="km_typing_dot_color_third">#000000</color>
 </resources>

--- a/kommunicateui/src/main/res/values/colors.xml
+++ b/kommunicateui/src/main/res/values/colors.xml
@@ -90,4 +90,6 @@
     <color name="km_multiple_select_text_color">#00A4BF</color>
     <color name="km_multiple_select_border_color">#00A4BF</color>
     <color name="km_multiple_select_selected_background_color">#D4F3F8</color>
+
+    <color name="km_typing_dot_color">#000000</color>
 </resources>

--- a/kommunicateui/src/main/res/values/colors.xml
+++ b/kommunicateui/src/main/res/values/colors.xml
@@ -91,5 +91,8 @@
     <color name="km_multiple_select_border_color">#00A4BF</color>
     <color name="km_multiple_select_selected_background_color">#D4F3F8</color>
 
-    <color name="km_typing_dot_color">#000000</color>
+    <!--Typing Indicator dots-->
+    <color name="km_typing_dot_color_first">#000000</color>
+    <color name="km_typing_dot_color_second">#00A4BF</color>
+    <color name="km_typing_dot_color_third">#686464</color>
 </resources>


### PR DESCRIPTION
## Summary:
1. Changed Recycler view layout from bottom to top TO top to Bottom. Messages will start coming from top now.
2. Changed typing indicator design to match web sdk. Typing indicator will show where the message will come.

## How was the code tested?
- Tested it on my local device

## Screenshot:

<img src="https://user-images.githubusercontent.com/121423566/230074809-20a5ba17-5f81-4722-a845-2094272467b7.png" width="325" height="525"/>