### PR TITLE
[CM-1653] Fixed message template crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed message template crash
 ## Kommunicate Android SDK 2.8.0
 1) Added customisation to change the option menu icon on Conversation Screen
 ## Kommunicate Android SDK 2.7.9

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -645,12 +645,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             }
         }
 
-        if(alCustomizationSettings.getMessageTemplate().isLeftAligned()){
-            ViewGroup.LayoutParams layoutParams = messageTemplateView.getLayoutParams();
-            layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
-            messageTemplateView.setLayoutParams(layoutParams);
-        }
-
         boolean isAgentApp = alCustomizationSettings != null && alCustomizationSettings.isAgentApp();
 
         if (!isAgentApp && MobiComUserPreference.getInstance(getContext()).getPricingPackage() == 1) {
@@ -950,6 +944,11 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
         if (messageTemplate != null && messageTemplate.isEnabled()) {
             messageTemplateView.setVisibility(View.VISIBLE);
+            if(messageTemplate.isLeftAligned()){
+                ViewGroup.LayoutParams layoutParams = messageTemplateView.getLayoutParams();
+                layoutParams.width = ViewGroup.LayoutParams.MATCH_PARENT;
+                messageTemplateView.setLayoutParams(layoutParams);
+            }
             templateAdapter = new MobicomMessageTemplateAdapter(messageTemplate);
             MobicomMessageTemplateAdapter.MessageTemplateDataListener listener = new MobicomMessageTemplateAdapter.MessageTemplateDataListener() {
                 @Override


### PR DESCRIPTION
## Summary
When message templates were null the app was crashing which is fixed by adding a check.

## Steps to reproduce
To reproduce the crash remove the following code from  `applozic-settings.json` , build the app and go to conversation screen. 
```
"messageTemplate": {
    "isEnabled": false,
    "isLeftAligned" : false,
    "borderColor": "#5c5aa7",
    "backgroundColor": "#FFFFFF",
    "hideOnSend": false,
    "sendMessageOnClick": true,
    "cornerRadius": 30,
    "textColor": "#5c5aa7",
    "messageList": {
      "Greetings": "Hey",
      "Help?": "How may I help you?",
      "Email-Id": "May I know your emailId",
      "Company": "May I know your company name?",
      "Platform?": "Is this related to Android, iOS, or web?",
      "Doc?": "Did you follow our doc?"
    }
  },
```
