### PR TITLE
[CM-1705] Added hidePostCTA configuration for form action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Added configuration for form submit button in hidePostCTA
 ## Kommunicate Android SDK 2.8.4
 1) Reduce time taken for conversation creation
 ## Kommunicate Android SDK 2.8.3

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -161,7 +161,7 @@
     "submit": false,
     "link": false,
     "quickReply": false,
-    "formSubmitButton": false
+    "hidePostFormSubmit": false
   },
   "receiverNameTextColor": "#5C6677",
   "innerTimestampDesign": false,

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -160,7 +160,8 @@
   "hidePostCTA": {
     "submit": false,
     "link": false,
-    "quickReply": false
+    "quickReply": false,
+    "formSubmitButton": false
   },
   "receiverNameTextColor": "#5C6677",
   "innerTimestampDesign": false,

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
@@ -39,7 +39,7 @@ public class KmFormRichMessage extends KmRichMessage {
         final KmFormItemAdapter formItemAdapter = new KmFormItemAdapter(context, kmRichMessageModel.getFormModelList(), message.getKeyString(), alCustomizationSettings);
         alFormLayoutRecycler.setAdapter(formItemAdapter);
 
-        if (isMessageProcessed && themeHelper.hideSubmitButtonsPostCTA()) {
+        if (isMessageProcessed && themeHelper.hideFormSubmitButtonsPostCTA()) {
             return;
         }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
@@ -39,15 +39,16 @@ public class KmFormRichMessage extends KmRichMessage {
         final KmFormItemAdapter formItemAdapter = new KmFormItemAdapter(context, kmRichMessageModel.getFormModelList(), message.getKeyString(), alCustomizationSettings);
         alFormLayoutRecycler.setAdapter(formItemAdapter);
 
-        if (isMessageProcessed && themeHelper.hideFormSubmitButtonsPostCTA()) {
-            return;
-        }
-
         List<Object> actionModelList = new ArrayList<>();
 
         for (Object object : kmRichMessageModel.getFormModelList()) {
             if (object instanceof KmFormPayloadModel) {
                 KmFormPayloadModel formPayloadModel = (KmFormPayloadModel) object;
+
+                if (isMessageProcessed && themeHelper.hideFormSubmitButtonsPostCTA() && KmFormPayloadModel.Type.SUBMIT.getValue().equals(formPayloadModel.getType())) {
+                    continue;
+                }
+
                 if (KmFormPayloadModel.Type.SUBMIT.getValue().equals(formPayloadModel.getType()) || KmFormPayloadModel.Type.ACTION.getValue().equals(formPayloadModel.getType()) || TextUtils.isEmpty(formPayloadModel.getType())) {
                     actionModelList.add(formPayloadModel.getAction());
                 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -20,6 +20,7 @@ public class KmThemeHelper implements KmCallback {
     private static final String SUBMIT_BUTTON = "submit";
     private static final String LINK_BUTTON = "link";
     private static final String QUICK_REPLIES = "quickReply";
+    private static final String FORM_SUBMIT_BUTTON = "formSubmitButton";
     private static KmThemeHelper kmThemeHelper;
     private final Context context;
     private final KmAppSettingPreferences appSettingPreferences;
@@ -119,6 +120,11 @@ public class KmThemeHelper implements KmCallback {
     @SuppressWarnings("ConstantConditions")
     public boolean hideSubmitButtonsPostCTA() {
         return getHidePostCTA().get(SUBMIT_BUTTON) != null ? getHidePostCTA().get(SUBMIT_BUTTON) : false;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public boolean hideFormSubmitButtonsPostCTA() {
+        return getHidePostCTA().get(FORM_SUBMIT_BUTTON) != null ? getHidePostCTA().get(FORM_SUBMIT_BUTTON) : false;
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -20,7 +20,7 @@ public class KmThemeHelper implements KmCallback {
     private static final String SUBMIT_BUTTON = "submit";
     private static final String LINK_BUTTON = "link";
     private static final String QUICK_REPLIES = "quickReply";
-    private static final String FORM_SUBMIT_BUTTON = "formSubmitButton";
+    private static final String FORM_SUBMIT_BUTTON = "hidePostFormSubmit";
     private static KmThemeHelper kmThemeHelper;
     private final Context context;
     private final KmAppSettingPreferences appSettingPreferences;


### PR DESCRIPTION
## Summary

Previously when the hidePostCTA was enabled for submit button it was also hiding the form action button, hence made a separate configuration for form's action button so that both the configurations become independent.

## Screenshot

<img src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/4e26254b-4e96-44ec-b519-7efe279c8d55" alt="after" width="300" height="525">