### PR TITLE
[CM-1239] Fixed typing indicator appearing after welcome message was received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed typing indicator appearing after welcome message was received
 ## Kommunicate Android SDK 2.8.3
 1) Team Concept phase 3
 ## Kommunicate Android SDK 2.8.2

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4086,8 +4086,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
 
                     nextMessageList = conversationService.getMessages(lastConversationloadTime + 1L, null, contact, channel, conversationId, false, !TextUtils.isEmpty(messageSearchString));
-                }
-                else if (firstVisibleItem == 1 && loadMore && !messageList.isEmpty()) {
+                } else if (firstVisibleItem == 1 && loadMore && !messageList.isEmpty()) {
                     loadMore = false;
                     Long endTime = null;
                     for (Message message : messageList) {


### PR DESCRIPTION
## Summary

Previously, if we set the delay for bot message, there was no delay for the welcome message and the typing indicator was appearing after the welcome message was received which is fixed here.

### Before

<img src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/f4adcd60-9d25-4da7-b9f3-daff50cd139f" alt="before" width="300" height="525">

### After

<img src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/6678b634-854e-4022-ae3a-c53c8a3b873b" alt="after" width="300" height="525">