### PR TITLE
[CM-1733] - Attachment option to only provide Images, Videos 

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -112,9 +112,9 @@
     "messageEditTextFont": ""
   },
   "filterGallery": {
-    "ALL_FILES": false,
+    "ALL_FILES": true,
     "IMAGE_VIDEO": false,
-    "IMAGE_ONLY": true,
+    "IMAGE_ONLY": false,
     "AUDIO_ONLY": false,
     "VIDEO_ONLY": false
   },

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -112,9 +112,9 @@
     "messageEditTextFont": ""
   },
   "filterGallery": {
-    "ALL_FILES": true,
+    "ALL_FILES": false,
     "IMAGE_VIDEO": false,
-    "IMAGE_ONLY": false,
+    "IMAGE_ONLY": true,
     "AUDIO_ONLY": false,
     "VIDEO_ONLY": false
   },

--- a/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
@@ -117,15 +117,6 @@ public class PermissionsUtils {
             }
 
             return isGranted;
-
-//            return ActivityCompat.checkSelfPermission()
-//
-//            return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
-//                    != PackageManager.PERMISSION_GRANTED)
-//                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_VIDEO)
-//                    != PackageManager.PERMISSION_GRANTED)
-//                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_AUDIO)
-//                    != PackageManager.PERMISSION_GRANTED);
         }
         else {
             return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -153,7 +144,6 @@ public class PermissionsUtils {
     }
 
     public static void requestPermissions(Activity activity, String[] permissions, int requestCode) {
-//        ActivityCompat.requestPermissions(activity,new String[]{"android.permission.READ_MEDIA_IMAGES"}, requestCode);
         ActivityCompat.requestPermissions(activity, permissions, requestCode);
     }
 

--- a/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/commons/core/utils/PermissionsUtils.java
@@ -3,10 +3,15 @@ package com.applozic.mobicommons.commons.core.utils;
 import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PermissionInfo;
 import android.os.Build;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by sunil on 20/1/16.
@@ -34,6 +39,27 @@ public class PermissionsUtils {
             return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
         }
     }
+
+    public static String[] getStoragePermission(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            try {
+                PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
+                List<String> permissions = new ArrayList<>();
+                for (String permission : info.requestedPermissions){
+                    if (permission.contains("android.permission.READ_MEDIA")){
+                        permissions.add(permission);
+                    }
+                }
+                return permissions.toArray(new String[0]);
+            } catch (Exception exception){
+                exception.printStackTrace();
+                return new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO};
+            }
+        } else {
+            return new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        }
+    }
+
     public static boolean verifyPermissions(int[] grantResults) {
         if (grantResults.length < 1) {
             return false;
@@ -83,12 +109,23 @@ public class PermissionsUtils {
 
     public static boolean checkSelfForStoragePermission(Activity activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
-                    != PackageManager.PERMISSION_GRANTED)
-                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_VIDEO)
-                    != PackageManager.PERMISSION_GRANTED)
-                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_AUDIO)
-                    != PackageManager.PERMISSION_GRANTED);
+
+            boolean isGranted = false;
+
+            for (String permission : getStoragePermission(activity.getApplicationContext())){
+                isGranted = isGranted || (ActivityCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED);
+            }
+
+            return isGranted;
+
+//            return ActivityCompat.checkSelfPermission()
+//
+//            return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
+//                    != PackageManager.PERMISSION_GRANTED)
+//                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_VIDEO)
+//                    != PackageManager.PERMISSION_GRANTED)
+//                    || (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_AUDIO)
+//                    != PackageManager.PERMISSION_GRANTED);
         }
         else {
             return (ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -116,6 +153,7 @@ public class PermissionsUtils {
     }
 
     public static void requestPermissions(Activity activity, String[] permissions, int requestCode) {
+//        ActivityCompat.requestPermissions(activity,new String[]{"android.permission.READ_MEDIA_IMAGES"}, requestCode);
         ActivityCompat.requestPermissions(activity, permissions, requestCode);
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -761,7 +761,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
     @Override
     public void checkPermission(KmStoragePermission storagePermission) {
-        PermissionsUtils.requestPermissions(this, PermissionsUtils.PERMISSIONS_STORAGE, PermissionsUtils.REQUEST_STORAGE);
+        PermissionsUtils.requestPermissions(this, PermissionsUtils.getStoragePermission(getApplicationContext()), PermissionsUtils.REQUEST_STORAGE);
         this.alStoragePermission = storagePermission;
     }
 
@@ -1128,6 +1128,8 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
     }
 
     public void processAttachment() {
+//        Intent intentPick = new Intent(this, MobiComAttachmentSelectorActivity.class);
+//        startActivityForResult(intentPick, MultimediaOptionFragment.REQUEST_MULTI_ATTCAHMENT);
         if (Utils.hasMarshmallow() && PermissionsUtils.checkSelfForStoragePermission(this)) {
             applozicPermission.requestStoragePermissions(KmPermissions.REQUEST_STORAGE_ATTACHMENT);
         } else {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -1128,8 +1128,6 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
     }
 
     public void processAttachment() {
-//        Intent intentPick = new Intent(this, MobiComAttachmentSelectorActivity.class);
-//        startActivityForResult(intentPick, MultimediaOptionFragment.REQUEST_MULTI_ATTCAHMENT);
         if (Utils.hasMarshmallow() && PermissionsUtils.checkSelfForStoragePermission(this)) {
             applozicPermission.requestStoragePermissions(KmPermissions.REQUEST_STORAGE_ATTACHMENT);
         } else {


### PR DESCRIPTION
## Summary

- Fixed an issue in Api 33+ when only images permission is given on manifest file and "IMAGE_ONLY" is set to true in filterGallery (applozic-settings.json) the file explorer will not open