### PR TITLE
[CM-1276] - change default visibility of startNewConversation button

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -513,7 +513,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         setupChatBackground();
 
         frameLayoutProgressbar = list.findViewById(R.id.idProgressBarLayout);
-
+        Button startNewConv = list.findViewById(R.id.start_new_conversation);
+        startNewConv.setVisibility(GONE);
         customToolbarLayout = toolbar.findViewById(R.id.custom_toolbar_root_layout);
         loggedInUserId = MobiComUserPreference.getInstance(getContext()).getUserId();
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
@@ -178,6 +178,8 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
 
         if (alCustomizationSettings != null && alCustomizationSettings.isShowStartNewConversation() && User.RoleType.USER_ROLE.getValue().equals(MobiComUserPreference.getInstance(getContext()).getUserRoleType())) {
             startNewConv.setVisibility(View.VISIBLE);
+        } else {
+            startNewConv.setVisibility(View.GONE);
         }
 
         startNewConv.setOnClickListener(new View.OnClickListener() {

--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -99,7 +99,7 @@
                 android:textAllCaps="false"
                 android:textColor="@color/default_start_new_button_text_color"
                 android:textSize="14sp"
-                android:visibility="gone" />
+                android:visibility="visible" />
         </RelativeLayout>
 
         <TextView


### PR DESCRIPTION
## Summary:
- "Start new conversation" button is not visible few times. 

### Root cause:
- It is happening because by default the start new conversation is not not visible. When the settings file is not available when the conversation was opened, the the button will not show.

## Fix:
- By default, the visibility of Start new conversation is set to VISIBLE. From settings, we can change it to visible.