### PR TITLE
Quick reply feature for Taxbuddy

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -1,12 +1,17 @@
 package com.applozic.mobicomkit.api.conversation;
 
+import static com.applozic.mobicommons.ApplozicService.getAppContext;
+import static com.applozic.mobicommons.ApplozicService.getContext;
+
 import android.content.Context;
 import android.text.TextUtils;
 import android.util.Patterns;
 
 import com.applozic.mobicomkit.ApplozicClient;
+import com.applozic.mobicomkit.api.account.user.User;
 import com.applozic.mobicomkit.api.notification.VideoCallNotificationHelper;
 import com.applozic.mobicomkit.channel.service.ChannelService;
+import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.json.JsonMarker;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
 import com.applozic.mobicomkit.api.attachment.FileMeta;
@@ -689,7 +694,8 @@ public class Message extends JsonMarker {
     }
 
     public boolean hasHideKey() {
-        return GroupMessageMetaData.TRUE.getValue().equals(getMetaDataValueForKey(GroupMessageMetaData.HIDE_KEY.getValue())) || Message.ContentType.HIDDEN.getValue().equals(getContentType()) || hidden || Message.MetaDataType.HIDDEN.getValue().equals(getMetaDataValueForKey(Message.MetaDataType.KEY.getValue()));
+        int loggedInUserRole = MobiComUserPreference.getInstance(getAppContext()).getUserRoleType();
+        return GroupMessageMetaData.TRUE.getValue().equals(getMetaDataValueForKey(GroupMessageMetaData.HIDE_KEY.getValue())) || Message.ContentType.HIDDEN.getValue().equals(getContentType()) || hidden || (Message.MetaDataType.HIDDEN.getValue().equals(getMetaDataValueForKey(Message.MetaDataType.KEY.getValue())) && !(loggedInUserRole == User.RoleType.AGENT.getValue()));
     }
 
     public boolean isGroupMetaDataUpdated() {

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAutoSuggestionModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAutoSuggestionModel.java
@@ -12,7 +12,15 @@ public class KmAutoSuggestionModel extends JsonMarker {
     private long updated_at;
     private String userName;
     private long id;
+    private boolean supportsRichMessage = false;
 
+
+    public boolean isSupportsRichMessage() {
+        return supportsRichMessage;
+    }
+    public void setSupportsRichMessage(boolean SupportRichMessage) {
+        this.supportsRichMessage = SupportRichMessage;
+    }
     public String getName() {
         return name;
     }

--- a/kommunicate/src/main/java/io/kommunicate/services/KmService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmService.java
@@ -42,6 +42,7 @@ public class KmService {
     public static final String KM_NO_ALERT = "NO_ALERT";
     public static final String KM_BADGE_COUNT = "BADGE_COUNT";
 
+    public static List<KmAutoSuggestionModel> autoSuggestionList;
     public KmService(Context context) {
         this.context = ApplozicService.getContext(context);
         clientService = new KmClientService(context);
@@ -66,6 +67,7 @@ public class KmService {
             KmApiResponse<List<KmAutoSuggestionModel>> kmApiResponse = new Gson().fromJson(clientService.getKmAutoSuggestions(), listType);
             if (kmApiResponse != null) {
                 List<KmAutoSuggestionModel> autoSuggestionList = kmApiResponse.getData();
+                setAutoSuggestionList(autoSuggestionList);
                 if (autoSuggestionList != null && !autoSuggestionList.isEmpty() && autoSuggestionDatabase != null) {
                     for (KmAutoSuggestionModel kmAutoSuggestion : autoSuggestionList) {
                         autoSuggestionDatabase.upsertAutoSuggestion(kmAutoSuggestion);
@@ -78,6 +80,13 @@ public class KmService {
         }
         return null;
     }
+    public void setAutoSuggestionList(List<KmAutoSuggestionModel> autoSuggestionList) {
+        KmService.autoSuggestionList = autoSuggestionList;
+    }
+    public static List<KmAutoSuggestionModel> getAutoSuggestionList() {
+        return autoSuggestionList;
+    }
+
 
     public String getAppSetting(String appId) {
         return clientService.getAppSetting(appId);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4938,6 +4938,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                             autoSuggestionMetadata.put("skipBot","true");
                             autoSuggestionMetadata.put("category","HIDDEN");
                             sendMessage("KM_EVENT_QUICKREPLY_CLICK", autoSuggestionMetadata, null, null, Message.ContentType.DEFAULT.getValue());
+                            messageEditText.setText("");
                             getLoaderManager().destroyLoader(1);
                             kmAutoSuggestionRecycler.setVisibility(View.GONE);
                             if (kmAutoSuggestionDivider != null) {


### PR DESCRIPTION
### Overview
Taxbuddy wanted to reassign a conversation back to a bot by using quick replies provided in the dashboard.
We have modified the quickreplies for the same. 
The idea is that they will identify the event at universal webhook and trigger reassignment.

### Code changes

Currently the agent app was not receiving hidden messages, hence added a check to ensure that if a message has `"category":"HIDDEN"`, it is shown in the agent app.

### What do you want to achieve?
- Provide a way to send specific events along with the quickreplies.
