### PR TITLE
[CM-1907] Fixed agent app not showing notifications after automatic assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-
 2) Fixed anonymous icon not showing for anonymous android users in dashboard
 3) Added support for dialogflow fulfilment form
 3) group v5 API optimizations
+4) Fixed agent app notification issue
 ## Kommunicate Android SDK 2.9.1
 1) Added customisation for multiple attachment selection
 2) Fixed documents showing incorrect filename for non-english names

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/Message.java
@@ -986,6 +986,7 @@ public class Message extends JsonMarker {
                 ", status=" + status +
                 ", hidden=" + hidden +
                 ", replyMessage=" + replyMessage +
+                ", groupAssignee=" + groupAssignee +
                 '}';
     }
 }

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/api/conversation/MobiComMessageService.java
@@ -156,6 +156,7 @@ public class MobiComMessageService {
         message.setMessageId(messageToProcess.getMessageId());
         message.setKeyString(messageToProcess.getKeyString());
         message.setPairedMessageKeyString(messageToProcess.getPairedMessageKeyString());
+        message.setGroupAssignee(messageToProcess.getGroupAssignee());
 
         if (message.getMessage() != null && PersonalizedMessage.isPersonalized(message.getMessage())) {
             Contact contact = null;

--- a/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/broadcast/BroadcastService.java
@@ -11,11 +11,13 @@ import com.applozic.mobicomkit.ApplozicClient;
 import com.applozic.mobicomkit.api.MobiComKitConstants;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
 import com.applozic.mobicomkit.api.account.user.User;
+import com.applozic.mobicomkit.api.account.user.UserService;
 import com.applozic.mobicomkit.api.conversation.Message;
 import com.applozic.mobicomkit.api.conversation.service.ConversationService;
 import com.applozic.mobicomkit.api.notification.NotificationService;
 import com.applozic.mobicomkit.channel.service.ChannelService;
 import com.applozic.mobicomkit.contact.AppContactService;
+import com.applozic.mobicomkit.contact.BaseContactService;
 import com.applozic.mobicommons.ALSpecificSettings;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.json.GsonUtils;
@@ -163,6 +165,11 @@ public class BroadcastService {
 
             if (MobiComUserPreference.getInstance(context).isLoggedIn()) {
                 Channel channel = ChannelService.getInstance(context).getChannelInfo(message.getGroupId());
+                BaseContactService baseContactService = new AppContactService(context);
+                UserService userService = UserService.getInstance(context);
+                if (!baseContactService.isContactPresent(message.getContactIds())) {
+                    userService.processUserDetails(message.getContactIds());
+                }
                 Contact contact = new AppContactService(context).getContactById(message.getContactIds());
 
                 if(!showNotification(context, contact, channel, message)) {


### PR DESCRIPTION
## Summary

- As the message is not having conversation assignee name , so the agent was not receiving notifications after automatic assignment which is fixed now.

## How was testing done ?

- Tested agent app notifications and verified that they are working fine and all notifications are getting received from fcm except `assigned to <agent name>`
- Tested sdk notifications and verified that they are also working fine and all notifications are getting received from fcm now