### PR TITLE
[CM-1797] Fixed sent message icon color not changing in sample app

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -6,7 +6,7 @@
   "sentMessageCreatedAtTimeColor": "",
   "receivedMessageCreatedAtTimeColor": "",
   "attachmentIconsBackgroundColor": "#FF03A9F4",
-  "channelCustomMessageBgColor": "#cccccc",
+  "channelCustomMessageBgColor": "",
   "sentContactMessageTextColor:": "#5fba7d",
   "chatBackgroundColorOrDrawable": "#FFFFFF",
   "receivedContactMessageTextColor": "#646262",

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -1,6 +1,6 @@
 {
   "customMessageBackgroundColor": "#e6e5ec",
-  "sentMessageBackgroundColor": "#5c5aa7",
+  "sentMessageBackgroundColor": "",
   "receivedMessageBackgroundColor": "#e6e5ec",
   "sendButtonBackgroundColor": "#5c5aa7",
   "sentMessageCreatedAtTimeColor": "",

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -6,7 +6,7 @@
   "sentMessageCreatedAtTimeColor": "",
   "receivedMessageCreatedAtTimeColor": "",
   "attachmentIconsBackgroundColor": "#FF03A9F4",
-  "channelCustomMessageBgColor": "",
+  "channelCustomMessageBgColor": "#cccccc",
   "sentContactMessageTextColor:": "#5fba7d",
   "chatBackgroundColorOrDrawable": "#FFFFFF",
   "receivedContactMessageTextColor": "#646262",

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -22,7 +22,7 @@
   "conversationDayTextColor": "#333333",
   "messageTimeTextColor": "#ede6e6",
   "channelCustomMessageTextColor": "#666666",
-  "sentMessageBorderColor": "#5c5aa7",
+  "sentMessageBorderColor": "",
   "receivedMessageBorderColor": "#e6e5ec",
   "channelCustomMessageBorderColor": "#cccccc",
   "collapsingToolbarLayoutColor": "#5c5aa7",


### PR DESCRIPTION
## Description

Earlier in our sample app the sent message background color was not changing with change in dashboard theme which is fixed now.

## Screenshot

<img src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/1772eb83-3b18-4477-b88e-77caa3d754aa" alt="after" width="300" height="525">