### PR TITLE
[CM-1748] Fixed agent app crashing while deleting messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed crash while deleting message on agent app
 ## Kommunicate Android SDK 2.8.6
 1) Fixed typing indicator appearing after welcome message was received
 2) Fixed hidePostCta

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1215,7 +1215,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                 public void onCreateContextMenu(ContextMenu contextMenu, View view, ContextMenu.ContextMenuInfo contextMenuInfo) {
                     int positionInSmsList = position;
 
-                    if (positionInSmsList < 0 || messageList.isEmpty()) {
+                    if (positionInSmsList < 0 || messageList.isEmpty() || positionInSmsList >= messageList.size()) {
                         return;
                     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4512,6 +4512,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     @Override
                     public void onSuccess(Object response) {
                         if (getContext() != null) {
+                            deleteMessageFromDeviceList(message.getKeyString());
+                            recyclerDetailConversationAdapter.notifyItemRangeChanged(position,messageList.size() - position);
                             KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
                         }
                     }
@@ -4521,11 +4523,11 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         KmToast.error(ApplozicService.getContext(getContext()), "Error while deleting Message", Toast.LENGTH_SHORT).show();
                     }
                 }).execute();
-                deleteMessageFromDeviceList(message.getKeyString());
                 break;
             case 2:
                 messageDatabaseService.deleteMessageFromDb(message);
                 deleteMessageFromDeviceList(message.getKeyString());
+                recyclerDetailConversationAdapter.notifyItemRangeChanged(position,messageList.size() - position);
                 Message messageToResend = new Message(message);
                 messageToResend.setCreatedAtTime(System.currentTimeMillis() + MobiComUserPreference.getInstance(getActivity()).getDeviceTimeOffset());
                 conversationService.sendMessage(messageToResend, messageIntentClass);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4513,7 +4513,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     public void onSuccess(Object response) {
                         if (getContext() != null) {
                             deleteMessageFromDeviceList(message.getKeyString());
-                            recyclerDetailConversationAdapter.notifyItemRangeChanged(position,messageList.size() - position);
+                            recyclerDetailConversationAdapter.notifyItemRangeChanged(position-1,messageList.size());
                             KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
                         }
                     }
@@ -4527,7 +4527,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             case 2:
                 messageDatabaseService.deleteMessageFromDb(message);
                 deleteMessageFromDeviceList(message.getKeyString());
-                recyclerDetailConversationAdapter.notifyItemRangeChanged(position,messageList.size() - position);
+                recyclerDetailConversationAdapter.notifyItemRangeChanged(position-1,messageList.size());
                 Message messageToResend = new Message(message);
                 messageToResend.setCreatedAtTime(System.currentTimeMillis() + MobiComUserPreference.getInstance(getActivity()).getDeviceTimeOffset());
                 conversationService.sendMessage(messageToResend, messageIntentClass);
@@ -4536,6 +4536,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 String messageKeyString = message.getKeyString();
                 new DeleteConversationAsyncTask(conversationService, message, contact).execute();
                 deleteMessageFromDeviceList(messageKeyString);
+                recyclerDetailConversationAdapter.notifyItemRangeChanged(position-1,messageList.size());
                 break;
             case 4:
                 String messageJson = GsonUtils.getJsonFromObject(message, Message.class);


### PR DESCRIPTION
## Summary

- After the deletion of item from message list, adapter was not notified due to which positions of items below the delete item were not correct