### PR TITLE
[CM-1433] - Expose Method to populate text on chat bar

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlMessageEvent.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlMessageEvent.java
@@ -130,5 +130,6 @@ public class AlMessageEvent extends JsonMarker {
         public static final String USER_ACTIVATED = "USER_ACTIVATED";
         public static final String USER_DEACTIVATED = "USER_DEACTIVATED";
         public static final String AWAY_STATUS = "AWAY_STATUS";
+        public static final String ACTION_TEXT_UPDATED = "ACTION_TEXT_UPDATED";
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlMessageEvent.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/AlMessageEvent.java
@@ -130,6 +130,6 @@ public class AlMessageEvent extends JsonMarker {
         public static final String USER_ACTIVATED = "USER_ACTIVATED";
         public static final String USER_DEACTIVATED = "USER_DEACTIVATED";
         public static final String AWAY_STATUS = "AWAY_STATUS";
-        public static final String ACTION_TEXT_UPDATED = "ACTION_TEXT_UPDATED";
+        public static final String ACTION_POPULATE_CHAT_TEXT = "ACTION_POPULATE_CHAT_TEXT";
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -366,6 +366,13 @@ public class BroadcastService {
         sendBroadcast(context, intent);
     }
 
+    public static void onAutoText(Context context, String prefilledText) {
+        postEventData(context, new AlMessageEvent().setAction(AlMessageEvent.ActionType.ACTION_TEXT_UPDATED));
+        Intent intent = new Intent();
+        intent.setAction(INTENT_ACTIONS.ACTION_TEXT_UPDATED.toString());
+        intent.putExtra("preFilled", prefilledText);
+        sendBroadcast(context, intent);
+    }
     public static IntentFilter getIntentFilter() {
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(INTENT_ACTIONS.FIRST_TIME_SYNC_COMPLETE.toString());
@@ -400,6 +407,7 @@ public class BroadcastService {
         intentFilter.addAction(INTENT_ACTIONS.LOGGED_USER_DELETE.toString());
         intentFilter.addAction(INTENT_ACTIONS.AGENT_STATUS.toString());
         intentFilter.addCategory(Intent.CATEGORY_DEFAULT);
+        intentFilter.addAction(INTENT_ACTIONS.ACTION_TEXT_UPDATED.toString());
         return intentFilter;
     }
 
@@ -418,6 +426,6 @@ public class BroadcastService {
         UPDATE_LAST_SEEN_AT_TIME, UPDATE_TYPING_STATUS, MESSAGE_READ_AND_DELIVERED, MESSAGE_READ_AND_DELIVERED_FOR_CONTECT, CHANNEL_SYNC,
         CONTACT_VERIFIED, NOTIFY_USER, MQTT_DISCONNECTED, UPDATE_CHANNEL_NAME, UPDATE_TITLE_SUBTITLE, CONVERSATION_READ, UPDATE_USER_DETAIL,
         MESSAGE_METADATA_UPDATE, MUTE_USER_CHAT, MQTT_CONNECTED, USER_ONLINE, USER_OFFLINE, GROUP_MUTE, CONTACT_PROFILE_CLICK, LOGGED_USER_DELETE,
-        AGENT_STATUS
+        AGENT_STATUS,ACTION_TEXT_UPDATED
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -367,9 +367,9 @@ public class BroadcastService {
     }
 
     public static void onAutoText(Context context, String prefilledText) {
-        postEventData(context, new AlMessageEvent().setAction(AlMessageEvent.ActionType.ACTION_TEXT_UPDATED));
+        postEventData(context, new AlMessageEvent().setAction(AlMessageEvent.ActionType.ACTION_POPULATE_CHAT_TEXT));
         Intent intent = new Intent();
-        intent.setAction(INTENT_ACTIONS.ACTION_TEXT_UPDATED.toString());
+        intent.setAction(INTENT_ACTIONS.ACTION_POPULATE_CHAT_TEXT.toString());
         intent.putExtra("preFilled", prefilledText);
         sendBroadcast(context, intent);
     }
@@ -407,7 +407,7 @@ public class BroadcastService {
         intentFilter.addAction(INTENT_ACTIONS.LOGGED_USER_DELETE.toString());
         intentFilter.addAction(INTENT_ACTIONS.AGENT_STATUS.toString());
         intentFilter.addCategory(Intent.CATEGORY_DEFAULT);
-        intentFilter.addAction(INTENT_ACTIONS.ACTION_TEXT_UPDATED.toString());
+        intentFilter.addAction(INTENT_ACTIONS.ACTION_POPULATE_CHAT_TEXT.toString());
         return intentFilter;
     }
 
@@ -426,6 +426,6 @@ public class BroadcastService {
         UPDATE_LAST_SEEN_AT_TIME, UPDATE_TYPING_STATUS, MESSAGE_READ_AND_DELIVERED, MESSAGE_READ_AND_DELIVERED_FOR_CONTECT, CHANNEL_SYNC,
         CONTACT_VERIFIED, NOTIFY_USER, MQTT_DISCONNECTED, UPDATE_CHANNEL_NAME, UPDATE_TITLE_SUBTITLE, CONVERSATION_READ, UPDATE_USER_DETAIL,
         MESSAGE_METADATA_UPDATE, MUTE_USER_CHAT, MQTT_CONNECTED, USER_ONLINE, USER_OFFLINE, GROUP_MUTE, CONTACT_PROFILE_CLICK, LOGGED_USER_DELETE,
-        AGENT_STATUS,ACTION_TEXT_UPDATED
+        AGENT_STATUS, ACTION_POPULATE_CHAT_TEXT
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -19,6 +19,7 @@ import com.applozic.mobicomkit.api.account.user.PushNotificationTask;
 import com.applozic.mobicomkit.api.account.user.User;
 import com.applozic.mobicomkit.api.notification.MobiComPushReceiver;
 import com.applozic.mobicomkit.api.people.ChannelInfo;
+import com.applozic.mobicomkit.broadcast.BroadcastService;
 import com.applozic.mobicomkit.contact.database.ContactDatabase;
 import com.applozic.mobicomkit.feed.ChannelFeedApiResponse;
 
@@ -891,5 +892,9 @@ public class Kommunicate {
 
     public static void removeApplicationKey(Context context) {
         new SecureSharedPreferences(AlPrefSettings.AL_PREF_SETTING_KEY, ApplozicService.getContext(context)).edit().remove("APPLICATION_KEY").commit();
+    }
+
+    public static void setChatText(Context context, String PreFilledText) {
+        BroadcastService.onAutoText(context,PreFilledText);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -833,6 +833,9 @@ public class ConversationUIService {
     }
 
     public void setAutoText(String preFilled) {
+        if(BroadcastService.isQuick()){
+            return;
+        }
         getConversationFragment().setAutoTextOnEditText(preFilled);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -27,7 +27,6 @@ import com.applozic.mobicomkit.api.account.user.UserClientService;
 import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.api.attachment.FileMeta;
 import com.applozic.mobicomkit.api.conversation.Message;
-import com.applozic.mobicomkit.api.conversation.MobiComConversationService;
 import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
 import com.applozic.mobicomkit.broadcast.BroadcastService;
 import com.applozic.mobicomkit.channel.service.ChannelService;
@@ -50,7 +49,6 @@ import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.file.FileUtils;
 import com.applozic.mobicommons.json.GsonUtils;
 import com.applozic.mobicommons.people.channel.Channel;
-import com.applozic.mobicommons.people.channel.ChannelUtils;
 import com.applozic.mobicommons.people.contact.Contact;
 
 import java.io.File;
@@ -259,7 +257,7 @@ public class ConversationUIService {
                 setPositiveButton(R.string.delete_conversation, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        new KmDeleteConversationTask(context, channel.getKey(),false, new KmCallback() {
+                        new KmDeleteConversationTask(context, channel.getKey(), false, new KmCallback() {
                             @Override
                             public void onSuccess(Object message) {
                                 KmToast.success(context, R.string.conversation_delete_successful, Toast.LENGTH_SHORT).show();
@@ -466,7 +464,7 @@ public class ConversationUIService {
         if (BroadcastService.isIndividual()) {
             getConversationFragment().deleteMessageFromDeviceList(keyString);
         }
-        if(BroadcastService.isQuick()) {
+        if (BroadcastService.isQuick()) {
             getQuickConversationFragment().deleteMessage(message, userId);
         }
     }
@@ -631,7 +629,7 @@ public class ConversationUIService {
     }
 
     public void updateMessageMetadata(String keyString) {
-        if(BroadcastService.isIndividual()) {
+        if (BroadcastService.isIndividual()) {
             getConversationFragment().updateMessageMetadata(keyString);
         }
     }
@@ -646,23 +644,21 @@ public class ConversationUIService {
         if (BroadcastService.isQuick()) {
             return;
         }
-        if(userId != null && status != null && !KmUtils.isAgent() && getConversationFragment().getChannel() != null && !TextUtils.isEmpty(getConversationFragment().getChannel().getConversationAssignee()) && getConversationFragment().getChannel().getConversationAssignee().equals(userId)) {
-                if(status.equals(KmConstants.STATUS_AWAY)) {
-                    getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), false);
-                    getConversationFragment().showAwayMessage(true, null);
-                } else if(status.equals(KmConstants.STATUS_ONLINE)) {
-                    getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), true);
-                    getConversationFragment().showAwayMessage(false, null);
-                }
-                else if(status.equals(KmConstants.STATUS_OFFLINE)){
-                    getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
-                    getConversationFragment().showAwayMessage(true, null);
-                }
-                else if(status.equals(KmConstants.STATUS_CONNECTED)){
-                    getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
-                    getConversationFragment().loadAwayMessage();
-                }
-        } else if(userId != null && status != null && getConversationFragment().getChannel() != null && KmChannelService.getInstance(fragmentActivity).getUserInSupportGroup(getConversationFragment().getChannel().getKey()).equals(userId)) {
+        if (userId != null && status != null && !KmUtils.isAgent() && getConversationFragment().getChannel() != null && !TextUtils.isEmpty(getConversationFragment().getChannel().getConversationAssignee()) && getConversationFragment().getChannel().getConversationAssignee().equals(userId)) {
+            if (status.equals(KmConstants.STATUS_AWAY)) {
+                getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), false);
+                getConversationFragment().showAwayMessage(true, null);
+            } else if (status.equals(KmConstants.STATUS_ONLINE)) {
+                getConversationFragment().switchContactStatus(baseContactService.getContactById(userId), true);
+                getConversationFragment().showAwayMessage(false, null);
+            } else if (status.equals(KmConstants.STATUS_OFFLINE)) {
+                getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
+                getConversationFragment().showAwayMessage(true, null);
+            } else if (status.equals(KmConstants.STATUS_CONNECTED)) {
+                getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
+                getConversationFragment().loadAwayMessage();
+            }
+        } else if (userId != null && status != null && getConversationFragment().getChannel() != null && KmChannelService.getInstance(fragmentActivity).getUserInSupportGroup(getConversationFragment().getChannel().getKey()).equals(userId)) {
             getConversationFragment().processSupportGroupDetails(getConversationFragment().getChannel());
         }
     }
@@ -752,16 +748,16 @@ public class ConversationUIService {
         }
 
         String keyString = intent.getStringExtra("keyString");
-        if(message == null && !TextUtils.isEmpty(keyString) ){
+        if (message == null && !TextUtils.isEmpty(keyString)) {
             message = new MessageDatabaseService(fragmentActivity).getMessage(keyString);
         }
 
-        if(message == null && channelKey != -1) {
+        if (message == null && channelKey != -1) {
             List<Message> messages = new MessageDatabaseService(fragmentActivity).getLatestMessageByChannelKey(channelKey);
             message = (messages.size() != 0) ? messages.get(0) : null;
         }
 
-        if(message != null) {
+        if (message != null) {
             if (message.getGroupId() != null) {
                 channel = ChannelService.getInstance(fragmentActivity).getChannelByChannelKey(message.getGroupId());
             } else {
@@ -787,7 +783,6 @@ public class ConversationUIService {
         if (contact != null) {
             openConversationFragment(contact, conversationId, searchString, intent.getStringExtra(MESSAGE_SEARCH_STRING));
         }
-
         String preFilledMessage = intent.getStringExtra(KmConstants.KM_PREFILLED_MESSAGE);
         if (channel != null) {
             openConversationFragment(channel, conversationId, searchString, intent.getStringExtra(MESSAGE_SEARCH_STRING), preFilledMessage);
@@ -835,5 +830,9 @@ public class ConversationUIService {
             return ((KmFragmentGetter) context.getApplicationContext()).getConversationFragment(contact, channel, conversationId, searchString, messageSearchString);
         }
         return ConversationFragment.newInstance(contact, channel, conversationId, searchString, messageSearchString, preFilledMessage);
+    }
+
+    public void setAutoText(String preFilled) {
+        getConversationFragment().setAutoTextOnEditText(preFilled);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -39,10 +39,6 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent.getAction().equals("ACTION_POPULATE_CHAT_TEXT")) {
-            String preFilledText = intent.getStringExtra("preFilled");
-            conversationUIService.setAutoText(preFilledText);
-        }
         String action = intent.getAction();
         Message message = null;
         String keyString = intent.getStringExtra("keyString");
@@ -137,6 +133,9 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
             conversationUIService.muteUserChat(intent.getBooleanExtra("mute", false), intent.getStringExtra("userId"));
         } else if(BroadcastService.INTENT_ACTIONS.AGENT_STATUS.toString().equals(action)) {
             conversationUIService.updateAgentStatus(intent.getStringExtra("userId"), intent.getIntExtra("status", KmConstants.STATUS_ONLINE));
+        } else if (intent.getAction().equals("ACTION_POPULATE_CHAT_TEXT")) {
+            String preFilledText = intent.getStringExtra("preFilled");
+            conversationUIService.setAutoText(preFilledText);
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -7,7 +7,6 @@ import androidx.fragment.app.FragmentActivity;
 import io.kommunicate.utils.KmConstants;
 
 import android.text.TextUtils;
-
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitConstants;
 import com.applozic.mobicomkit.api.conversation.Message;
@@ -40,6 +39,10 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        if (intent.getAction().equals("ACTION_TEXT_UPDATED")) {
+            String preFilledText = intent.getStringExtra("preFilled");
+            conversationUIService.setAutoText(preFilledText);
+        }
         String action = intent.getAction();
         Message message = null;
         String keyString = intent.getStringExtra("keyString");

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -39,7 +39,7 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        if (intent.getAction().equals("ACTION_TEXT_UPDATED")) {
+        if (intent.getAction().equals("ACTION_POPULATE_CHAT_TEXT")) {
             String preFilledText = intent.getStringExtra("preFilled");
             conversationUIService.setAutoText(preFilledText);
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/MobiComKitBroadcastReceiver.java
@@ -133,7 +133,7 @@ public class MobiComKitBroadcastReceiver extends BroadcastReceiver {
             conversationUIService.muteUserChat(intent.getBooleanExtra("mute", false), intent.getStringExtra("userId"));
         } else if(BroadcastService.INTENT_ACTIONS.AGENT_STATUS.toString().equals(action)) {
             conversationUIService.updateAgentStatus(intent.getStringExtra("userId"), intent.getIntExtra("status", KmConstants.STATUS_ONLINE));
-        } else if (intent.getAction().equals("ACTION_POPULATE_CHAT_TEXT")) {
+        } else if (BroadcastService.INTENT_ACTIONS.ACTION_POPULATE_CHAT_TEXT.toString().equals(action)) {
             String preFilledText = intent.getStringExtra("preFilled");
             conversationUIService.setAutoText(preFilledText);
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/ConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/ConversationFragment.java
@@ -1,5 +1,6 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.fragment;
 
+
 import android.app.Activity;
 import android.location.Location;
 import android.os.Bundle;
@@ -157,7 +158,9 @@ public class ConversationFragment extends MobiComConversationFragment implements
         });
         return view;
     }
-
+    public void setAutoTextOnEditText(String newText){
+        messageEditText.setText(newText);
+    }
     @Override
     protected void processMobiTexterUserCheck() {
 


### PR DESCRIPTION
## Summary 

- To expose a method that allows the text in the chat to be populated from an external source.
- The method provide flexibility for external components to set the desired text and update the chat interface accordingly.
- use 'setChatText' method in 'kommunicate.java' class, pass context and desired string to the method