### PR TITLE
[CM-1570] - to make menu items appear below the Action Bar area

### DIFF
--- a/kommunicateui/src/main/res/layout/feedback_rating_layout.xml
+++ b/kommunicateui/src/main/res/layout/feedback_rating_layout.xml
@@ -117,7 +117,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:gravity="center_horizontal"
-                android:text="@string/rating_good" />
+                android:text="@string/rating_great" />
         </LinearLayout>
 
     </LinearLayout>

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -8,7 +8,7 @@
     <string name="select_at_least">At least 1 contact must be selected</string>
     <string name="group_name_hint">Name of the group</string>
     <string name="empty_conversations">No conversations!</string>
-    <string name="enter_message_hint">Write a message…</string>
+    <string name="enter_message_hint">Type your message...</string>
     <string name="send_text">SEND</string>
     <string name="cancel_text">CANCEL</string>
     <string name="ok_text">OK</string>

--- a/kommunicateui/src/main/res/values/mobicom_strings.xml
+++ b/kommunicateui/src/main/res/values/mobicom_strings.xml
@@ -203,7 +203,7 @@
     <string name="km_read">Read</string>
     <string name="km_not_read">Not read yet</string>
     <string name="km_not_sent">Not sent</string>
-    <string name="default_start_new_conversation">Start new conversation</string>
+    <string name="default_start_new_conversation">Start New Conversation</string>
     <string name="start_conversation">Start Conversation</string>
     <string name="info_file_attachment_mime_type_not_supported">Can\'t send this type of files!</string>
     <string name="processing_take_over_from_bot">Taking over from bot</string>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -227,7 +227,7 @@
     <string name="resolved_info_text">This conversation has been marked as resolved.</string>
     <string name="restart_conversation_text">Restart conversation</string>
     <string name="rating_text">You rated the conversation</string>
-    <string name="rating_good">Good</string>
+    <string name="rating_great">Great</string>
     <string name="add_a_comment">Add a comment..</string>
     <string name="submit_your_rating">Submit your rating</string>
     <string name="rating_average">Average</string>

--- a/kommunicateui/src/main/res/values/styles.xml
+++ b/kommunicateui/src/main/res/values/styles.xml
@@ -26,6 +26,9 @@
 
     <style name="KommunicateActionBar" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="android:textColorSecondary">@color/km_toolbar_icon_color</item>
+<!--        to make menu items appear below the Action Bar area-->
+        <item name="overlapAnchor">false</item>
+        <item name="android:dropDownVerticalOffset">?attr/actionBarSize</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary

- Made changes to make menu items appear below the Action Bar area
- Changed the text of feedback rating(Good -> Great)
- Changed the hint for conversation_message textview("Write a message…" -> "Type your message...")


![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/128575315/70fe2104-ae68-44e2-993a-f18463e86cf1)


![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/128575315/fdb14965-4891-4217-abb1-79c9a3ea7961)


![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/128575315/201f7cdf-0943-4bdc-b2a1-44cd3a2acb8e)
