### PR TITLE
[CM-1524]- add support to send message on language change

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -630,6 +630,12 @@ public class ConversationUIService {
 
     }
 
+    public void sendMessage(String message) {
+        if(BroadcastService.isIndividual()) {
+            getConversationFragment().sendMessage(message);
+        }
+    }
+
     public void updateMessageMetadata(String keyString) {
         if (BroadcastService.isIndividual()) {
             getConversationFragment().updateMessageMetadata(keyString);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -728,8 +728,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             languageChangeButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    if (KmSpeechToTextSetting.getInstance(getContext()).getMultipleLanguage() != null) {
-                        new KmLanguageSlideView(KmSpeechToTextSetting.getInstance(getContext()).getMultipleLanguage()).show(getChildFragmentManager(), KmLanguageSlideView.getFragTag());
+                    if (KmSpeechToTextSetting.getInstance(getContext()).getSpeechToTextList() != null) {
+                        new KmLanguageSlideView(conversationUIService, KmSpeechToTextSetting.getInstance(getContext()).getSpeechToTextList()).show(getChildFragmentManager(), KmLanguageSlideView.getFragTag());
                     }
                 }
             });

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmLanguageSelectionAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmLanguageSelectionAdapter.java
@@ -47,8 +47,6 @@ public class KmLanguageSelectionAdapter extends RecyclerView.Adapter {
         mViewHolder.kmLanguageCode.setVisibility(KmSpeechToTextSetting.getInstance(context).isShowLanguageCode() ? View.VISIBLE : View.GONE);
 
         mViewHolder.kmLanguageName.setText(languages.get(position).getName());
-//        mViewHolder.kmLanguageName.setText("name");
-//        mViewHolder.kmLanguageCode.setText("code");
         mViewHolder.kmLanguageCode.setText(languages.get(position).getCode());
         if (languages.get(position).getCode().equals(selectedLanguageCode)) {
             mViewHolder.parentView.setBackgroundColor(Utils.getColor(context, R.color.km_language_selected_background_color));

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmLanguageSelectionAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/adapters/KmLanguageSelectionAdapter.java
@@ -13,23 +13,24 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.KmPrefSettings;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.KmClickHandler;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.models.KmSpeechToTextModel;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.settings.KmSpeechToTextSetting;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
+
+import java.util.List;
 
 public class KmLanguageSelectionAdapter extends RecyclerView.Adapter {
     private Context context;
-    private LinkedHashMap<String, String> languageMap;
-    private KmClickHandler<String> kmClickHandler;
+    private List<KmSpeechToTextModel> languages;
+    private KmClickHandler<KmSpeechToTextModel> kmClickHandler;
     private String selectedLanguageCode;
 
-    public KmLanguageSelectionAdapter(Context context, Map<String, String> languages, KmClickHandler<String> kmClickHandler) {
+    public KmLanguageSelectionAdapter(Context context, List<KmSpeechToTextModel> languages, KmClickHandler<KmSpeechToTextModel> kmClickHandler) {
         this.kmClickHandler = kmClickHandler;
         this.context = context;
         this.selectedLanguageCode = KmPrefSettings.getInstance(context).getSpeechToTextLanguage();
-        this.languageMap = new LinkedHashMap<>(languages);
+        this.languages = languages;
     }
 
     @NonNull
@@ -40,33 +41,33 @@ public class KmLanguageSelectionAdapter extends RecyclerView.Adapter {
     }
 
     @Override
-    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, int position) {
-       KmLanguageSelectionAdapter.LanguageViewHolder mViewHolder = (KmLanguageSelectionAdapter.LanguageViewHolder) viewHolder;
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder viewHolder, final int position) {
+       final KmLanguageSelectionAdapter.LanguageViewHolder mViewHolder = (KmLanguageSelectionAdapter.LanguageViewHolder) viewHolder;
         mViewHolder.kmLanguageName.setVisibility(View.VISIBLE);
         mViewHolder.kmLanguageCode.setVisibility(KmSpeechToTextSetting.getInstance(context).isShowLanguageCode() ? View.VISIBLE : View.GONE);
 
-        mViewHolder.kmLanguageName.setText(getMapValue(position));
-        mViewHolder.kmLanguageCode.setText(getMapKey(position));
-        if (getMapKey(position).equals(selectedLanguageCode)) {
+        mViewHolder.kmLanguageName.setText(languages.get(position).getName());
+//        mViewHolder.kmLanguageName.setText("name");
+//        mViewHolder.kmLanguageCode.setText("code");
+        mViewHolder.kmLanguageCode.setText(languages.get(position).getCode());
+        if (languages.get(position).getCode().equals(selectedLanguageCode)) {
             mViewHolder.parentView.setBackgroundColor(Utils.getColor(context, R.color.km_language_selected_background_color));
             mViewHolder.kmLanguageName.setTextColor(Utils.getColor(context, R.color.km_language_selected_name_text_color));
             mViewHolder.kmLanguageCode.setTextColor(Utils.getColor(context, R.color.km_language_selected_code_text_color));
         }
-    }
-
-    private String getMapValue(int position) {
-        String[] keys = languageMap.keySet().toArray(new String[0]);
-        return languageMap.get(keys[position]);
-    }
-
-    private String getMapKey(int position) {
-        String[] keys = languageMap.keySet().toArray(new String[0]);
-        return keys[position];
+        mViewHolder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                if(view != null && kmClickHandler != null) {
+                    kmClickHandler.onItemClicked(mViewHolder.itemView, languages.get(position));
+                }
+            }
+        });
     }
 
     @Override
     public int getItemCount() {
-        return languageMap.size();
+        return languages.size();
     }
 
     private class LanguageViewHolder extends RecyclerView.ViewHolder {
@@ -78,15 +79,6 @@ public class KmLanguageSelectionAdapter extends RecyclerView.Adapter {
             kmLanguageName = itemView.findViewById(R.id.km_language_name);
             kmLanguageCode = itemView.findViewById(R.id.km_language_code);
             parentView = itemView.findViewById(R.id.km_language_parent_view);
-
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    if (kmClickHandler != null) {
-                        kmClickHandler.onItemClicked(itemView, kmLanguageCode.getText().toString());
-                    }
-                }
-            });
         }
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/models/KmSpeechToTextModel.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/models/KmSpeechToTextModel.java
@@ -1,0 +1,54 @@
+package com.applozic.mobicomkit.uiwidgets.kommunicate.models;
+
+import com.applozic.mobicomkit.uiwidgets.kommunicate.settings.KmSpeechToTextSetting;
+import com.applozic.mobicommons.json.JsonMarker;
+
+public class KmSpeechToTextModel extends JsonMarker {
+    private String code;
+    private String name;
+    private String messageToSend;
+    private boolean sendMessageOnClick;
+
+    public KmSpeechToTextModel(String code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+    public KmSpeechToTextModel(String code, String name, String messageToSend, boolean sendMessageOnClick) {
+        this.code = code;
+        this.name = name;
+        this.messageToSend = messageToSend;
+        this.sendMessageOnClick = sendMessageOnClick;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getMessageToSend() {
+        return messageToSend;
+    }
+
+    public void setMessageToSend(String messageToSend) {
+        this.messageToSend = messageToSend;
+    }
+
+    public boolean isSendMessageOnClick() {
+        return sendMessageOnClick;
+    }
+
+    public void setSendMessageOnClick(boolean sendMessageOnClick) {
+        this.sendMessageOnClick = sendMessageOnClick;
+    }
+}

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/settings/KmSpeechToTextSetting.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/settings/KmSpeechToTextSetting.java
@@ -4,9 +4,13 @@ import android.content.Context;
 import android.content.SharedPreferences;
 
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
+import com.applozic.mobicomkit.api.people.ChannelInfo;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.models.KmSpeechToTextModel;
 import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.json.GsonUtils;
+import com.google.gson.reflect.TypeToken;
 
+import java.util.List;
 import java.util.Map;
 
 public class KmSpeechToTextSetting {
@@ -16,6 +20,7 @@ public class KmSpeechToTextSetting {
     private static final String ENABLE_MULTIPLE_SPEECH_TO_TEXT = "ENABLE_MULTIPLE_SPEECH_TO_TEXT";
     private static final String SEND_MESSAGE_ON_SPEECH_END = "SEND_MESSAGE_ON_SPEECH_END";
     private static final String SHOW_LANGUAGE_CODE = "SHOW_LANGUAGE_CODE";
+    private static final String S2T_LANGUAGE_LIST = "S2T_LANGUAGE_LIST";
 
 
     private KmSpeechToTextSetting(Context context) {
@@ -42,6 +47,24 @@ public class KmSpeechToTextSetting {
         if(sharedPreferences != null) {
             Map<String, String> languages = (Map<String, String>) GsonUtils.getObjectFromJson(sharedPreferences.getString(S2T_LANGUAGES, ""), Map.class);
             return languages;
+        }
+        return null;
+    }
+
+    public KmSpeechToTextSetting setSpeechToTextList(List<KmSpeechToTextModel> speechToTextList) {
+        if(sharedPreferences != null) {
+            String listJson = GsonUtils.getJsonFromObject(speechToTextList,  new
+                    TypeToken<List<KmSpeechToTextModel>>() {
+                    }.getType());
+            sharedPreferences.edit().putString(S2T_LANGUAGE_LIST, listJson).apply();
+        }
+        return this;
+    }
+
+    public List<KmSpeechToTextModel> getSpeechToTextList() {
+        if(sharedPreferences != null) {
+            return (List<KmSpeechToTextModel>) GsonUtils.getObjectFromJson(sharedPreferences.getString(S2T_LANGUAGE_LIST, ""), new TypeToken<List<KmSpeechToTextModel>>() {
+                    }.getType());
         }
         return null;
     }
@@ -85,4 +108,6 @@ public class KmSpeechToTextSetting {
         }
         return false;
     }
+
+
 }


### PR DESCRIPTION
## Summary
- Added support to trigger an intent when language is selected for speech to text
- Created KmSpeechToTextModel class to use it on Multiple Language support for Speech to Text
- This is can be enabled like below

```
List<KmSpeechToTextModel> list = new ArrayList<>();
        KmSpeechToTextModel m1 = new KmSpeechToTextModel("en", "English", "Change language to English", true);
        KmSpeechToTextModel m2 = new KmSpeechToTextModel("hi", "Hindi", "Change language to Hindi", true);
        KmSpeechToTextModel m3 = new KmSpeechToTextModel("zh", "Chinese", "Change language to Chinse", true);
        list.add(m1);
        list.add(m2);
        list.add(m3);
        KmSpeechToTextSetting.getInstance(SplashScreenActivity.this).setSpeechToTextList(list)
                .enableMultipleSpeechToText(true)
                .sendMessageOnSpeechEnd(true)
                .showLanguageCode(false);
```

