### PR TITLE
[CM-914]-Added support for chatwidget disabled flag

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -934,6 +934,9 @@ public class Kommunicate {
                     }
                     @Override
                     public void onFailure(Object error) {
+                        if (callback != null) {
+                            callback.onResult(false);
+                        }
                     }
                 }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -54,6 +54,7 @@ import io.kommunicate.callbacks.KMLogoutHandler;
 import io.kommunicate.callbacks.KMLoginHandler;
 import io.kommunicate.callbacks.KmAwayMessageHandler;
 import io.kommunicate.callbacks.KmCallback;
+import io.kommunicate.callbacks.KmChatWidgetCallback;
 import io.kommunicate.callbacks.KmFaqTaskListener;
 import io.kommunicate.callbacks.KmGetConversationInfoCallback;
 import io.kommunicate.callbacks.KmPrechatCallback;
@@ -911,5 +912,30 @@ public class Kommunicate {
 
     public static void hideAssigneeStatus(Context context,Boolean hide) {
         BroadcastService.hideAssignee(context,hide);
+    }
+
+    public static void isChatWidgetDisabled(final KmChatWidgetCallback callback) {
+        final KmAppSettingModel appSettingModel = new KmAppSettingModel();
+
+        new KmAppSettingTask(ApplozicService.getAppContext(),
+                MobiComKitClientService.getApplicationKey(ApplozicService.getAppContext()),
+                new KmCallback() {
+                    @Override
+                    public void onSuccess(Object message) {
+                        final KmAppSettingModel appSettingModel = (KmAppSettingModel) message;
+                        boolean isDisabled = false;
+                        if (appSettingModel != null && appSettingModel.getResponse() != null && appSettingModel.getChatWidget() != null) {
+                            isDisabled =   appSettingModel.getChatWidget().isDisableChatWidget();
+
+                        }
+                        if (callback != null) {
+                            callback.onResult(isDisabled);
+                        }
+                    }
+                    @Override
+                    public void onFailure(Object error) {
+                    }
+                }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/callbacks/KmChatWidgetCallback.java
+++ b/kommunicate/src/main/java/io/kommunicate/callbacks/KmChatWidgetCallback.java
@@ -1,0 +1,5 @@
+package io.kommunicate.callbacks;
+
+public interface KmChatWidgetCallback {
+    void onResult(boolean isDisabled);
+}

--- a/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
+++ b/kommunicate/src/main/java/io/kommunicate/models/KmAppSettingModel.java
@@ -135,10 +135,12 @@ public class KmAppSettingModel extends JsonMarker {
         private boolean singleThreaded;
         private String preChatGreetingMsg;
         private UploadOverride defaultUploadOverride;
+        private boolean disableChatWidget;
 
         public String getPosition() {
             return position;
         }
+        public boolean isDisableChatWidget() {return disableChatWidget;}
 
         public boolean isPseudonymsEnabled() {return pseudonymsEnabled;}
 


### PR DESCRIPTION
## Summary
- Client can disable chat widget on dashboard.Once it is disabled , web chat widget will not popup on website.
- To match with the same feature, we have exposed an function to get this config value set from dashboard

```
  Kommunicate.isChatWidgetDisabled(new KmChatWidgetCallback() {
                   @Override
                   public void onResult(boolean isDisabled) {
                       if (isDisabled) {
                           // Can add the code to hide chat icon or button on the app
                       } else {
                           //Can add the code to show chat icon or button on the app
                       }
                   }
               });
```