### PR TITLE
release changes for v2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
 
-## Unreleased
+## Kommunicate Android SDK 2.7.8
 1) Fixed dropdown list of spinner in form type rich message clashing with the spinner layout
 2) Added customization to center toolbar title and left align message templates
 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.7"
+        versionName "2.7.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'
         buildConfigField "String", "API_SERVER_URL", '"https://api.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 33
         versionCode 1
-        versionName "2.7.7"
+        versionName "2.7.8"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Kommunicate Android SDK 2.7.8
1) Fixed dropdown list of spinner in form type rich message clashing with the spinner layout
2) Added customization to center toolbar title and left align message templates
