### PR TITLE
Fix crash for Focus Search

### DIFF
--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -461,6 +461,7 @@
                                 android:minLines="2"
                                 android:textAlignment="viewStart"
                                 android:textColorHint="#8f8b8b"
+                                android:imeOptions="actionDone"
                                 android:textSize="14sp" />
 
                         </RelativeLayout>


### PR DESCRIPTION
## Issue:
java.lang.IllegalStateException: focus search returned a view that wasn't able to take focus!

## Resource: 
https://stackoverflow.com/questions/13614101/fatal-crash-focus-search-returned-a-view-that-wasnt-able-to-take-focus