### PR TITLE
[CM-1762] Fixed user messages coming on right side in agent app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed user messages coming on right side in agent app
 ## Kommunicate Android SDK 2.8.8
 1) Fixed crash while deleting message on agent app
 ##  Kommunicate Android SDK 2.8.7

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
@@ -524,15 +524,18 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
                                 if (NOTIFICATION_TYPE.MESSAGE_SENT.getValue().equals(mqttMessageResponse.getType())) {
                                     GcmMessageResponse messageResponse = (GcmMessageResponse) GsonUtils.getObjectFromJson(messageDataString, GcmMessageResponse.class);
                                     Message sentMessageSync = messageResponse.getMessage();
-                                    if (sentMessageSync.getGroupId() != null) {
 
-                                        Channel channel = ChannelService.getInstance(context).getChannelByChannelKey(sentMessageSync.getGroupId());
-                                        if (channel != null && channel.getKmStatus() == Channel.NOTSTARTED_CONVERSATIONS &&  sentMessageSync.getGroupStatus() != null && !sentMessageSync.getGroupStatus().equals(Message.GroupStatus.INITIAL.getValue())) {
-                                            channel.setKmStatus(Channel.ALL_CONVERSATIONS);
-                                            ChannelService.getInstance(context).updateChannel(channel);
+                                    if (sentMessageSync.getTo() == null || MobiComUserPreference.getInstance(context).getUserId() == null || sentMessageSync.getTo().equals(MobiComUserPreference.getInstance(context).getUserId())) {
+                                        if (sentMessageSync.getGroupId() != null) {
+
+                                            Channel channel = ChannelService.getInstance(context).getChannelByChannelKey(sentMessageSync.getGroupId());
+                                            if (channel != null && channel.getKmStatus() == Channel.NOTSTARTED_CONVERSATIONS &&  sentMessageSync.getGroupStatus() != null && !sentMessageSync.getGroupStatus().equals(Message.GroupStatus.INITIAL.getValue())) {
+                                                channel.setKmStatus(Channel.ALL_CONVERSATIONS);
+                                                ChannelService.getInstance(context).updateChannel(channel);
+                                            }
                                         }
+                                        syncCallService.syncMessages(sentMessageSync.getKeyString(), sentMessageSync);
                                     }
-                                    syncCallService.syncMessages(sentMessageSync.getKeyString(), sentMessageSync);
                                 }
 
                                 if (NOTIFICATION_TYPE.USER_BLOCKED.getValue().equals(mqttMessageResponse.getType()) ||

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/ApplozicMqttService.java
@@ -525,7 +525,9 @@ public class ApplozicMqttService extends MobiComKitClientService implements Mqtt
                                     GcmMessageResponse messageResponse = (GcmMessageResponse) GsonUtils.getObjectFromJson(messageDataString, GcmMessageResponse.class);
                                     Message sentMessageSync = messageResponse.getMessage();
 
-                                    if (sentMessageSync.getTo() == null || MobiComUserPreference.getInstance(context).getUserId() == null || sentMessageSync.getTo().equals(MobiComUserPreference.getInstance(context).getUserId())) {
+                                    if (TextUtils.isEmpty(sentMessageSync.getTo()) ||
+                                            TextUtils.isEmpty(MobiComUserPreference.getInstance(context).getUserId()) ||
+                                            sentMessageSync.getTo().equals(MobiComUserPreference.getInstance(context).getUserId())) {
                                         if (sentMessageSync.getGroupId() != null) {
 
                                             Channel channel = ChannelService.getInstance(context).getChannelByChannelKey(sentMessageSync.getGroupId());


### PR DESCRIPTION
## Summary

Fixed user sent message coming on the RHS in agent app

## Root Cause & Fix

When the user sends a message, first a MQTT received message is being received in the agent app and then a MQTT sent message is being received in agent app due to which agent app was considering it as a sent message and was showing on the RHS insread of LHS. Hence, added a check to ensure that sent message from MQTT will only be considered when received `sent message user id` and `logged in user id` are same 