### PR TITLE
[CM-1766] Fixed message status icon colour customisation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Fixed message status icon color customisation
 ## Kommunicate Android SDK 2.8.9
 1) Fixed typing indicator for welcome message
 2) Fixed "no conversations" showing sometimes for the first time when conversation is created

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -10,7 +10,7 @@
   "sentContactMessageTextColor:": "#5fba7d",
   "chatBackgroundColorOrDrawable": "#FFFFFF",
   "receivedContactMessageTextColor": "#646262",
-  "messageStatusIconColor": "#5c5aa7",
+  "messageStatusIconColor": "",
   "sentMessageTextColor": "#FFFFFFFF",
   "receivedMessageTextColor": "#646262",
   "messageEditTextTextColor": "#000000",

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -201,18 +201,18 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     }
 
     public DetailedConversationAdapter(final Context context, int textViewResourceId, List<Message> messageList, Channel channel, Class messageIntentClass, EmojiconHandler emojiconHandler) {
-        this(context, textViewResourceId, messageList, null, channel, messageIntentClass, emojiconHandler);
+        this(context, textViewResourceId, messageList, null, channel, messageIntentClass, emojiconHandler, null);
     }
 
     public DetailedConversationAdapter(final Context context, int textViewResourceId, List<Message> messageList, Contact contact, Class messageIntentClass, EmojiconHandler emojiconHandler) {
-        this(context, textViewResourceId, messageList, contact, null, messageIntentClass, emojiconHandler);
+        this(context, textViewResourceId, messageList, contact, null, messageIntentClass, emojiconHandler, null);
     }
 
     public void setLastSentMessage(Message message) {
         this.lastSentMessage = message;
     }
 
-    public DetailedConversationAdapter(final Context context, int textViewResourceId, List<Message> messageList, final Contact contact, Channel channel, Class messageIntentClass, EmojiconHandler emojiconHandler) {
+    public DetailedConversationAdapter(final Context context, int textViewResourceId, List<Message> messageList, final Contact contact, Channel channel, Class messageIntentClass, EmojiconHandler emojiconHandler, AlCustomizationSettings alCustomizationSettings) {
         //super(context, textViewResourceId, messageList);
         this.messageIntentClass = messageIntentClass;
         this.context = context;
@@ -226,6 +226,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         this.contactService = new AppContactService(context);
         this.imageCache = ImageCache.getInstance(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         this.messageList = messageList;
+        this.alCustomizationSettings = alCustomizationSettings;
         geoApiKey = Applozic.getInstance(context).getGeoApiKey();
         contactImageLoader = new ImageLoader(context, ImageUtils.getLargestScreenDimension((Activity) context)) {
             @Override
@@ -254,7 +255,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         imageThumbnailLoader.setImageFadeIn(false);
         imageThumbnailLoader.addImageCache(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
 
-        if(useInnerTimeStampDesign) {
+        if(useInnerTimeStampDesign || (alCustomizationSettings != null && !TextUtils.isEmpty(alCustomizationSettings.getMessageStatusIconColor()))) {
             sentIcon = context.getResources().getDrawable(R.drawable.km_sent_icon_c);
             deliveredIcon = context.getResources().getDrawable(R.drawable.km_delivered_icon_c);
             readIcon = context.getResources().getDrawable(R.drawable.km_read_icon_c);
@@ -1729,14 +1730,21 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
             messageRootLayout = (RelativeLayout) customView.findViewById(R.id.messageLayout);
             emailLayout = customView.findViewById(R.id.emailLayout);
             viaEmailView = customView.findViewById(R.id.via_email_text_view);
+            statusIconBackground = customView.findViewById(R.id.statusIconBackground);
 
             if(useInnerTimeStampDesign) {
-                statusIconBackground = customView.findViewById(R.id.statusIconBackground);
-                    if (statusIconBackground != null) {
-                        KmUtils.setGradientSolidColor(statusIconBackground, themeHelper.getMessageStatusIconColor());
-                    }
+                if (statusIconBackground != null) {
+                    KmUtils.setGradientSolidColor(statusIconBackground, themeHelper.getMessageStatusIconColor());
+                }
             }
             else {
+                if(statusIconBackground != null){
+                    if (!TextUtils.isEmpty(alCustomizationSettings.getMessageStatusIconColor())) {
+                        KmUtils.setGradientSolidColor(statusIconBackground, themeHelper.getMessageStatusIconColor());
+                    } else {
+                        statusIconBackground.setVisibility(GONE);
+                    }
+                }
                 timestampLayout = customView.findViewById(R.id.timestampLayout);
                 statusImageView = customView.findViewById(R.id.statusImageView);
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -415,8 +415,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     protected DetailedConversationAdapter getConversationAdapter(Activity activity,
-                                                                 int rowViewId, List<Message> messageList, Contact contact, Channel channel, Class messageIntentClass, EmojiconHandler emojiIconHandler) {
-        return new DetailedConversationAdapter(activity, rowViewId, messageList, contact, channel, messageIntentClass, emojiIconHandler);
+                                                                 int rowViewId, List<Message> messageList, Contact contact, Channel channel, Class messageIntentClass, EmojiconHandler emojiIconHandler, AlCustomizationSettings alCustomizationSettings) {
+        return new DetailedConversationAdapter(activity, rowViewId, messageList, contact, channel, messageIntentClass, emojiIconHandler, alCustomizationSettings);
     }
 
     @Override
@@ -707,7 +707,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         emptyTextView.setTextColor(Color.parseColor(alCustomizationSettings.getNoConversationLabelTextColor().trim()));
         emoticonsBtn.setOnClickListener(this);
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
-        if(alCustomizationSettings.getInnerTimestampDesign()) {
+        if(alCustomizationSettings.getInnerTimestampDesign() || !TextUtils.isEmpty(alCustomizationSettings.getMessageStatusIconColor())) {
             sentIcon = getResources().getDrawable(R.drawable.km_sent_icon_c);
             deliveredIcon = getResources().getDrawable(R.drawable.km_delivered_icon_c);
             readIcon = getResources().getDrawable(R.drawable.km_read_icon_c);
@@ -2068,7 +2068,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             selfDestructMessageSpinner.setSelection(0);
         }
         recyclerDetailConversationAdapter = getConversationAdapter(getActivity(),
-                R.layout.mobicom_message_row_view, messageList, contact, channel, messageIntentClass, emojiIconHandler);
+                R.layout.mobicom_message_row_view, messageList, contact, channel, messageIntentClass, emojiIconHandler, alCustomizationSettings);
         recyclerDetailConversationAdapter.setAlCustomizationSettings(alCustomizationSettings);
         recyclerDetailConversationAdapter.setContextMenuClickListener(this);
         recyclerDetailConversationAdapter.setRichMessageCallbackListener(richMessageActionProcessor.getRichMessageListener());

--- a/kommunicateui/src/main/res/layout/km_sent_message_list_view.xml
+++ b/kommunicateui/src/main/res/layout/km_sent_message_list_view.xml
@@ -150,6 +150,13 @@
                 android:layout_height="12dp"
                 android:visibility="visible"
                 android:layout_gravity="center" />
+
+            <View
+                android:id="@+id/statusIconBackground"
+                android:layout_width="13dp"
+                android:layout_height="13dp"
+                android:background="@drawable/km_status_icon_background" />
+
             <ImageView
                 android:id="@+id/statusImageView"
                 android:layout_width="12dp"


### PR DESCRIPTION
## Summary

After the new timestamp was developed in sdk, the message status icon colour customisation was only available while enabling inner time stamp design which is fixed now.

## Screenshot

After changing `"messageStatusIconColor"` to "`#0000FF"`

<img src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/91adbd26-7465-40c3-b01c-7977ea132cf2" alt="Screenshot" width="300" height="525">
