### PR TITLE
[CM-1576] - Status bar theme colour Fix

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -84,7 +84,7 @@
   "toolbarTitleColor": "#ffffff",
   "toolbarSubtitleColor": "#ffffff",
   "toolbarColor": "",
-  "statusBarColor": "#ffffff",
+  "statusBarColor": "",
   "richMessageThemeColor": "",
   "restrictMessageTypingWithBots": false,
   "enableFaqOption": [

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -366,7 +366,11 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         customToolbarLayout = myToolbar.findViewById(R.id.custom_toolbar_root_layout);
         myToolbar.setBackgroundColor(KmThemeHelper.getInstance(this, alCustomizationSettings).getToolbarColor());
         customToolbarLayout.setBackgroundColor(KmThemeHelper.getInstance(this, alCustomizationSettings).getToolbarColor());
-        KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getStatusBarColor());
+        if (!alCustomizationSettings.getStatusBarColor().isEmpty()) {
+            KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getStatusBarColor());
+        } else {
+            KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getPrimaryColor());
+        }
 
         setSupportActionBar(myToolbar);
         setToolbarTitleSubtitleColorFromSettings();


### PR DESCRIPTION
## Summary

- Earlier by default status bar colour was set from "applozic-settings.json" file.
- Now the colour of status bar will be fetched from chat widget, if a colour is passed on customisation file it will override chat widget colour.