### PR TITLE
[CM-1586] - Getting duplicate data on recycler view (conversation list)

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/database/MessageDatabaseService.java
@@ -1114,7 +1114,7 @@ public class MessageDatabaseService {
                         "AND m.type not in (6, 7) AND m.channelKey = 0 " +
                         "group by m.contactNumbers " +
                         ") temp " +
-                        (lastFetchTime != null && lastFetchTime > 0 ? " where temp.maxCreatedAt < ?" : "") +
+                        (lastFetchTime != null && lastFetchTime > 0 ? " where temp.maxCreatedAt < " + lastFetchTime : "") +
                         " ORDER BY temp.maxCreatedAt DESC";
                 selectionArgs.add(String.valueOf(status));
                 if (lastFetchTime != null && lastFetchTime > 0) {


### PR DESCRIPTION
## Summary

- Duplicate conversation were showing in the conversation list 
- This issue Was happening because of wrong SQL query in MessageDatabaseService class


## How it is tested

- Tested on local release build