### PR TITLE
[CM-1473] - add support for autosuggest through API

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/async/KmGetDataAsyncTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmGetDataAsyncTask.java
@@ -2,8 +2,10 @@ package io.kommunicate.async;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.text.TextUtils;
 
 import java.lang.ref.WeakReference;
+import java.net.URLEncoder;
 import java.util.Map;
 
 import io.kommunicate.callbacks.KmCallback;
@@ -33,7 +35,10 @@ public class KmGetDataAsyncTask extends AsyncTask<Void, Void, String> {
     @Override
     protected String doInBackground(Void... voids) {
         try {
-            return new KmHttpClient(context.get()).getResponseWithException(url, contentType, accept, data, headers);
+            if(!TextUtils.isEmpty(data)) {
+                url = url + (URLEncoder.encode(data, "UTF-8")).trim();
+            }
+            return new KmHttpClient(context.get()).getResponseWithException(url, contentType, accept, headers);
         } catch (Exception e) {
             e.printStackTrace();
             exception = e;

--- a/kommunicate/src/main/java/io/kommunicate/async/KmGetDataAsyncTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmGetDataAsyncTask.java
@@ -1,0 +1,55 @@
+package io.kommunicate.async;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+import io.kommunicate.callbacks.KmCallback;
+import io.kommunicate.services.KmHttpClient;
+
+public class KmGetDataAsyncTask extends AsyncTask<Void, Void, String> {
+
+    private WeakReference<Context> context;
+    private KmCallback callback;
+    private String contentType;
+    private String data;
+    private String accept;
+    private String url;
+    private Exception exception = null;
+    private Map<String, String> headers;
+
+    public KmGetDataAsyncTask(Context context, String url, String accept, String contentType, String data, Map<String, String> headers, KmCallback callback) {
+        this.context = new WeakReference<>(context);
+        this.callback = callback;
+        this.url = url;
+        this.contentType = contentType;
+        this.data = data;
+        this.accept = accept;
+        this.headers = headers;
+    }
+
+    @Override
+    protected String doInBackground(Void... voids) {
+        try {
+            return new KmHttpClient(context.get()).getResponseWithException(url, contentType, accept, data, headers);
+        } catch (Exception e) {
+            e.printStackTrace();
+            exception = e;
+            return null;
+        }
+    }
+
+    @Override
+    protected void onPostExecute(String response) {
+        if (callback != null) {
+            if (response != null) {
+                callback.onSuccess(response);
+            } else {
+                callback.onFailure(exception);
+            }
+        }
+        super.onPostExecute(response);
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
@@ -96,7 +96,7 @@ public class KmHttpClient {
         return null;
     }
 
-    public String getResponseWithException(String urlString, String contentType, String accept, String query, Map<String, String> headers) throws Exception {
+    public String getResponseWithException(String urlString, String contentType, String accept, Map<String, String> headers) throws Exception {
         Utils.printLog(context, TAG, "Calling url **[GET]** : " + urlString);
 
         HttpURLConnection connection = null;

--- a/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
@@ -13,8 +13,13 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.crypto.IllegalBlockSizeException;
 
 public class KmHttpClient {
 
@@ -89,5 +94,75 @@ public class KmHttpClient {
             e.printStackTrace();
         }
         return null;
+    }
+
+    public String getResponseWithException(String urlString, String contentType, String accept, String query, Map<String, String> headers) throws Exception {
+        Utils.printLog(context, TAG, "Calling url **[GET]** : " + urlString);
+
+        HttpURLConnection connection = null;
+        MobiComUserPreference userPreference = MobiComUserPreference.getInstance(context);
+        URL url;
+
+        try {
+            url = new URL(urlString);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setInstanceFollowRedirects(true);
+            connection.setRequestMethod("GET");
+            connection.setUseCaches(false);
+            connection.setDoInput(true);
+
+            if (!TextUtils.isEmpty(contentType)) {
+                connection.setRequestProperty("Content-Type", contentType);
+            }
+            if (!TextUtils.isEmpty(accept)) {
+                connection.setRequestProperty("Accept", accept);
+            }
+            if(headers != null && !headers.isEmpty()) {
+                for (Map.Entry<String, String> header : headers.entrySet()) {
+                    connection.setRequestProperty(header.getKey(), header.getValue());
+                }
+            }
+            connection.connect();
+
+            BufferedReader br = null;
+            if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                InputStream inputStream = connection.getInputStream();
+                br = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
+            } else {
+                Utils.printLog(context, TAG, "\n\nResponse code for url: " + urlString + "\n** Code ** : " + connection.getResponseCode() + "\n\n");
+            }
+
+            StringBuilder sb = new StringBuilder();
+            try {
+                String line;
+                if (br != null) {
+                    while ((line = br.readLine()) != null) {
+                        sb.append(line);
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            } finally {
+                if (br != null) {
+                    br.close();
+                }
+            }
+
+            Utils.printLog(context, TAG, "\n\nGET Response for url: " + urlString + "\n** Response **: " + sb.toString() + "\n\n");
+            return sb.toString();
+        } catch (ConnectException e) {
+            Utils.printLog(context, TAG, "failed to connect Internet is not working");
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        } catch (Throwable e) {
+            throw e;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -803,7 +803,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         if(isApiAutoSuggest) {
                             final AutoCompleteTextView autoCompleteTextView = (AutoCompleteTextView) messageEditText;
                             autoCompleteTextView.setThreshold(2);
-                            new KmGetDataAsyncTask(getContext(), autoSuggestUrl, "application/json", "application/json", "option", autoSuggestHeaders, new KmCallback() {
+                            new KmGetDataAsyncTask(getContext(), autoSuggestUrl, "application/json", "application/json", s.toString().trim(), autoSuggestHeaders, new KmCallback() {
                                 @Override
                                 public void onSuccess(Object message) {
                                     try {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmAutoSuggestion.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/models/v2/KmAutoSuggestion.java
@@ -5,6 +5,8 @@ import android.text.TextUtils;
 import com.applozic.mobicomkit.api.conversation.Message;
 import com.applozic.mobicommons.json.GsonUtils;
 
+import java.util.Map;
+
 public class KmAutoSuggestion {
     private String placeholder;
     private Object source;
@@ -36,6 +38,7 @@ public class KmAutoSuggestion {
         private String searchKey;
         private String message;
         private String url;
+        private Map<String, String> headers;
 
         public String getSearchKey() {
             return searchKey;
@@ -59,6 +62,12 @@ public class KmAutoSuggestion {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+        public void setHeaders(Map<String, String> headers) {
+            this.headers = headers;
         }
 
         @Override


### PR DESCRIPTION
## Summary:
- To fetch AutoSuggestion data from API
- API will be called after 2nd alphabet, for every alphabet - This approach is better than storing all the data locally.

## Data from APi:
```json
{"data": [
 {
                    "searchKey": "option1",
                    "message": "option 1"
                },
                {
                    "searchKey": "option2",
                    "message": "option 2"
                },
                {
                    "searchKey": "option3",
                    "message": "option 3"
                },
                {
                    "searchKey": "option4",
                    "message": "option 4"
                },
                {
                    "searchKey": "option5",
                    "message": "option 5"
                },
                {
                    "searchKey": "option6",
                    "message": "option 6"
                },
                {
                    "searchKey": "option7",
                    "message": "option 7"
                },
                {
                    "searchKey": "option8",
                    "message": "option 8"
                },
                {
                    "searchKey": "option9",
                    "message": "option 9"
                },
                {
                    "searchKey": "option10",
                    "message": "option 10"
                },
                {
                    "searchKey": "option11",
                    "message": "option 11"
                }
]
}
```