### PR TITLE
[CM-1572] Added DropDownVerticalOffset for Form type rich message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed dropdown list of spinner in form type rich message clashing with the spinner layout
+
 ## Kommunicate Android SDK 2.7.7
 1) Added support to send message on language change
 2) Show/Hide Template message buttons when resolved conversation

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -15,6 +15,7 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.CheckBox;
@@ -340,6 +341,16 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                                 }
 
                                 KmDropdownItemAdapter dropdownItemAdapter = new KmDropdownItemAdapter(context, android.R.layout.simple_spinner_item, dropdownList.getOptions());
+
+                                formItemViewHolder.formDropdownList.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+                                    @Override
+                                    public void onGlobalLayout() {
+                                        Spinner spinner = formItemViewHolder.formDropdownList;
+                                        spinner.setDropDownVerticalOffset(spinner.getHeight());
+                                        spinner.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                                    }
+                                });
+
                                 formItemViewHolder.formDropdownList.setAdapter(dropdownItemAdapter);
                                 dropdownItemAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 


### PR DESCRIPTION
Earlier the drop down list of form type rich message is clashing with the spinner layout which is fixed

![Screenshot_20230803-173608](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/d7e08691-4f71-45b2-9828-ac10a6a4558d)