### PR TITLE
[CM-1595] Fixed toolbar title alignement when menu icon is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed toolbar title not in center when menu option is disabled
 
 ## Kommunicate Android SDK 2.7.8
 1) Fixed dropdown list of spinner in form type rich message clashing with the spinner layout

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -11,6 +11,7 @@ import android.content.IntentFilter;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.location.Location;
 import android.location.LocationManager;
@@ -23,10 +24,13 @@ import android.provider.MediaStore;
 import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
+import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -34,6 +38,7 @@ import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.ActionMenuView;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.core.app.ActivityCompat;
@@ -373,17 +378,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
         if (alCustomizationSettings.isToolbarTitleCenterAligned()) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                TextView toolbarTitle = myToolbar.findViewById(R.id.km_conversation_text_view);
-                RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) toolbarTitle.getLayoutParams();
-                layoutParams.addRule(RelativeLayout.CENTER_HORIZONTAL);
-                layoutParams.addRule(RelativeLayout.CENTER_VERTICAL);
-                layoutParams.addRule(RelativeLayout.ALIGN_PARENT_START, 0);
-                layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT, 0);
-                toolbarTitle.setLayoutParams(layoutParams);
-                RelativeLayout layout = findViewById(R.id.faqButtonLayout);
-                Toolbar.LayoutParams params = (Toolbar.LayoutParams) layout.getLayoutParams();
-                params.setMarginEnd(0);
-                layout.setLayoutParams(params);
+                centerToolbarTitle(myToolbar);
             }
         }
 
@@ -506,6 +501,38 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         if(alCustomizationSettings.isUseDeviceDefaultLanguage()){
             Applozic.setDefaultLanguage(this);
         }
+    }
+
+    private void centerToolbarTitle(Toolbar myToolbar) {
+        TextView toolbarTitle = myToolbar.findViewById(R.id.km_conversation_text_view);
+        RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) toolbarTitle.getLayoutParams();
+        toolbarTitle.setGravity(Gravity.CENTER);
+        ViewTreeObserver viewTreeObserver = getWindow().getDecorView().getViewTreeObserver();
+
+        Resources resources = getResources();
+        TypedValue typedValue = new TypedValue();
+        getApplicationContext().getTheme().resolveAttribute(
+                android.R.attr.actionBarSize, typedValue, true);
+
+        int actionBarWidth = (int) typedValue.getDimension(resources.getDisplayMetrics());
+
+        ViewTreeObserver.OnGlobalLayoutListener listener = new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                int marginEnd;
+                if(isOverflowMenuVisible(myToolbar)){
+                    marginEnd = 10;
+                }
+                else {
+                    marginEnd = actionBarWidth - 30;
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    layoutParams.setMarginEnd(marginEnd);
+                }
+                toolbarTitle.setLayoutParams(layoutParams);
+            }
+        };
+        viewTreeObserver.addOnGlobalLayoutListener(listener);
     }
 
     @Override
@@ -639,6 +666,17 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
                 Utils.printLog(this, TAG, "URI format(extension) is empty.");
                 break;
         }
+    }
+
+    private boolean isOverflowMenuVisible(Toolbar toolbar) {
+
+        for (int i = 0; i < toolbar.getChildCount(); i++) {
+            if (toolbar.getChildAt(i) instanceof ActionMenuView) {
+                ActionMenuView actionMenuView = (ActionMenuView) toolbar.getChildAt(i);
+                return actionMenuView.getMenu().hasVisibleItems();
+            }
+        }
+        return false;
     }
 
     public void setToolbarTitleSubtitleColorFromSettings() {

--- a/kommunicateui/src/main/res/layout/quickconversion_activity.xml
+++ b/kommunicateui/src/main/res/layout/quickconversion_activity.xml
@@ -29,11 +29,13 @@
 
             <TextView
                 android:id="@+id/km_conversation_text_view"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
-                android:layout_centerVertical="true"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerInParent="true"
                 android:text="@string/conversations"
                 android:textColor="@color/km_toolbar_icon_color"
                 android:textSize="18sp"


### PR DESCRIPTION
## When menu icon is enabled
![Screenshot_20230816-175544](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/641080e3-da87-4e06-8ee4-5e9db7d3ed49)

## When menu icon is disabled

![Screenshot_20230816-175559](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/acb034fc-9e5e-4e23-b978-003052ee8f15)