### PR TITLE
release changes for v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
-## [Unreleased]
+## Kommunicate Android SDK 2.7.1
  1) Added support for group creation source in sdk
+ 2) Added support for Multilingual bot 
+ 3) Added a new field addFormLabelInMessage to form Rich message, which controls whether or not to show the form label in the message when the form data is submitted
+ 4) Expose Method to populate text on chat bar - Kommunicate.setChatText(context, "Text to populate");
   
 ## Kommunicate Android SDK 2.7.0
 1) Fix for rating asked everytime in a resolved conversation

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,11 +4,6 @@
     package="io.kommunicate.app">
 
     <uses-permission android:name="io.kommunicate.app.permission.MAPS_RECEIVE" />
-    <permission
-        android:name="io.kommunicate.app.permission.MAPS_RECEIVE"
-        android:protectionLevel="signature" />
-
-
 
         <!--Permissions to be used when using these features-->
         <uses-permission

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.0"
+        versionName "2.7.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'
         buildConfigField "String", "API_SERVER_URL", '"https://api.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.0"
+        versionName "2.7.1"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Kommunicate Android SDK 2.7.1
 1) Added support for group creation source in sdk
 2) Added support for Multilingual bot 
 3) Added a new field addFormLabelInMessage to form Rich message, which controls whether or not to show the form label in the message when the form data is submitted
 4) Expose Method to populate text on chat bar - Kommunicate.setChatText(context, "Text to populate");
  