### PR TITLE
[CM-1527] - Show/Hide Template message buttons based on Restart butto…

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4708,6 +4708,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
      * @param display true to display/ false to not
      */
     public void setFeedbackDisplay(boolean display) {
+        hideMessageTemplate();
         if (channel != null && !channel.isDeleted()) {
             if (display) {
                 kmFeedbackView.setVisibility(VISIBLE);
@@ -5190,6 +5191,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             recordLayout.setVisibility(hideLayout || !isRecordOptionEnabled ? GONE : VISIBLE);
         } else {
             individualMessageSendLayout.setVisibility(VISIBLE);
+        }
+    }
+    public void hideMessageTemplate() {
+        if (messageTemplate != null && messageTemplate.isEnabled()) {
+            if (!alCustomizationSettings.isRestartConversationButtonVisibility() && channel != null && channel.getKmStatus() == Channel.CLOSED_CONVERSATIONS) {
+                messageTemplateView.setVisibility(GONE);
+            } else {
+                messageTemplateView.setVisibility(View.VISIBLE);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixed conversation getting reopen when user clicks on message template even when the restart conversation button is disabled.

