### PR TITLE
[CM-1824] Added customization for multiple attachment selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
 ## Unreleased
-1) Added customization for multiple attachment selection
+1) Added customisation for multiple attachment selection
 ## Kommunicate Android SDK 2.9.0
 1) Fixed message status icon color customisation
 ## Kommunicate Android SDK 2.8.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unreleased
+1) Added customization for multiple attachment selection
 ## Kommunicate Android SDK 2.9.0
 1) Fixed message status icon color customisation
 ## Kommunicate Android SDK 2.8.9

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -177,5 +177,6 @@
   "useDeviceDefaultLanguage": true,
   "toolbarTitleCenterAligned": false,
   "disableFormPostSubmit": false,
-  "chatBarTopLineViewColor": ""
+  "chatBarTopLineViewColor": "",
+  "isMultipleAttachmentSelectionEnabled": true
 }

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -178,5 +178,5 @@
   "toolbarTitleCenterAligned": false,
   "disableFormPostSubmit": false,
   "chatBarTopLineViewColor": "",
-  "isMultipleAttachmentSelectionEnabled": true
+  "isMultipleAttachmentSelectionEnabled": false
 }

--- a/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
@@ -656,7 +656,7 @@ public class FileUtils {
      * @return The intent for opening a file with Intent.createChooser()
      * @author paulburke
      */
-    public static Intent createGetContentIntent(GalleryFilterOptions choosenOption, PackageManager packageManager) {
+    public static Intent createGetContentIntent(GalleryFilterOptions choosenOption, PackageManager packageManager, boolean isMultipleSectionEnabled) {
         Intent intent = new Intent();
         ArrayList<String> mimeType = new ArrayList<>();
         switch (choosenOption) {
@@ -671,6 +671,9 @@ public class FileUtils {
                 mimeType.add("video/*");
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
                     intent = new Intent(Intent.ACTION_GET_CONTENT);
+                    if (isMultipleSectionEnabled) {
+                        intent.addCategory(Intent.ACTION_SEND_MULTIPLE);
+                    }
                     intent.setType("image/*");
                     intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
                     intent.addCategory(Intent.CATEGORY_OPENABLE);
@@ -678,21 +681,33 @@ public class FileUtils {
                 }
                 intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
                 intent.addCategory(Intent.CATEGORY_OPENABLE);
+                if (isMultipleSectionEnabled) {
+                    intent.addCategory(Intent.ACTION_SEND_MULTIPLE);
+                }
                 intent.setType("*/*");
                 intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{"image/*", "video/*"});
                 break;
             case IMAGE_ONLY:
                 intent = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+                if (isMultipleSectionEnabled) {
+                    intent.addCategory(Intent.ACTION_SEND_MULTIPLE);
+                }
                 intent.setType("image/*");
                 mimeType.add("image/*");
                 break;
             case AUDIO_ONLY:
                 intent = new Intent(Intent.ACTION_PICK, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI);
+                if (isMultipleSectionEnabled) {
+                    intent.addCategory(Intent.ACTION_SEND_MULTIPLE);
+                }
                 intent.setType("audio/*");
                 mimeType.add("audio/*");
                 break;
             case VIDEO_ONLY:
                 intent = new Intent(Intent.ACTION_PICK, MediaStore.Video.Media.EXTERNAL_CONTENT_URI);
+                if (isMultipleSectionEnabled) {
+                    intent.addCategory(Intent.ACTION_SEND_MULTIPLE);
+                }
                 intent.setType("video/*");
                 mimeType.add("video/*");
                 break;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -149,6 +149,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean toolbarTitleCenterAligned = false;
     private boolean disableFormPostSubmit = false;
     private String chatBarTopLineViewColor = "";
+    private boolean isMultipleAttachmentSelectionEnabled = false;
 
     public String getStaticTopMessage() {
         return staticTopMessage;
@@ -774,6 +775,10 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public boolean isDisableFormPostSubmit() {
         return disableFormPostSubmit;
+    }
+
+    public boolean isMultipleAttachmentSelectionEnabled() {
+        return isMultipleAttachmentSelectionEnabled;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -1140,7 +1140,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         if (Utils.hasMarshmallow() && PermissionsUtils.checkSelfForStoragePermission(this)) {
             applozicPermission.requestStoragePermissions(KmPermissions.REQUEST_STORAGE_MULTI_SELECT_GALLERY);
         } else {
-            Intent contentChooserIntent = FileUtils.createGetContentIntent(FileUtils.GalleryFilterOptions.IMAGE_VIDEO, getPackageManager());
+            Intent contentChooserIntent = FileUtils.createGetContentIntent(FileUtils.GalleryFilterOptions.IMAGE_VIDEO, getPackageManager(),true);
             contentChooserIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
             contentChooserIntent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
             Intent intentPick = Intent.createChooser(contentChooserIntent, getString(R.string.select_file));

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/MobiComAttachmentGridViewAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/MobiComAttachmentGridViewAdapter.java
@@ -95,8 +95,11 @@ public class MobiComAttachmentGridViewAdapter extends BaseAdapter {
                     e.printStackTrace();
                 }
 
-                Intent contentChooserIntent = FileUtils.createGetContentIntent(filterOptions, context.getPackageManager());
+                Intent contentChooserIntent = FileUtils.createGetContentIntent(filterOptions, context.getPackageManager(), alCustomizationSettings.isMultipleAttachmentSelectionEnabled());
                 contentChooserIntent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
+                if (alCustomizationSettings.isMultipleAttachmentSelectionEnabled()){
+                    contentChooserIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+                }
                 Intent intentPick = Intent.createChooser(contentChooserIntent, context.getString(R.string.select_file));
                 ((Activity) context).startActivityForResult(intentPick, REQUEST_CODE);
             }


### PR DESCRIPTION
## Summary

Added customisation to allow users to select multiple attachments while sending from gallery

## Video

[Screen_recording_20240108_120053.webm](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/ae984624-7ad5-496d-8a37-3103710c15a6)

## How the code was tested ?

The code was tested with API Level 22,29,30 and 33. 