### PR TITLE
[CM-1556] - NullPointerException When trying to login in agent app

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/data/SecureSharedPreferences.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/data/SecureSharedPreferences.java
@@ -66,13 +66,7 @@ public class SecureSharedPreferences implements SharedPreferences {
      * @return the plain value for the given key
      */
     private <T> String getDecryptedString(String key, T defValue) {
-        try{
-            return SecurityUtils.decrypt(SecurityUtils.AES, sharedPreferences.getString(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector).trim(), String.valueOf(defValue)), secretKeyAES, initializationVector);
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
+        return SecurityUtils.decrypt(SecurityUtils.AES, sharedPreferences.getString(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector).trim(), String.valueOf(defValue)), secretKeyAES, initializationVector);
     }
 
     /**
@@ -82,13 +76,8 @@ public class SecureSharedPreferences implements SharedPreferences {
      * @return the encrypted string
      */
     private String encryptString(String string) {
-        try {
-            return !TextUtils.isEmpty(string) ? SecurityUtils.encrypt(SecurityUtils.AES, string, secretKeyAES, initializationVector) : "";
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }    }
+        return !TextUtils.isEmpty(string) ? SecurityUtils.encrypt(SecurityUtils.AES, string, secretKeyAES, initializationVector) : "";
+    }
 
     /**
      * encrypts the entire shared preference passed to it
@@ -142,22 +131,15 @@ public class SecureSharedPreferences implements SharedPreferences {
     @Nullable
     @Override
     public Set<String> getStringSet(String key, @Nullable Set<String> defValue) {
-        try {
-            Set<String> encryptSet = sharedPreferences.getStringSet(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector), defValue);
-
-            Set<String> decryptSet = new HashSet<>();
-            if (encryptSet == null) {
-                return defValue;
-            }
-            for (Object string : encryptSet) {
-                decryptSet.add(SecurityUtils.decrypt(SecurityUtils.AES, (String) string, secretKeyAES, initializationVector));
-            }
-
-            return decryptSet;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
+        Set encryptSet = sharedPreferences.getStringSet(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector), defValue);
+        Set<String> decryptSet = new HashSet<>();
+        if (encryptSet == null) {
+            return defValue;
         }
+        for (Object string : encryptSet) {
+            decryptSet.add(SecurityUtils.decrypt(SecurityUtils.AES, (String) string, secretKeyAES, initializationVector));
+        }
+        return decryptSet;
     }
 
     @Override

--- a/kommunicate/src/main/java/com/applozic/mobicommons/data/SecureSharedPreferences.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/data/SecureSharedPreferences.java
@@ -66,7 +66,13 @@ public class SecureSharedPreferences implements SharedPreferences {
      * @return the plain value for the given key
      */
     private <T> String getDecryptedString(String key, T defValue) {
-        return SecurityUtils.decrypt(SecurityUtils.AES, sharedPreferences.getString(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector).trim(), String.valueOf(defValue)), secretKeyAES, initializationVector);
+        try{
+            return SecurityUtils.decrypt(SecurityUtils.AES, sharedPreferences.getString(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector).trim(), String.valueOf(defValue)), secretKeyAES, initializationVector);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     /**
@@ -76,8 +82,13 @@ public class SecureSharedPreferences implements SharedPreferences {
      * @return the encrypted string
      */
     private String encryptString(String string) {
-        return !TextUtils.isEmpty(string) ? SecurityUtils.encrypt(SecurityUtils.AES, string, secretKeyAES, initializationVector) : "";
-    }
+        try {
+            return !TextUtils.isEmpty(string) ? SecurityUtils.encrypt(SecurityUtils.AES, string, secretKeyAES, initializationVector) : "";
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }    }
 
     /**
      * encrypts the entire shared preference passed to it
@@ -131,15 +142,22 @@ public class SecureSharedPreferences implements SharedPreferences {
     @Nullable
     @Override
     public Set<String> getStringSet(String key, @Nullable Set<String> defValue) {
-        Set encryptSet = sharedPreferences.getStringSet(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector), defValue);
-        Set<String> decryptSet = new HashSet<>();
-        if (encryptSet == null) {
-            return defValue;
+        try {
+            Set<String> encryptSet = sharedPreferences.getStringSet(SecurityUtils.encrypt(SecurityUtils.AES, key, secretKeyAES, initializationVector), defValue);
+
+            Set<String> decryptSet = new HashSet<>();
+            if (encryptSet == null) {
+                return defValue;
+            }
+            for (Object string : encryptSet) {
+                decryptSet.add(SecurityUtils.decrypt(SecurityUtils.AES, (String) string, secretKeyAES, initializationVector));
+            }
+
+            return decryptSet;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
         }
-        for (Object string : encryptSet) {
-            decryptSet.add(SecurityUtils.decrypt(SecurityUtils.AES, (String) string, secretKeyAES, initializationVector));
-        }
-        return decryptSet;
     }
 
     @Override

--- a/kommunicate/src/main/java/com/applozic/mobicommons/encryption/SecurityUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/encryption/SecurityUtils.java
@@ -221,6 +221,24 @@ public class SecurityUtils {
                 return secretKey;
             }
         } catch (Exception exception) {
+            if (exception instanceof IllegalBlockSizeException) {
+            SharedPreferences sharedPreferences = context.getApplicationContext().getSharedPreferences(CRYPTO_SHARED_PREF, Context.MODE_PRIVATE);
+            SecretKey secretKey = generateAESKey();
+            if (secretKey == null) {
+                Utils.printLog(context, TAG, "SecretKey is null. There are problems occurring with it's generation at runtime.");
+                return null;
+            }
+
+            //do not encrypt aes key if rsa keypair is null
+            String cipherKey = Base64.encodeToString(secretKey.getEncoded(), Base64.DEFAULT);
+
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putString(AES_ENCRYPTION_KEY, cipherKey);
+            editor.putBoolean(AES_KEY_ENCRYPTED,false);
+            editor.apply();
+            return secretKey;
+        }
+            exception.printStackTrace();
             return null;
         }
     }
@@ -268,7 +286,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the cipher text
      */
-    private static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) {
+    private static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) throws Exception{
         if (TextUtils.isEmpty(plainText) || TextUtils.isEmpty(cryptAlgorithm)) {
             return null;
         }
@@ -290,7 +308,7 @@ public class SecurityUtils {
      * @param keyPairRSA     the key pair for rsa encryption/decryption
      * @return the cipher text
      */
-    public static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA) {
+    public static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA) throws Exception {
         return encrypt(cryptAlgorithm, plainText, keyPairRSA, null, null);
     }
 
@@ -303,7 +321,7 @@ public class SecurityUtils {
      * @param initializationVector the IV for ECB encryption mode
      * @return the cipher text
      */
-    public static String encrypt(String cryptAlgorithm, String plainText, SecretKey secretKeyAES, byte[] initializationVector) {
+    public static String encrypt(String cryptAlgorithm, String plainText, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
         return encrypt(cryptAlgorithm, plainText, null, secretKeyAES, initializationVector);
     }
 
@@ -317,7 +335,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the plain text
      */
-    private static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) {
+    private static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
         try {
             Cipher cipher = returnCipher(cryptAlgorithm, Cipher.DECRYPT_MODE, keyPairRSA, secretKeyAES, initializationVector);
             byte[] cipherArray = Base64.decode(cipherText, Base64.DEFAULT);
@@ -336,7 +354,7 @@ public class SecurityUtils {
      * @param keyPairRSA     the key pair for rsa encryption/decryption
      * @return the plain text
      */
-    public static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA) {
+    public static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA) throws Exception {
         return decrypt(cryptAlgorithm, cipherText, keyPairRSA, null, null);
     }
 
@@ -349,7 +367,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the plain text
      */
-    public static String decrypt(String cryptAlgorithm, String cipherText, SecretKey secretKeyAES, byte[] initializationVector) {
+    public static String decrypt(String cryptAlgorithm, String cipherText, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
         return decrypt(cryptAlgorithm, cipherText, null, secretKeyAES, initializationVector);
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicommons/encryption/SecurityUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/encryption/SecurityUtils.java
@@ -221,24 +221,6 @@ public class SecurityUtils {
                 return secretKey;
             }
         } catch (Exception exception) {
-            if (exception instanceof IllegalBlockSizeException) {
-            SharedPreferences sharedPreferences = context.getApplicationContext().getSharedPreferences(CRYPTO_SHARED_PREF, Context.MODE_PRIVATE);
-            SecretKey secretKey = generateAESKey();
-            if (secretKey == null) {
-                Utils.printLog(context, TAG, "SecretKey is null. There are problems occurring with it's generation at runtime.");
-                return null;
-            }
-
-            //do not encrypt aes key if rsa keypair is null
-            String cipherKey = Base64.encodeToString(secretKey.getEncoded(), Base64.DEFAULT);
-
-            SharedPreferences.Editor editor = sharedPreferences.edit();
-            editor.putString(AES_ENCRYPTION_KEY, cipherKey);
-            editor.putBoolean(AES_KEY_ENCRYPTED,false);
-            editor.apply();
-            return secretKey;
-        }
-            exception.printStackTrace();
             return null;
         }
     }
@@ -286,7 +268,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the cipher text
      */
-    private static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) throws Exception{
+    private static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) {
         if (TextUtils.isEmpty(plainText) || TextUtils.isEmpty(cryptAlgorithm)) {
             return null;
         }
@@ -308,7 +290,7 @@ public class SecurityUtils {
      * @param keyPairRSA     the key pair for rsa encryption/decryption
      * @return the cipher text
      */
-    public static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA) throws Exception {
+    public static String encrypt(String cryptAlgorithm, String plainText, KeyPair keyPairRSA) {
         return encrypt(cryptAlgorithm, plainText, keyPairRSA, null, null);
     }
 
@@ -321,7 +303,7 @@ public class SecurityUtils {
      * @param initializationVector the IV for ECB encryption mode
      * @return the cipher text
      */
-    public static String encrypt(String cryptAlgorithm, String plainText, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
+    public static String encrypt(String cryptAlgorithm, String plainText, SecretKey secretKeyAES, byte[] initializationVector) {
         return encrypt(cryptAlgorithm, plainText, null, secretKeyAES, initializationVector);
     }
 
@@ -335,7 +317,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the plain text
      */
-    private static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
+    private static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA, SecretKey secretKeyAES, byte[] initializationVector) {
         try {
             Cipher cipher = returnCipher(cryptAlgorithm, Cipher.DECRYPT_MODE, keyPairRSA, secretKeyAES, initializationVector);
             byte[] cipherArray = Base64.decode(cipherText, Base64.DEFAULT);
@@ -354,7 +336,7 @@ public class SecurityUtils {
      * @param keyPairRSA     the key pair for rsa encryption/decryption
      * @return the plain text
      */
-    public static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA) throws Exception {
+    public static String decrypt(String cryptAlgorithm, String cipherText, KeyPair keyPairRSA) {
         return decrypt(cryptAlgorithm, cipherText, keyPairRSA, null, null);
     }
 
@@ -367,7 +349,7 @@ public class SecurityUtils {
      * @param initializationVector the vector for aes encryption/decryption
      * @return the plain text
      */
-    public static String decrypt(String cryptAlgorithm, String cipherText, SecretKey secretKeyAES, byte[] initializationVector) throws Exception {
+    public static String decrypt(String cryptAlgorithm, String cipherText, SecretKey secretKeyAES, byte[] initializationVector) {
         return decrypt(cryptAlgorithm, cipherText, null, secretKeyAES, initializationVector);
     }
 }


### PR DESCRIPTION
## Summary

### Root cause
-  This issue happens when user uninstall the app(Without clearing the app data) and the reinstall the app again.
- Problem arises because there is already AES key is present in the sharedPreferences and it is encrypted with old RSA keyPair(public and private key) so when the app is installed again the app generates new RSA keyPair so it cannot decrypt the old AES key

### Fix for this issue
- For this we clear the sharedPreferences and then generatesAES key, encrypt it, store it to shared pref and return the un-encrypted version 


## How it is tested
- Tested basic functionality of the agent app locally

![image](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/128575315/832dbfd8-5c25-4278-8626-7e7e80fde4f4)
