### PR TITLE
[CM-1470] null check for destroyed activity

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3326,6 +3326,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     public void updateSupportGroupTitleAndImageAndHideSubtitle(Channel channel) {
+        if(getActivity() == null) {
+            return;
+        }
         toolbarAlphabeticImage.setVisibility(VISIBLE);
         toolbarImageView.setVisibility(GONE);
         if(alCustomizationSettings.isAgentApp() && channel != null && !TextUtils.isEmpty(channel.getImageUrl())) {


### PR DESCRIPTION
## Summary:
Fatal Exception: java.lang.NullPointerException: You cannot start a load on a not yet attached View or a Fragment where getActivity() returns null (which usually occurs when getActivity() is called before the Fragment is attached or after the Fragment is destroyed).

## Fix:
- Added a null check to getActivity