### PR TITLE
[CM-1529] - Refresh icon squeezed on conversation screen | Android

### DIFF
--- a/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_custom_toolbar_layout.xml
@@ -187,10 +187,8 @@
             android:background="@drawable/km_refresh_icon"
             android:paddingStart="7dp"
             android:paddingLeft="7dp"
-            android:paddingTop="5dp"
             android:paddingEnd="7dp"
             android:paddingRight="7dp"
-            android:paddingBottom="5dp"
             android:textSize="16sp"
             android:textStyle="bold" />
     </LinearLayout>


### PR DESCRIPTION
## Summary

- Fixed the refresh icon distortion reported by MG