### PR TITLE
[CM-1734] Fixed unread count returing wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed unreadCount returning wrong value
 ## Kommunicate Android SDK 2.8.6
 1) Fixed typing indicator appearing after welcome message was received
 2) Fixed hidePostCta

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/AlTotalUnreadCountTask.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/AlTotalUnreadCountTask.java
@@ -5,9 +5,21 @@ import android.content.Context;
 import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
 import com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService;
+import com.applozic.mobicomkit.broadcast.BroadcastService;
+import com.applozic.mobicomkit.channel.service.ChannelService;
+import com.applozic.mobicomkit.feed.ChannelFeed;
 import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.commons.core.utils.Utils;
+import com.applozic.mobicommons.json.AnnotationExclusionStrategy;
+import com.applozic.mobicommons.json.ArrayAdapterFactory;
+import com.applozic.mobicommons.json.GsonUtils;
 import com.applozic.mobicommons.task.AlAsyncTask;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.json.JSONObject;
 
 import java.lang.ref.WeakReference;
 
@@ -27,12 +39,16 @@ public class AlTotalUnreadCountTask extends AlAsyncTask<Void, Integer> {
     @Override
     protected Integer doInBackground() {
         try {
-            // Call the List api method only if server call for list was not done before and return the unread count.
-            if (!ApplozicClient.getInstance(ApplozicService.getContextFromWeak(weakReferenceContext)).wasServerCallDoneBefore(null, null, null)) {
-                if (!Utils.isInternetAvailable(ApplozicService.getContextFromWeak(weakReferenceContext))) {
-                    return null;
+            String data = new MessageClientService(ApplozicService.getContextFromWeak(weakReferenceContext)).getMessages(null,null,null,null,null,false);
+            JsonObject jsonObject = JsonParser.parseString(data).getAsJsonObject();
+            if (jsonObject.has("groupFeeds")) {
+                String channelFeedResponse = jsonObject.get("groupFeeds").toString();
+                ChannelFeed[] channelFeeds = (ChannelFeed[]) GsonUtils.getObjectFromJson(channelFeedResponse, ChannelFeed[].class);
+                int totalUnreadCount = 0;
+                for (ChannelFeed channelFeed : channelFeeds){
+                    totalUnreadCount += channelFeed.getUnreadCount();
                 }
-                SyncCallService.getInstance(ApplozicService.getContextFromWeak(weakReferenceContext)).getLatestMessagesGroupByPeople(null, MobiComUserPreference.getInstance(ApplozicService.getContextFromWeak(weakReferenceContext)).getParentGroupKey());
+                return totalUnreadCount;
             }
             return messageDatabaseService.getTotalUnreadCount();
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

- Unread count from sever was returning a wrong value which is fixed.

## Testing

- Use the below code in `SplashScreenActivity.java` to fetch unread count from the server ->

```
    new AlTotalUnreadCountTask(this, new AlTotalUnreadCountTask.TaskListener() {
        @Override
        public void onSuccess(Integer unreadCount) {
            Log.d("serverCount",String.valueOf(unreadCount));
        }
        @Override
        public void onFailure(String error) {

        }
    }).execute();
```