### PR TITLE
[CM-1377]- Add support for Custom Input Field

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -82,6 +82,8 @@ public class Message extends JsonMarker {
     public static final String SKIP_BOT = "skipBot";
     public static final String AL_DELETE_MESSAGE_FOR_ALL_KEY = "AL_DELETE_GROUP_MESSAGE_FOR_ALL";
     public static final String AUTO_SUGGESTION_TYPE_MESSAGE = "KM_AUTO_SUGGESTION";
+    public static final String KM_FIELD = "KM_FIELD";
+
     public static final String STATUS_CLOSED = "closed";
     public static final String STATUS_OPEN = "open";
     public static final String RICH_MESSAGE_CONTENT_TYPE = "300";
@@ -775,6 +777,10 @@ public class Message extends JsonMarker {
 
     public boolean isRichMessage() {
         return metadata != null && RICH_MESSAGE_CONTENT_TYPE.equals(metadata.get("contentType"));
+    }
+
+    public boolean isCustomInputField() {
+        return metadata != null && metadata.containsKey(KM_FIELD);
     }
 
     public boolean isAttachmentEncrypted() {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4242,15 +4242,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         switch(fieldType) {
             case(KmCustomInputModel.EMAIL) : {
                 user.setEmail(message);
-                return;
+                break;
             }
             case(KmCustomInputModel.NAME) : {
                 user.setDisplayName(message);
-                return;
+                break;
             }
             case(KmCustomInputModel.PHONE_NUMBER) : {
                 user.setContactNumber(message);
-                return;
+                break;
             }
             default: {
                 Map<String, String> inputMetadata = new HashMap<>();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmCustomInputModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmCustomInputModel.java
@@ -1,0 +1,93 @@
+package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2;
+
+import android.text.TextUtils;
+
+import com.applozic.mobicomkit.api.conversation.Message;
+import com.applozic.mobicommons.json.GsonUtils;
+import com.applozic.mobicommons.json.JsonMarker;
+
+import java.util.Map;
+
+public class KmCustomInputModel {
+    private short templateId;
+    private KmField KM_FIELD;
+    private Map<String, String> replyMetadata;
+    public static final String EMAIL = "EMAIL";
+    public static final String NAME = "NAME";
+    public static final String PHONE_NUMBER = "PHONE_NUMBER";
+    public static final String UpdateUserDetails = "updateUserDetails";
+
+    public short getTemplateId() {
+        return templateId;
+    }
+
+    public KmField getKM_FIELD() {
+        return KM_FIELD;
+    }
+
+    public Map<String, String> getReplyMetadata() {
+        return replyMetadata;
+    }
+
+    public static KmCustomInputModel parseCustomInputModel(Message message) {
+        if (!TextUtils.isEmpty(message.getMetadata().get(Message.KM_FIELD))) {
+            return (KmCustomInputModel) GsonUtils.getObjectFromJson(message.getMetadata().toString(), KmCustomInputModel.class);
+        }
+        return null;
+    }
+
+    public static class KmField {
+        private String label;
+        private String field;
+        private String fieldType;
+        private String placeholder;
+        private Map<String, Object> action;
+        private Validation validation;
+
+        public Validation getValidation() {
+            return validation;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public String getFieldType() {
+            return fieldType;
+        }
+
+        public String getPlaceholder() {
+            return placeholder;
+        }
+
+        public Map<String, Object> getAction() {
+            return action;
+        }
+
+    }
+
+    public static class Validation extends JsonMarker {
+        private String regex;
+        private String errorText;
+
+        public String getRegex() {
+            return regex;
+        }
+
+        public void setRegex(String regex) {
+            this.regex = regex;
+        }
+
+        public String getErrorText() {
+            return errorText;
+        }
+
+        public void setErrorText(String errorText) {
+            this.errorText = errorText;
+        }
+    }
+}


### PR DESCRIPTION
## What do you want to achieve?
- Added support for Custom Input FIeld: https://docs.kommunicate.io/docs/message-types#custom-input-field
- Validation and Action are optional. 
- Validation regex differs in Javascript and Java. Same regex was giving PatternSyntaxException in Java, so added default regex for email and phone in case PatternSyntaxException is thrown.
- When regex does not match, show error toast message from - "errorText" -> If errorText not present then "Invalid validation regex" toast message
- If replyMetadata is present, then send the message message by adding this metadata to trigger next intent

### PR Checklist
<!-- To enable check in the below list: [x] -->
- [x] I have tested it locally and all functionalities are working fine.
- [x] I have compared it with mocks and all design elements are the same.

### How was the code tested?
<!-- Be as specific as possible. -->
- 
`{
    "message": "",
    "platform": "kommunicate",
    "metadata": {
        "templateId": "13",
        "KM_FIELD": {
            "label": "Email",
            "field": "email",
            "fieldType": "EMAIL",
            "placeholder": "Enter your email",
            "action": {
                "updateUserDetails": true
            },
            "validation": {
                "regex": "^(([^<>()\\[\\]\\.;:\\s@\"]+(\\.[^<>()[\\]\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$",
                "errorText": "The email you have entered is either invalid or not accepted"
            }
        },
        "replyMetadata": {
            "KM_TRIGGER_EVENT": "phone number"
        }
    }
}`

##Screenshot
![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/121423566/00132526-1ce4-4477-b0e0-a1cd2e3dc89b)
![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/121423566/c97bff40-99bd-44cf-9f05-0dca274dd796)
