### PR TITLE
[CM-1396] - set kmUserLocale when changing language

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -170,5 +170,6 @@
   "hideChatInHelpcenter": true,
   "checkboxAsMultipleButton": true,
   "staticTopMessage": "",
-  "staticTopIcon": "km_lock"
+  "staticTopIcon": "km_lock",
+  "useDeviceDefaultLanguage": true
 }

--- a/kommunicate/src/main/java/io/kommunicate/KmSettings.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmSettings.java
@@ -1,5 +1,6 @@
 package io.kommunicate;
 
+import static io.kommunicate.utils.KmConstants.KM_USER_LOCALE;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -71,7 +72,7 @@ public class KmSettings {
 
     public static void updateUserLanguage(Context context, String languageCode) {
         Map<String, String> languageCodeMap = new HashMap<>();
-        languageCodeMap.put(KM_LANGUAGE_UPDATE_KEY, languageCode);
+        languageCodeMap.put(KM_USER_LOCALE, languageCode);
         updateChatContext(context, languageCodeMap);
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -119,6 +119,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean disableGlobalStoragePermission = true;
 
     private boolean launchChatFromProfilePicOrName = false;
+    private boolean useDeviceDefaultLanguage = true;
     private Map<String, Boolean> filterGallery;
     private boolean enableShareConversation = false;
     private String messageStatusIconColor = "";
@@ -637,6 +638,9 @@ public class AlCustomizationSettings extends JsonMarker {
     public boolean isAgentApp() {
         return isAgentApp;
     }
+    public boolean isUseDeviceDefaultLanguage(){
+        return useDeviceDefaultLanguage;
+    }
 
     public boolean isGroupSubtitleHidden() {
         return hideGroupSubtitle;
@@ -812,6 +816,7 @@ public class AlCustomizationSettings extends JsonMarker {
                 ", messageCharacterLimit" + messageCharacterLimit +
                 ", toolbarTitleColor=" + toolbarTitleColor +
                 ", toolbarSubtitleColor=" + toolbarSubtitleColor +
+                ", useDeviceDefaultLanguage=" + useDeviceDefaultLanguage +
                 '}';
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -487,7 +487,9 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         };
 
         AlEventManager.getInstance().sendOnPluginLaunchEvent();
-        Applozic.setDefaultLanguage(this);
+        if(alCustomizationSettings.isUseDeviceDefaultLanguage()){
+            Applozic.setDefaultLanguage(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

- When user sets the language , it  override the default language
- In 'applogic-settings.json' file, if "useDeviceDefaultLanguage": true then device default language is passed to the bot 
- User can set the bot language by calling "updateUserLanguage()" method present in "KmSettings.java" and set "useDeviceDefaultLanguage": false


## How was the code tested?
- Tested it on the  local device