### PR TITLE
[CM-1390] - Passing LanguageCode to GroupMetadata and MessageMetadata

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
@@ -66,7 +66,7 @@ public class Applozic {
     }
     public static void setDefaultLanguage(Context context){
         String deviceLanguage = context.getResources().getConfiguration().locale.getLanguage();
-        if(deviceLanguage.isEmpty()){
+        if(!TextUtils.isEmpty(deviceLanguage)){
             return;
         }
         AlPrefSettings.getInstance(context).setDeviceDefaultLanguageToBot(deviceLanguage);

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
@@ -1,5 +1,6 @@
 package com.applozic.mobicomkit;
 
+import static io.kommunicate.utils.KmConstants.KM_USER_LOCALE;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -34,7 +35,9 @@ import com.applozic.mobicommons.people.channel.Channel;
 import com.applozic.mobicommons.people.contact.Contact;
 import com.applozic.mobicommons.task.AlTask;
 
+import java.util.HashMap;
 import java.util.Map;
+import io.kommunicate.KmSettings;
 
 /**
  * Created by sunil on 29/8/16.
@@ -60,6 +63,16 @@ public class Applozic {
         applozic = getInstance(context);
         AlPrefSettings.getInstance(context).setApplicationKey(applicationKey);
         return applozic;
+    }
+    public static void setDefaultLanguage(Context context){
+        String deviceLanguage = context.getResources().getConfiguration().locale.getLanguage();
+        if(deviceLanguage.isEmpty()){
+            return;
+        }
+        AlPrefSettings.getInstance(context).setDeviceDefaultLanguageToBot(deviceLanguage);
+        Map<String, String> localeMetadata = new HashMap<>();
+        localeMetadata.put(KM_USER_LOCALE,deviceLanguage);
+        KmSettings.updateChatContext(context,localeMetadata);
     }
 
     public static Applozic getInstance(Context context) {

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
@@ -66,7 +66,7 @@ public class Applozic {
     }
     public static void setDefaultLanguage(Context context){
         String deviceLanguage = context.getResources().getConfiguration().locale.getLanguage();
-        if(!TextUtils.isEmpty(deviceLanguage)){
+        if(TextUtils.isEmpty(deviceLanguage)){
             return;
         }
         AlPrefSettings.getInstance(context).setDeviceDefaultLanguageToBot(deviceLanguage);

--- a/kommunicate/src/main/java/com/applozic/mobicommons/data/AlPrefSettings.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/data/AlPrefSettings.java
@@ -10,6 +10,7 @@ public class AlPrefSettings {
     public static final String AL_PREF_SETTING_KEY = "al_secret_key_pref";
     private static final String APPLICATION_KEY = "APPLICATION_KEY";
     public static final String GOOGLE_API_KEY_META_DATA = "com.google.android.geo.API_KEY";
+    public static final String DEFAULT_LANGUAGE = "DEFAULT_LANGUAGE";
     private static String USER_ENCRYPTION_KEY = "user_encryption_key";
     private static String USER_AUTH_TOKEN = "user_auth_token";
     private static String ENCRYPTION_KEY = "encryption_key";
@@ -114,5 +115,11 @@ public class AlPrefSettings {
         decodedPassword = password;
         sharedPreferences.edit().putString(PASSWORD, password).commit();
         return this;
+    }
+    public void setDeviceDefaultLanguageToBot(String languageCode) {
+       sharedPreferences.edit().putString(DEFAULT_LANGUAGE, languageCode).apply();
+    }
+    public String getDeviceDefaultLanguageToBot() {
+        return sharedPreferences.getString(DEFAULT_LANGUAGE, null);
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -654,8 +654,8 @@ public class KmConversationHelper {
         metadata.put("GROUP_META_DATA_UPDATED_MESSAGE", "");
         metadata.put("HIDE", "true");
         String languageCode = AlPrefSettings.getInstance(conversationBuilder.getContext()).getDeviceDefaultLanguageToBot();
-        Map<String, String> localeMetadata = new HashMap<>();
-        if(!languageCode.isEmpty()){
+        if(!TextUtils.isEmpty(languageCode)){
+            Map<String, String> localeMetadata = new HashMap<>();
             localeMetadata.put(KM_USER_LOCALE,languageCode);
             metadata.put(KM_CHAT_CONTEXT, GsonUtils.getJsonFromObject(localeMetadata,Map.class));
         }

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -1,12 +1,13 @@
 package io.kommunicate;
 
+import static io.kommunicate.KmSettings.KM_CHAT_CONTEXT;
+import static io.kommunicate.utils.KmConstants.KM_USER_LOCALE;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.ResultReceiver;
 import android.text.TextUtils;
-
 import com.applozic.mobicomkit.Applozic;
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitClientService;
@@ -19,6 +20,7 @@ import com.applozic.mobicomkit.exception.ApplozicException;
 import com.applozic.mobicomkit.feed.ChannelFeedApiResponse;
 import com.applozic.mobicomkit.listners.MessageListHandler;
 import com.applozic.mobicommons.commons.core.utils.Utils;
+import com.applozic.mobicommons.data.AlPrefSettings;
 import com.applozic.mobicommons.json.GsonUtils;
 import com.applozic.mobicommons.people.channel.Channel;
 
@@ -651,7 +653,12 @@ public class KmConversationHelper {
         metadata.put("GROUP_USER_ROLE_UPDATED_MESSAGE", "");
         metadata.put("GROUP_META_DATA_UPDATED_MESSAGE", "");
         metadata.put("HIDE", "true");
-
+        String languageCode = AlPrefSettings.getInstance(conversationBuilder.getContext()).getDeviceDefaultLanguageToBot();
+        Map<String, String> localeMetadata = new HashMap<>();
+        if(!languageCode.isEmpty()){
+            localeMetadata.put(KM_USER_LOCALE,languageCode);
+            metadata.put(KM_CHAT_CONTEXT, GsonUtils.getJsonFromObject(localeMetadata,Map.class));
+        }
         if (!TextUtils.isEmpty(conversationBuilder.getConversationAssignee())) {
             metadata.put(CONVERSATION_ASSIGNEE, conversationBuilder.getConversationAssignee());
             metadata.put(SKIP_ROUTING, "true");

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmConstants.java
@@ -28,4 +28,5 @@ public class KmConstants {
     public static final String NOTIFICATION_TONE = "com.applozic.mobicomkit.notification.tone";
     public static final String CLOSE_CONVERSATION_SCREEN = "CLOSE_CONVERSATION_SCREEN";
     public static final String AWS_ENCRYPTED = "AWS-ENCRYPTED-";
+    public static final String KM_USER_LOCALE = "kmUserLocale";
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -487,6 +487,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         };
 
         AlEventManager.getInstance().sendOnPluginLaunchEvent();
+        Applozic.setDefaultLanguage(this);
     }
 
     @Override


### PR DESCRIPTION
## Summary:
- Device language code is passed to the GroupMetadata and MessageMetadata.
- `KM_CHAT_CONTEXT: "{\"kmUserLocale\":\"en\"}"`
## How was the code tested?
- Tested it on the  local device