### PR TITLE
[customizations-for-mg] Fixed toolbar title alignment when menu options are enabled/disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed toolbar title not in center when menu option is disabled
 
 ## Kommunicate Android SDK 2.7.8
 1) Fixed dropdown list of spinner in form type rich message clashing with the spinner layout

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -669,12 +669,10 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
     }
 
     private boolean isOverflowMenuVisible(Toolbar toolbar) {
-        Log.d("hey toolbarChildCount " , ""+toolbar.getChildCount());
 
         for (int i = 0; i < toolbar.getChildCount(); i++) {
             if (toolbar.getChildAt(i) instanceof ActionMenuView) {
                 ActionMenuView actionMenuView = (ActionMenuView) toolbar.getChildAt(i);
-                Log.d("here",""+actionMenuView.getMenu().hasVisibleItems());
                 return actionMenuView.getMenu().hasVisibleItems();
             }
         }

--- a/kommunicateui/src/main/res/layout/quickconversion_activity.xml
+++ b/kommunicateui/src/main/res/layout/quickconversion_activity.xml
@@ -29,11 +29,13 @@
 
             <TextView
                 android:id="@+id/km_conversation_text_view"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
-                android:layout_centerVertical="true"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerInParent="true"
                 android:text="@string/conversations"
                 android:textColor="@color/km_toolbar_icon_color"
                 android:textSize="18sp"


### PR DESCRIPTION
## When menu icon is enabled
![Screenshot_20230816-175544](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/641080e3-da87-4e06-8ee4-5e9db7d3ed49)

## When menu icon is disabled

![Screenshot_20230816-175559](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/acb034fc-9e5e-4e23-b978-003052ee8f15)