### PR TITLE
[CM-1864] group list API optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 ## Unreleased
 1) Conversation assignment message UI update
 2) Fixed anonymous icon not showing for anonymous android users in dashboard
+3) group list API optimizations
 ## Kommunicate Android SDK 2.9.1
 1) Added customisation for multiple attachment selection
 2) Fixed documents showing incorrect filename for non-english names

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
@@ -281,12 +281,13 @@ public class MobiComMessageService {
         }
         if (syncMessageFeed != null && syncMessageFeed.getMessages() != null) {
             List<Message> messageList = syncMessageFeed.getMessages();
+            Long channelLastSyncTime = Long.parseLong(userpref.getChannelSyncTime());
 
             for (int i = messageList.size() - 1; i >= 0; i--) {
                 if (Message.ContentType.CHANNEL_CUSTOM_MESSAGE.getValue().equals(messageList.get(i).getContentType())) {
                     if (messageList.get(i).isGroupMetaDataUpdated()) {
                         syncChannelForMetadata = true;
-                    } else {
+                    } else if (channelLastSyncTime == 0L || messageList.get(i).getCreatedAtTime() > channelLastSyncTime) {
                         syncChannel = true;
                     }
                     //Todo: fix this, what if there are mulitple messages.
@@ -449,10 +450,11 @@ public class MobiComMessageService {
         if (!baseContactService.isContactPresent(message.getContactIds())) {
             userService.processUserDetails(message.getContactIds());
         }
+        Long channelLastSyncTime = Long.parseLong(MobiComUserPreference.getInstance(context).getChannelSyncTime());
         if (Message.ContentType.CHANNEL_CUSTOM_MESSAGE.getValue().equals(message.getContentType())) {
             if (message.isGroupMetaDataUpdated()) {
                 ChannelService.getInstance(context).syncChannels(true);
-            } else {
+            } else if (channelLastSyncTime == 0L || message.getCreatedAtTime() > channelLastSyncTime) {
                 ChannelService.getInstance(context).syncChannels(false);
             }
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3518,7 +3518,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             return;
         }
 
-        if (Objects.equals(contact.getRoleType(), User.RoleType.BOT.getValue()) || !contact.isConnected()) {
+        if (User.RoleType.BOT.getValue().equals(contact.getRoleType()) || !contact.isConnected()) {
             kmAwayView.setVisibility(GONE);
         }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -3518,6 +3518,10 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             return;
         }
 
+        if (Objects.equals(contact.getRoleType(), User.RoleType.BOT.getValue()) || !contact.isConnected()) {
+            kmAwayView.setVisibility(GONE);
+        }
+
         if (agentStatus == null) {
             agentStatus = this.agentStatus != null ? this.agentStatus : true; //default to true
         } else {
@@ -5343,7 +5347,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         return twentyFourHoursAgoMillis;
     }
     protected void restrictWhatsappConversation(Message lastMessage) {
-        if (alCustomizationSettings.isAgentApp()) {
+        if (alCustomizationSettings.isAgentApp() && channel.getMetadata() != null) {
             String conversationSource = channel.getMetadata().get(CONVERSATION_SOURCE);
             if (conversationSource != null){
                 for (String source : WHATSAPP_SOURCE) {


### PR DESCRIPTION
## Summary

- There were unnecessary API calls happening in the agent app for group list which is fixed
- Fixed KmConversationFragment.onResume crash
- Fixed away message showing even after conversation is assigned to bot