### PR TITLE
Release changes for V2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Kommunicate Android SDK 2.7.6
+1) Change default visibility of startNewConversation button
+2) Away message visibility effects
+3) Fixed crashes
+
 ## Kommunicate Android SDK 2.7.5
 1) Fixed online/offline issue for taxbuddy
 2) Fixed issue in which gray status dot is showing when agent is online(hideAssigneeStatus)

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.5"
+        versionName "2.7.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'
         buildConfigField "String", "API_SERVER_URL", '"https://api.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.5"
+        versionName "2.7.6"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Kommunicate Android SDK 2.7.6
1) Change default visibility of startNewConversation button
2) Away message visibility effects
3) Fixed crashes