### PR TITLE
[CM-1516] - Android Agent app crash - LayoutInflater null pointer

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4413,7 +4413,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 new MessageDeleteTask(getContext(), message.getKeyString(), true, new AlCallback() {
                     @Override
                     public void onSuccess(Object response) {
-                        KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
+                        KmToast.makeText(Objects.requireNonNull(getContext()), "Message Deleted", Toast.LENGTH_SHORT).show();
                     }
 
                     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4413,7 +4413,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 new MessageDeleteTask(getContext(), message.getKeyString(), true, new AlCallback() {
                     @Override
                     public void onSuccess(Object response) {
-                        KmToast.makeText(Objects.requireNonNull(getContext()), "Message Deleted", Toast.LENGTH_SHORT).show();
+                        if (getContext() != null) {
+                            KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
## Summary

- Fixed null pointer caused by KmToast.makeText.