### PR TITLE
release changes for v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Kommunicate Android SDK 2.7.2
+1) Added support for Custom Input Field
+2) Added Restriction for Start Plan in Android SDK
+3) Added team concept in companySettings
+4) Fixed a bug in which user Unable to retrieve all conversation list in the agent app(While using latest SDK).
 ## Kommunicate Android SDK 2.7.1
  1) Added support for group creation source in sdk
  2) Added support for Multilingual bot 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.1"
+        versionName "2.7.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'
         buildConfigField "String", "API_SERVER_URL", '"https://api.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.1"
+        versionName "2.7.2"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
 ## Kommunicate Android SDK 2.7.2
1) Added support for Custom Input Field
2) Added Restriction for Start Plan in Android SDK
3) Added team concept in companySettings
4) Fixed a bug in which user Unable to retrieve all conversation list in the agent app(While using latest SDK).