### PR TITLE
Updated ChannelDatabaseService.java to add Conversation History in Agent App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Added a function to get channel and last message created time as a key-value pair in ChannelDatabaseService.java
+
 ## Kommunicate Android SDK 2.7.5
 1) Fixed online/offline issue for taxbuddy
 2) Fixed issue in which gray status dot is showing when agent is online(hideAssigneeStatus)


### PR DESCRIPTION
Added a function to get a map of channel and last message created time as a key-value pair in order to update the conversation history in agent app. For detailed info -> [CM-1503 Agent App](https://github.com/Kommunicate-io/AgentApp/pull/295)