### PR TITLE
[CM-1945] Dark Mode Support (Part - 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,6 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
-## Kommunicate Android SDK 2.9.5
-1) Added customization for image compression
-2) Fixed crash caused by empty form action message when submitting the form
-## Kommunicate Android SDK 2.9.4
-1) Added support for iframe in HTML type rich message
-2) Fixed location issues
-3) Image full screen view improvement
-4) Added back button in in-app browser
-## Kommunicate Android SDK 2.9.3
-1) Added support for updating agent status dynamically
 ## Kommunicate Android SDK 2.9.2
 1) Conversation assignment message UI update
 2) Fixed anonymous icon not showing for anonymous android users in dashboard

--- a/app/src/androidTest/java/kommunicate/io/sample/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/kommunicate/io/sample/ExampleInstrumentedTest.java
@@ -1,14 +1,13 @@
 package kommunicate.io.sample;
 
 import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.*;
-
-import androidx.test.InstrumentationRegistry;
-import androidx.test.runner.AndroidJUnit4;
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -122,8 +122,7 @@
     ":location": true,
     ":camera": true,
     ":file": true,
-    ":audio": true,
-    ":video": false
+    ":audio": true
   },
   "editTextHintText": "",
   "replyMessageLayoutSentMessageBackground": "#C0C0C0",
@@ -179,7 +178,5 @@
   "toolbarTitleCenterAligned": false,
   "disableFormPostSubmit": false,
   "chatBarTopLineViewColor": "",
-  "isMultipleAttachmentSelectionEnabled": false,
-  "isImageCompressionEnabled": false,
-  "minimumCompressionThresholdForImagesInMB": 5
+  "isMultipleAttachmentSelectionEnabled": false
 }

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 34
         versionCode 1
-        versionName "2.9.5"
+        versionName "2.9.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'
         buildConfigField "String", "API_SERVER_URL", '"https://api.kommunicate.io"'

--- a/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
@@ -1013,41 +1013,4 @@ public class FileUtils {
         return "content".equalsIgnoreCase(uri.getScheme());
     }
 
-    public static Uri compressImage(Uri uri, Context context, String fileName) {
-        try {
-            BitmapFactory.Options options = new BitmapFactory.Options();
-            options.inSampleSize = 2;
-            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, options);
-
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
-
-            File tempFile = File.createTempFile(fileName,null, context.getCacheDir());
-            tempFile.deleteOnExit();
-
-            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-            fileOutputStream.write(outputStream.toByteArray());
-            fileOutputStream.flush();
-            fileOutputStream.close();
-
-            return Uri.fromFile(tempFile);
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    public static boolean isCompressionNeeded(Context context, Uri uri, long fileSize, boolean isImageCompressionEnabled, int minimumCompressionThresholdForImagesInMB) {
-        if (!isImageCompressionEnabled) {
-            return false;
-        }
-        String mimeType = FileUtils.getMimeTypeByContentUriOrOther(context,uri);
-        boolean isMemeTypeImage = !TextUtils.isEmpty(mimeType) && mimeType.contains("image/");
-        if (!isMemeTypeImage) {
-            return false;
-        }
-        long limitForCompression = (long) minimumCompressionThresholdForImagesInMB * 1024 * 1024;
-        return fileSize >= limitForCompression;
-    }
-
 }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -18,7 +18,7 @@ android {
         minSdkVersion 17
         targetSdkVersion 34
         versionCode 1
-        versionName "2.9.5"
+        versionName "2.9.2"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
     }

--- a/kommunicateui/src/main/AndroidManifest.xml
+++ b/kommunicateui/src/main/AndroidManifest.xml
@@ -41,7 +41,7 @@
 
         <activity
             android:name="com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity"
-            android:configChanges="keyboardHidden|screenSize|locale|smallestScreenSize|screenLayout|orientation"
+            android:configChanges="keyboardHidden|screenSize|locale|smallestScreenSize|screenLayout|orientation|uiMode"
             android:label="@string/app_name"
             android:launchMode="singleTask"
             android:theme="@style/ApplozicTheme"

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -800,7 +800,7 @@ public class AlCustomizationSettings extends JsonMarker {
     public boolean isMultipleAttachmentSelectionEnabled() {
         return isMultipleAttachmentSelectionEnabled;
     }
-  
+
     private List<String> getColorList(Object color) {
         if (color instanceof String) {
             return Arrays.asList((String) color, (String) color);
@@ -808,14 +808,6 @@ public class AlCustomizationSettings extends JsonMarker {
             return (List<String>) color;
         }
         return Arrays.asList("", "");
-    }
-  
-    public boolean isImageCompressionEnabled() {
-        return isImageCompressionEnabled;
-    }
-  
-    public int getMinimumCompressionThresholdForImagesInMB() {
-        return minimumCompressionThresholdForImagesInMB;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -4,6 +4,8 @@ import com.applozic.mobicomkit.uiwidgets.conversation.MobicomMessageTemplate;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.models.KmFontModel;
 import com.applozic.mobicommons.json.JsonMarker;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -12,49 +14,49 @@ import java.util.Map;
 public class AlCustomizationSettings extends JsonMarker {
     public static final int DEFAULT_MESSAGE_CHAR_LIMIT = 2000;
 
-    private String customMessageBackgroundColor = "#e6e5ec";
-    private String sentMessageBackgroundColor = "";
-    private String startNewConversationButtonBackgroundColor = "";
-    private String receivedMessageBackgroundColor = "#e6e5ec";
-    private String sendButtonBackgroundColor = "";
-    private String attachmentIconsBackgroundColor = "#FF03A9F4";
-    private String chatBackgroundColorOrDrawable;
-    private String editTextBackgroundColorOrDrawable;
-    private String editTextLayoutBackgroundColorOrDrawable;
-    private String channelCustomMessageBgColor = "#cccccc";
-    private String toolbarTitleColor = "#ffffff";
-    private String toolbarSubtitleColor = "#ffffff";
-    private String receiverNameTextColor = "#5C6677";
+    private Object customMessageBackgroundColor = "#e6e5ec";
+    private Object sentMessageBackgroundColor = "";
+    private Object startNewConversationButtonBackgroundColor = "";
+    private Object receivedMessageBackgroundColor = Arrays.asList("#e6e5ec","#313131");
+    private Object sendButtonBackgroundColor = "";
+    private Object attachmentIconsBackgroundColor = "#FF03A9F4";
+    private Object chatBackgroundColorOrDrawable;
+    private Object editTextBackgroundColorOrDrawable;
+    private Object editTextLayoutBackgroundColorOrDrawable;
+    private Object channelCustomMessageBgColor = Arrays.asList("#000000","#FFFFFFFF");
+    private Object toolbarTitleColor = "#ffffff";
+    private Object toolbarSubtitleColor = "#ffffff";
+    private Object receiverNameTextColor = "#5C6677";
 
-    private String sentContactMessageTextColor = "#5fba7d";
-    private String receivedContactMessageTextColor = "#646262";
-    private String sentMessageTextColor = "#FFFFFFFF";
-    private String receivedMessageTextColor = "#646262";
-    private String messageEditTextTextColor = "#000000";
-    private String messageEditTextBackgroundColor = "";
-    private String autoSuggestionButtonBackgroundColor= "";
-    private String autoSuggestionButtonTextColor = "";
-    private String sentMessageLinkTextColor = "#FFFFFFFF";
-    private String receivedMessageLinkTextColor = "#5fba7d";
-    private String messageEditTextHintTextColor = "#bdbdbd";
-    private String typingTextColor;
-    private String noConversationLabelTextColor = "#000000";
-    private String conversationDateTextColor = "#333333";
-    private String conversationDayTextColor = "#333333";
-    private String messageTimeTextColor = "#ede6e6";
-    private String channelCustomMessageTextColor = "#666666";
-    private String sentMessageBorderColor = "";
-    private String receivedMessageBorderColor = "#e6e5ec";
-    private String channelCustomMessageBorderColor = "#cccccc";
-    private String collapsingToolbarLayoutColor = "#5c5aa7";
-    private String groupParticipantsTextColor = "#5c5aa7";
-    private String groupDeleteButtonBackgroundColor = "#5c5aa7";
-    private String groupExitButtonBackgroundColor = "#5c5aa7";
-    private String adminTextColor = "#5c5aa7";
-    private String adminBackgroundColor = "#FFFFFFFF";
+    private Object sentContactMessageTextColor = "#5fba7d";
+    private Object receivedContactMessageTextColor = "#646262";
+    private Object sentMessageTextColor = "#FFFFFFFF";
+    private Object receivedMessageTextColor = Arrays.asList("#646262","#FFFFFF");
+    private Object messageEditTextTextColor = "#000000";
+    private Object messageEditTextBackgroundColor = "";
+    private Object autoSuggestionButtonBackgroundColor= "";
+    private Object autoSuggestionButtonTextColor = "";
+    private Object sentMessageLinkTextColor = "#FFFFFFFF";
+    private Object receivedMessageLinkTextColor = "#5fba7d";
+    private Object messageEditTextHintTextColor = "#bdbdbd";
+    private Object typingTextColor;
+    private Object noConversationLabelTextColor = Arrays.asList("#000000", "#FFFFFFFF");
+    private Object conversationDateTextColor = Arrays.asList("#333333", "#FFFFFFFF");
+    private Object conversationDayTextColor = Arrays.asList("#333333", "#FFFFFFFF");
+    private Object messageTimeTextColor = "#ede6e6";
+    private Object channelCustomMessageTextColor = Arrays.asList("#000000", "#FFFFFFFF");
+    private Object sentMessageBorderColor = "";
+    private Object receivedMessageBorderColor = "#e6e5ec";
+    private Object channelCustomMessageBorderColor = "#cccccc";
+    private Object collapsingToolbarLayoutColor = "#5c5aa7";
+    private Object groupParticipantsTextColor = "#5c5aa7";
+    private Object groupDeleteButtonBackgroundColor = "#5c5aa7";
+    private Object groupExitButtonBackgroundColor = "#5c5aa7";
+    private Object adminTextColor = "#5c5aa7";
+    private Object adminBackgroundColor = "#FFFFFFFF";
     private String attachCameraIconName = "applozic_ic_action_camera_new";
-    private String adminBorderColor = "#5c5aa7";
-    private String userNotAbleToChatTextColor = "#000000";
+    private Object adminBorderColor = "#5c5aa7";
+    private Object userNotAbleToChatTextColor = "#000000";
     private String chatBackgroundImageName;
 
     private String audioPermissionNotFoundMsg;
@@ -90,8 +92,8 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean muteOption = true;
     private MobicomMessageTemplate messageTemplate;
     private String logoutPackageName = "kommunicate.io.sample.MainActivity";
-    private boolean logoutOption = false;
-    private boolean logoutOptionFromConversation = false;
+    private boolean logoutOption = true;
+    private boolean logoutOptionFromConversation = true;
     private int defaultGroupType = 2;
     private boolean muteUserChatOption = false;
     private String restrictedWordRegex;
@@ -100,12 +102,12 @@ public class AlCustomizationSettings extends JsonMarker {
     private int maxAttachmentSizeAllowed = 30;
     private int messageCharacterLimit = DEFAULT_MESSAGE_CHAR_LIMIT;
     private int totalOnlineUsers = 0;
-    private String themeColorPrimary;
-    private String themeColorPrimaryDark;
+    private Object themeColorPrimary;
+    private Object themeColorPrimaryDark;
     private String editTextHintText = "";
     private boolean replyOption = false;
-    private String replyMessageLayoutSentMessageBackground = "#C0C0C0";
-    private String replyMessageLayoutReceivedMessageBackground = "#F5F5F5";
+    private Object replyMessageLayoutSentMessageBackground = "#C0C0C0";
+    private Object replyMessageLayoutReceivedMessageBackground = "#F5F5F5";
     private boolean groupInfoScreenVisible = true;
     private boolean forwardOption = false;
     private Boolean innerTimestampDesign = false;
@@ -113,7 +115,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private String receivedMessageCreatedAtTimeColor;
     private boolean showStartNewConversation = true;
     private boolean enableAwayMessage = true;
-    private String awayMessageTextColor = "#A9A4A4";
+    private Object awayMessageTextColor = Arrays.asList("#A9A4A4","#FFFFFFFF");
     private boolean isAgentApp = false;
     private boolean hideGroupSubtitle = false;
     private boolean disableGlobalStoragePermission = true;
@@ -123,15 +125,15 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean showTypingIndicatorWhileFetchingResponse = false;
     private Map<String, Boolean> filterGallery;
     private boolean enableShareConversation = false;
-    private String messageStatusIconColor = "";
+    private Object messageStatusIconColor = "";
     private float[] sentMessageCornerRadii;
     private float[] receivedMessageCornerRadii;
     private KmFontModel fontModel;
     private boolean isFaqOptionEnabled = false;
     private boolean[] enableFaqOption = {true, false};
-    private String toolbarColor = "";
-    private String statusBarColor = "";
-    private String richMessageThemeColor = "";
+    private Object toolbarColor = "";
+    private Object statusBarColor = "";
+    private Object richMessageThemeColor = "";
     private Map<String, Boolean> attachmentOptions;
     private KmSpeechSetting textToSpeech;
     private KmSpeechSetting speechToText;
@@ -148,8 +150,13 @@ public class AlCustomizationSettings extends JsonMarker {
     private String menuIconOnConversationScreen = "";
     private boolean toolbarTitleCenterAligned = false;
     private boolean disableFormPostSubmit = false;
-    private String chatBarTopLineViewColor = "";
+    private Object chatBarTopLineViewColor = "";
     private boolean isMultipleAttachmentSelectionEnabled = false;
+    private boolean useDarkMode = true;
+
+    public boolean getUseDarkMode() {
+        return useDarkMode;
+    }
 
     public String getStaticTopMessage() {
         return staticTopMessage;
@@ -195,17 +202,17 @@ public class AlCustomizationSettings extends JsonMarker {
         return noConversationLabel;
     }
 
-    public String getCustomMessageBackgroundColor() {
-        return customMessageBackgroundColor;
+    public List<String> getCustomMessageBackgroundColor() {
+        return getColorList(customMessageBackgroundColor);
     }
 
 
-    public String getSentMessageBackgroundColor() {
-        return sentMessageBackgroundColor;
+    public List<String> getSentMessageBackgroundColor() {
+        return getColorList(sentMessageBackgroundColor);
     }
 
-    public String getReceivedMessageBackgroundColor() {
-        return receivedMessageBackgroundColor;
+    public List<String> getReceivedMessageBackgroundColor() {
+        return getColorList(receivedMessageBackgroundColor);
     }
 
     public boolean isOnlineStatusMasterList() {
@@ -216,8 +223,8 @@ public class AlCustomizationSettings extends JsonMarker {
         return priceWidget;
     }
 
-    public String getSendButtonBackgroundColor() {
-        return sendButtonBackgroundColor;
+    public List<String> getSendButtonBackgroundColor() {
+        return getColorList(sendButtonBackgroundColor);
     }
 
     public boolean isImageCompression() {
@@ -229,8 +236,8 @@ public class AlCustomizationSettings extends JsonMarker {
         return inviteFriendsInContactActivity;
     }
 
-    public String getAttachmentIconsBackgroundColor() {
-        return attachmentIconsBackgroundColor;
+    public List<String> getAttachmentIconsBackgroundColor() {
+        return getColorList(attachmentIconsBackgroundColor);
     }
 
     public boolean isLocationShareViaMap() {
@@ -241,36 +248,36 @@ public class AlCustomizationSettings extends JsonMarker {
         return conversationContactImageVisibility;
     }
 
-    public String getSentContactMessageTextColor() {
-        return sentContactMessageTextColor;
+    public List<String> getSentContactMessageTextColor() {
+        return getColorList(sentContactMessageTextColor);
     }
 
-    public String getReceivedContactMessageTextColor() {
-        return receivedContactMessageTextColor;
+    public List<String> getReceivedContactMessageTextColor() {
+        return getColorList(receivedContactMessageTextColor);
     }
 
-    public String getSentMessageTextColor() {
-        return sentMessageTextColor;
+    public List<String> getSentMessageTextColor() {
+        return getColorList(sentMessageTextColor);
     }
 
-    public String getReceivedMessageTextColor() {
-        return receivedMessageTextColor;
+    public List<String> getReceivedMessageTextColor() {
+        return getColorList(receivedMessageTextColor);
     }
 
-    public String getSentMessageBorderColor() {
-        return sentMessageBorderColor;
+    public List<String> getSentMessageBorderColor() {
+        return getColorList(sentMessageBorderColor);
     }
 
-    public String getReceivedMessageBorderColor() {
-        return receivedMessageBorderColor;
+    public List<String> getReceivedMessageBorderColor() {
+        return getColorList(receivedMessageBorderColor);
     }
 
-    public String getChatBackgroundColorOrDrawable() {
-        return chatBackgroundColorOrDrawable;
+    public List<String> getChatBackgroundColorOrDrawable() {
+        return getColorList(chatBackgroundColorOrDrawable);
     }
 
-    public String getMessageEditTextTextColor() {
-        return messageEditTextTextColor;
+    public List<String> getMessageEditTextTextColor() {
+        return getColorList(messageEditTextTextColor);
     }
 
     public String getAudioPermissionNotFoundMsg() {
@@ -289,16 +296,16 @@ public class AlCustomizationSettings extends JsonMarker {
         return showActionDialWithOutCalling;
     }
 
-    public String getSentMessageLinkTextColor() {
-        return sentMessageLinkTextColor;
+    public List<String> getSentMessageLinkTextColor() {
+        return getColorList(sentMessageLinkTextColor);
     }
 
-    public String getReceivedMessageLinkTextColor() {
-        return receivedMessageLinkTextColor;
+    public List<String> getReceivedMessageLinkTextColor() {
+        return getColorList(receivedMessageLinkTextColor);
     }
 
-    public String getMessageEditTextHintTextColor() {
-        return messageEditTextHintTextColor;
+    public List<String> getMessageEditTextHintTextColor() {
+        return getColorList(messageEditTextHintTextColor);
     }
 
     public boolean isHideGroupAddMembersButton() {
@@ -318,48 +325,48 @@ public class AlCustomizationSettings extends JsonMarker {
     }
 
 
-    public String getEditTextBackgroundColorOrDrawable() {
-        return editTextBackgroundColorOrDrawable;
+    public List<String> getEditTextBackgroundColorOrDrawable() {
+        return getColorList(editTextBackgroundColorOrDrawable);
     }
 
-    public String getEditTextLayoutBackgroundColorOrDrawable() {
-        return editTextLayoutBackgroundColorOrDrawable;
+    public List<String> getEditTextLayoutBackgroundColorOrDrawable() {
+        return getColorList(editTextLayoutBackgroundColorOrDrawable);
     }
 
-    public String getTypingTextColor() {
-        return typingTextColor;
+    public List<String> getTypingTextColor() {
+        return getColorList(typingTextColor);
     }
 
     public boolean isProfileOption() {
         return profileOption;
     }
 
-    public String getNoConversationLabelTextColor() {
-        return noConversationLabelTextColor;
+    public List<String> getNoConversationLabelTextColor() {
+        return getColorList(noConversationLabelTextColor);
     }
 
-    public String getConversationDateTextColor() {
-        return conversationDateTextColor;
+    public List<String> getConversationDateTextColor() {
+        return getColorList(conversationDateTextColor);
     }
 
-    public String getConversationDayTextColor() {
-        return conversationDayTextColor;
+    public List<String> getConversationDayTextColor() {
+        return getColorList(conversationDayTextColor);
     }
 
-    public String getMessageTimeTextColor() {
-        return messageTimeTextColor;
+    public List<String> getMessageTimeTextColor() {
+        return getColorList(messageTimeTextColor);
     }
 
-    public String getChannelCustomMessageBgColor() {
-        return channelCustomMessageBgColor;
+    public List<String> getChannelCustomMessageBgColor() {
+        return getColorList(channelCustomMessageBgColor);
     }
 
-    public String getChannelCustomMessageBorderColor() {
-        return channelCustomMessageBorderColor;
+    public List<String> getChannelCustomMessageBorderColor() {
+        return getColorList(channelCustomMessageBorderColor);
     }
 
-    public String getChannelCustomMessageTextColor() {
-        return channelCustomMessageTextColor;
+    public List<String> getChannelCustomMessageTextColor() {
+        return getColorList(channelCustomMessageTextColor);
     }
 
     public String getNoSearchFoundForChatMessages() {
@@ -396,40 +403,40 @@ public class AlCustomizationSettings extends JsonMarker {
         return totalOnlineUsers;
     }
 
-    public String getCollapsingToolbarLayoutColor() {
-        return collapsingToolbarLayoutColor;
+    public List<String> getCollapsingToolbarLayoutColor() {
+        return getColorList(collapsingToolbarLayoutColor);
     }
 
-    public String getGroupParticipantsTextColor() {
-        return groupParticipantsTextColor;
+    public List<String> getGroupParticipantsTextColor() {
+        return getColorList(groupParticipantsTextColor);
     }
 
-    public String getGroupExitButtonBackgroundColor() {
-        return groupExitButtonBackgroundColor;
+    public List<String> getGroupExitButtonBackgroundColor() {
+        return getColorList(groupExitButtonBackgroundColor);
     }
 
-    public String getGroupDeleteButtonBackgroundColor() {
-        return groupDeleteButtonBackgroundColor;
+    public List<String> getGroupDeleteButtonBackgroundColor() {
+        return getColorList(groupDeleteButtonBackgroundColor);
     }
 
-    public String getAdminTextColor() {
-        return adminTextColor;
+    public List<String> getAdminTextColor() {
+        return getColorList(adminTextColor);
     }
 
-    public String getAdminBackgroundColor() {
-        return adminBackgroundColor;
+    public List<String> getAdminBackgroundColor() {
+        return getColorList(adminBackgroundColor);
     }
 
     public String getAttachCameraIconName() {
         return attachCameraIconName;
     }
 
-    public String getAdminBorderColor() {
-        return adminBorderColor;
+    public List<String> getAdminBorderColor() {
+        return getColorList(adminBorderColor);
     }
 
-    public String getUserNotAbleToChatTextColor() {
-        return userNotAbleToChatTextColor;
+    public List<String> getUserNotAbleToChatTextColor() {
+        return getColorList(userNotAbleToChatTextColor);
     }
 
     public String getChatBackgroundImageName() {
@@ -526,12 +533,12 @@ public class AlCustomizationSettings extends JsonMarker {
         this.logoutPackageName = logoutPackageName;
     }
 
-    public String getThemeColorPrimary() {
-        return themeColorPrimary;
+    public List<String> getThemeColorPrimary() {
+        return getColorList(themeColorPrimary);
     }
 
-    public String getThemeColorPrimaryDark() {
-        return themeColorPrimaryDark;
+    public List<String> getThemeColorPrimaryDark() {
+        return getColorList(themeColorPrimaryDark);
     }
 
     public String getEditTextHintText() {
@@ -546,12 +553,12 @@ public class AlCustomizationSettings extends JsonMarker {
         this.replyOption = replyOption;
     }
 
-    public String getReplyMessageLayoutSentMessageBackground() {
-        return replyMessageLayoutSentMessageBackground;
+    public List<String> getReplyMessageLayoutSentMessageBackground() {
+        return getColorList(replyMessageLayoutSentMessageBackground);
     }
 
-    public String getReplyMessageLayoutReceivedMessageBackground() {
-        return replyMessageLayoutReceivedMessageBackground;
+    public List<String> getReplyMessageLayoutReceivedMessageBackground() {
+        return getColorList(replyMessageLayoutReceivedMessageBackground);
     }
 
     public void setUserChatMuteOption(boolean muteUserChatOption) {
@@ -610,15 +617,19 @@ public class AlCustomizationSettings extends JsonMarker {
         this.receivedMessageCreatedAtTimeColor = receivedMessageCreatedAtTimeColor;
     }
 
-    public String getStartNewConversationButtonBackgroundColor() {
-        return startNewConversationButtonBackgroundColor;
+    public List<String> getStartNewConversationButtonBackgroundColor() {
+        return getColorList(startNewConversationButtonBackgroundColor);
     }
 
-    public String getMessageEditTextBackgroundColor() {
-        return messageEditTextBackgroundColor;
+    public List<String> getMessageEditTextBackgroundColor() {
+        return getColorList(messageEditTextBackgroundColor);
     }
-    public String getAutoSuggestionButtonBackgroundColor() { return autoSuggestionButtonBackgroundColor; }
-    public String getAutoSuggestionButtonTextColor() { return autoSuggestionButtonTextColor; }
+    public List<String> getAutoSuggestionButtonBackgroundColor() {
+        return getColorList(autoSuggestionButtonBackgroundColor);
+    }
+    public List<String> getAutoSuggestionButtonTextColor() {
+        return getColorList(autoSuggestionButtonTextColor);
+    }
 
     public boolean isShowStartNewConversation() {
         return showStartNewConversation;
@@ -636,8 +647,8 @@ public class AlCustomizationSettings extends JsonMarker {
         this.enableAwayMessage = enableAwayMessage;
     }
 
-    public String getAwayMessageTextColor() {
-        return awayMessageTextColor;
+    public List<String> getAwayMessageTextColor() {
+        return getColorList(awayMessageTextColor);
     }
 
     public void setAwayMessageTextColor(String awayMessageTextColor) {
@@ -702,8 +713,8 @@ public class AlCustomizationSettings extends JsonMarker {
         return enableFaqOption[screen - 1];
     }
 
-    public String getMessageStatusIconColor() {
-        return messageStatusIconColor;
+    public List<String> getMessageStatusIconColor() {
+        return getColorList(messageStatusIconColor);
     }
 
     public void setMessageStatusIconColor(String messageStatusIconColor) {
@@ -714,35 +725,35 @@ public class AlCustomizationSettings extends JsonMarker {
         return restrictedWordRegex;
     }
 
-    public String getToolbarTitleColor() {
-        return toolbarTitleColor;
+    public List<String> getToolbarTitleColor() {
+        return getColorList(toolbarTitleColor);
     }
-    public String getChatBarTopLineViewColor() {
-        return chatBarTopLineViewColor;
+    public List<String> getChatBarTopLineViewColor() {
+        return getColorList(chatBarTopLineViewColor);
     }
 
     public void setToolbarTitleColor(String toolbarTitleColor) {
         this.toolbarTitleColor = toolbarTitleColor;
     }
 
-    public String getToolbarSubtitleColor() {
-        return toolbarSubtitleColor;
+    public List<String> getToolbarSubtitleColor() {
+        return getColorList(toolbarSubtitleColor);
     }
 
     public void setToolbarSubtitleColor(String toolbarSubtitleColor) {
         this.toolbarSubtitleColor = toolbarSubtitleColor;
     }
 
-    public String getToolbarColor() {
-        return toolbarColor;
+    public List<String> getToolbarColor() {
+        return getColorList(toolbarColor);
     }
 
-    public String getStatusBarColor() {
-        return statusBarColor;
+    public List<String> getStatusBarColor() {
+        return getColorList(statusBarColor);
     }
 
-    public String getRichMessageThemeColor() {
-        return richMessageThemeColor;
+    public List<String> getRichMessageThemeColor() {
+        return getColorList(richMessageThemeColor);
     }
 
     public boolean isRestrictMessageTypingWithBots() {
@@ -757,8 +768,8 @@ public class AlCustomizationSettings extends JsonMarker {
         return speechToText == null ? new KmSpeechSetting() : speechToText;
     }
 
-    public String getReceiverNameTextColor() {
-        return receiverNameTextColor;
+    public List<String> getReceiverNameTextColor() {
+        return getColorList(receiverNameTextColor);
     }
 
     public Map<String, Boolean> isHidePostCTA() {
@@ -779,6 +790,15 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public boolean isMultipleAttachmentSelectionEnabled() {
         return isMultipleAttachmentSelectionEnabled;
+    }
+
+    private List<String> getColorList(Object color) {
+        if (color instanceof String) {
+            return Arrays.asList((String) color, (String) color);
+        } else if (color instanceof List) {
+            return (List<String>) color;
+        }
+        return Arrays.asList("","");
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -17,13 +17,13 @@ public class AlCustomizationSettings extends JsonMarker {
     private Object customMessageBackgroundColor = "#e6e5ec";
     private Object sentMessageBackgroundColor = "";
     private Object startNewConversationButtonBackgroundColor = "";
-    private Object receivedMessageBackgroundColor = Arrays.asList("#e6e5ec","#313131");
+    private Object receivedMessageBackgroundColor = Arrays.asList("#e6e5ec", "#313131");
     private Object sendButtonBackgroundColor = "";
     private Object attachmentIconsBackgroundColor = "#FF03A9F4";
     private Object chatBackgroundColorOrDrawable;
     private Object editTextBackgroundColorOrDrawable;
     private Object editTextLayoutBackgroundColorOrDrawable;
-    private Object channelCustomMessageBgColor = Arrays.asList("#000000","#FFFFFFFF");
+    private Object channelCustomMessageBgColor = Arrays.asList("#000000", "#FFFFFFFF");
     private Object toolbarTitleColor = "#ffffff";
     private Object toolbarSubtitleColor = "#ffffff";
     private Object receiverNameTextColor = "#5C6677";
@@ -31,10 +31,10 @@ public class AlCustomizationSettings extends JsonMarker {
     private Object sentContactMessageTextColor = "#5fba7d";
     private Object receivedContactMessageTextColor = "#646262";
     private Object sentMessageTextColor = "#FFFFFFFF";
-    private Object receivedMessageTextColor = Arrays.asList("#646262","#FFFFFF");
+    private Object receivedMessageTextColor = Arrays.asList("#646262", "#FFFFFF");
     private Object messageEditTextTextColor = "#000000";
     private Object messageEditTextBackgroundColor = "";
-    private Object autoSuggestionButtonBackgroundColor= "";
+    private Object autoSuggestionButtonBackgroundColor = "";
     private Object autoSuggestionButtonTextColor = "";
     private Object sentMessageLinkTextColor = "#FFFFFFFF";
     private Object receivedMessageLinkTextColor = "#5fba7d";
@@ -115,7 +115,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private String receivedMessageCreatedAtTimeColor;
     private boolean showStartNewConversation = true;
     private boolean enableAwayMessage = true;
-    private Object awayMessageTextColor = Arrays.asList("#A9A4A4","#FFFFFFFF");
+    private Object awayMessageTextColor = Arrays.asList("#A9A4A4", "#FFFFFFFF");
     private boolean isAgentApp = false;
     private boolean hideGroupSubtitle = false;
     private boolean disableGlobalStoragePermission = true;
@@ -152,6 +152,8 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean disableFormPostSubmit = false;
     private Object chatBarTopLineViewColor = "";
     private boolean isMultipleAttachmentSelectionEnabled = false;
+    private boolean isImageCompressionEnabled = false;
+    private int minimumCompressionThresholdForImagesInMB = 5;
     private boolean useDarkMode = true;
 
     public boolean getUseDarkMode() {
@@ -169,17 +171,19 @@ public class AlCustomizationSettings extends JsonMarker {
     public String getMenuIconOnConversationScreen() {
         return menuIconOnConversationScreen;
     }
+
     public boolean isCheckboxAsMultipleButton() {
         return checkboxAsMultipleButton;
     }
+
     public boolean isRateConversationMenuOption() {
         return rateConversationMenuOption;
     }
-        
+
     public boolean isRestartConversationButtonVisibility() {
         return restartConversationButtonVisibility;
     }
-    
+
     public boolean isJavaScriptEnabled() {
         return javaScriptEnabled;
     }
@@ -624,9 +628,11 @@ public class AlCustomizationSettings extends JsonMarker {
     public List<String> getMessageEditTextBackgroundColor() {
         return getColorList(messageEditTextBackgroundColor);
     }
+
     public List<String> getAutoSuggestionButtonBackgroundColor() {
         return getColorList(autoSuggestionButtonBackgroundColor);
     }
+
     public List<String> getAutoSuggestionButtonTextColor() {
         return getColorList(autoSuggestionButtonTextColor);
     }
@@ -658,9 +664,11 @@ public class AlCustomizationSettings extends JsonMarker {
     public boolean isAgentApp() {
         return isAgentApp;
     }
-    public boolean isUseDeviceDefaultLanguage(){
+
+    public boolean isUseDeviceDefaultLanguage() {
         return useDeviceDefaultLanguage;
     }
+
     public boolean isShowTypingIndicatorWhileFetchingResponse() {
         return showTypingIndicatorWhileFetchingResponse;
     }
@@ -728,6 +736,7 @@ public class AlCustomizationSettings extends JsonMarker {
     public List<String> getToolbarTitleColor() {
         return getColorList(toolbarTitleColor);
     }
+
     public List<String> getChatBarTopLineViewColor() {
         return getColorList(chatBarTopLineViewColor);
     }
@@ -798,7 +807,7 @@ public class AlCustomizationSettings extends JsonMarker {
         } else if (color instanceof List) {
             return (List<String>) color;
         }
-        return Arrays.asList("","");
+        return Arrays.asList("", "");
     }
 
     @Override
@@ -865,7 +874,7 @@ public class AlCustomizationSettings extends JsonMarker {
                 ", toolbarTitleColor=" + toolbarTitleColor +
                 ", toolbarSubtitleColor=" + toolbarSubtitleColor +
                 ", useDeviceDefaultLanguage=" + useDeviceDefaultLanguage +
-                ", showTypingIndicatorWhileFetchingResponse=" + showTypingIndicatorWhileFetchingResponse+
+                ", showTypingIndicatorWhileFetchingResponse=" + showTypingIndicatorWhileFetchingResponse +
                 '}';
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -1,20 +1,13 @@
 package com.applozic.mobicomkit.uiwidgets.async;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
 
 import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
-import com.applozic.mobicommons.file.FileUtils;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
 
 /**
  * a async task that will write the given file with the given "uri" to the "file"
@@ -27,15 +20,13 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     Uri uri;
 
     PrePostUIMethods prePostUIMethods;
-    boolean isCompressionNeeded;
 
-    public FileTaskAsync(File file, Uri uri, Context context, PrePostUIMethods prePostUIMethods, boolean isCompressionNeeded) {
+    public FileTaskAsync(File file, Uri uri, Context context, PrePostUIMethods prePostUIMethods) {
         this.context = context;
         this.file = file;
         this.uri = uri;
         this.fileClientService = new FileClientService(context);
         this.prePostUIMethods = prePostUIMethods;
-        this.isCompressionNeeded = isCompressionNeeded;
     }
 
     @Override
@@ -46,9 +37,6 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
 
     @Override
     protected Boolean doInBackground(Void... voids) {
-        if (isCompressionNeeded) {
-            uri = FileUtils.compressImage(uri,context, file.getName());
-        }
         if (fileClientService != null) {
             fileClientService.writeFile(uri, file);
         }
@@ -58,6 +46,6 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     @Override
     protected void onPostExecute(Boolean completed) {
         super.onPostExecute(completed);
-        prePostUIMethods.postTaskUIMethod(uri, completed, file);
+        prePostUIMethods.postTaskUIMethod(completed, file);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -7,14 +7,11 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
-import android.provider.OpenableColumns;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
@@ -38,7 +35,6 @@ import com.applozic.mobicomkit.contact.AppContactService;
 import com.applozic.mobicomkit.contact.BaseContactService;
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
-import com.applozic.mobicomkit.uiwidgets.async.FileTaskAsync;
 import com.applozic.mobicomkit.uiwidgets.async.KmChannelDeleteTask;
 import com.applozic.mobicomkit.uiwidgets.async.KmChannelLeaveMember;
 import com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity;
@@ -48,10 +44,8 @@ import com.applozic.mobicomkit.uiwidgets.conversation.fragment.ConversationFragm
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MessageInfoFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MobiComQuickConversationFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MultimediaOptionFragment;
-import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmToast;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmFragmentGetter;
-import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.commons.core.utils.LocationInfo;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.file.FileUtils;
@@ -209,50 +203,14 @@ public class ConversationUIService {
                     selectedFileUri = ((ConversationActivity) fragmentActivity).getCapturedImageUri();
                     file = ((ConversationActivity) fragmentActivity).getFileObject();
                 }
-                String mimeType = FileUtils.getMimeTypeByContentUriOrOther(getConversationFragment().getContext(), selectedFileUri);
                 MediaScannerConnection.scanFile(fragmentActivity,
                         new String[]{file.getAbsolutePath()}, null,
                         new MediaScannerConnection.OnScanCompletedListener() {
                             public void onScanCompleted(String path, Uri uri) {
                             }
                         });
-                Log.d("xcode photo : ",Thread.currentThread().getName());
-                long fileSize = 0;
-                try {
-                    Cursor returnCursor =
-                            getConversationFragment().getContext().getContentResolver().query(selectedFileUri, null, null, null, null);
-                    if (returnCursor != null) {
-                        int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
-                        returnCursor.moveToFirst();
-                        fileSize = returnCursor.getLong(sizeIndex);
-                        returnCursor.close();
-                    }
-                } catch (Exception e){
-                    e.printStackTrace();
-                }
-                String jsonString = FileUtils.loadSettingsJsonFile(getConversationFragment().getContext());
-                AlCustomizationSettings alCustomizationSettings;
-                if (!TextUtils.isEmpty(jsonString)) {
-                    alCustomizationSettings = (AlCustomizationSettings) GsonUtils.getObjectFromJson(jsonString, AlCustomizationSettings.class);
-                } else {
-                    alCustomizationSettings = new AlCustomizationSettings();
-                }
-                boolean isFileCompressionNeeded = FileUtils.isCompressionNeeded(getConversationFragment().getContext(), selectedFileUri, fileSize, true, alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB());
-                if (isFileCompressionNeeded) {
-                    new FileTaskAsync(file, selectedFileUri, getConversationFragment().getContext(), new PrePostUIMethods() {
-                        @Override
-                        public void preTaskUIMethod() {}
-
-                        @Override
-                        public void postTaskUIMethod(Uri uri, boolean completed, File file) {
-                            getConversationFragment().loadFile(uri, file, mimeType);
-                            Utils.printLog(fragmentActivity, TAG, "File uri: " + uri);
-                        }
-                    }, true).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-                } else {
-                    getConversationFragment().loadFile(selectedFileUri, file, null);
-                    Utils.printLog(fragmentActivity, TAG, "File uri: " + selectedFileUri);
-                }
+                getConversationFragment().loadFile(selectedFileUri, file);
+                Utils.printLog(fragmentActivity, TAG, "File uri: " + selectedFileUri);
             }
 
             if (requestCode == REQUEST_CODE_CONTACT_GROUP_SELECTION && resultCode == Activity.RESULT_OK) {
@@ -269,7 +227,8 @@ public class ConversationUIService {
                 }
 
                 if (selectedFilePath != null) {
-                    getConversationFragment().loadFile(selectedFilePath, file, null);
+                    getConversationFragment().loadFile(selectedFilePath, file);
+                    getConversationFragment().sendMessage("", Message.ContentType.VIDEO_MSG.getValue());
                 }
             }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -483,7 +483,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
             }
 
             @Override
-            public void postTaskUIMethod(Uri uri, boolean completed, File file) {
+            public void postTaskUIMethod(boolean completed, File file) {
                 //TODO: add the progress bar in the feedback fragment commit to here
                 //TODO: conversationUIService.getConversationFragment().hideProgressBar();
                 conversationUIService.sendAttachments(new ArrayList<>(Arrays.asList(Uri.parse(file.getAbsolutePath()))), "");

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
@@ -65,7 +65,6 @@ public class FullScreenImageActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.mobicom_image_full_screen);
         Toolbar toolbar = (Toolbar) findViewById(R.id.my_toolbar);
         setSupportActionBar(toolbar);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
@@ -7,6 +7,10 @@ import android.content.ClipData;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.NinePatchDrawable;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -19,6 +23,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -74,6 +79,7 @@ public class MobiComAttachmentSelectorActivity extends AppCompatActivity {
     List<String> restrictedWords;
     private ArrayList<Uri> attachmentFileList = new ArrayList<>();
     private MobiComAttachmentGridViewAdapter imagesAdapter;
+    private LinearLayout idRootLinearLayout;
 
     KmAttachmentsController kmAttachmentsController;
     PrePostUIMethods prePostUIMethodsFileAsyncTask;
@@ -141,7 +147,15 @@ public class MobiComAttachmentSelectorActivity extends AppCompatActivity {
         cancelAttachment = (Button) findViewById(R.id.mobicom_attachment_cancel_btn);
         galleryImagesGridView = (GridView) findViewById(R.id.mobicom_attachment_grid_View);
         messageEditText = (EditText) findViewById(R.id.mobicom_attachment_edit_text);
-
+        KmThemeHelper themeHelper = KmThemeHelper.getInstance(this,alCustomizationSettings);
+        if (themeHelper.isDarkModeEnabledForSDK()) {
+            idRootLinearLayout = findViewById(R.id.idRootLinearLayout);
+            idRootLinearLayout.setBackgroundColor(getResources().getColor(R.color.dark_mode_default));
+            NinePatchDrawable bgShape = (NinePatchDrawable) messageEditText.getBackground();
+            bgShape.setColorFilter(getResources().getColor(R.color.received_message_bg_color_night), android.graphics.PorterDuff.Mode.MULTIPLY);
+            messageEditText.setTextColor(getResources().getColor(R.color.chatbar_text_color));
+            messageEditText.setHintTextColor(getResources().getColor(R.color.chatbar_text_color));
+        }
         cancelAttachment.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
@@ -222,7 +222,7 @@ public class MobiComAttachmentSelectorActivity extends AppCompatActivity {
             }
 
             @Override
-            public void postTaskUIMethod(Uri selectedFileUri, boolean completed, File file) {
+            public void postTaskUIMethod(boolean completed, File file) {
                 if (progressDialog != null && progressDialog.isShowing()) {
                     progressDialog.dismiss();
                 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
@@ -29,6 +29,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.applozic.mobicomkit.broadcast.ConnectivityReceiver;
@@ -74,6 +75,8 @@ public class MobicomLocationActivity extends AppCompatActivity implements OnMapR
     Marker myLocationMarker;
     KmPermissions kmPermissions;
     static final String TAG = "MobicomLocationActivity";
+    private LinearLayout locationLinearLayout;
+    private TextView sendLocationText;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -100,6 +103,12 @@ public class MobicomLocationActivity extends AppCompatActivity implements OnMapR
         sendLocation = (RelativeLayout) findViewById(R.id.sendLocation);
         mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         kmPermissions = new KmPermissions(MobicomLocationActivity.this, layout);
+        locationLinearLayout = findViewById(R.id.km_location_linear_layout);
+        sendLocationText = findViewById(R.id.km_send_location_text);
+        if (KmThemeHelper.getInstance(this,alCustomizationSettings).isDarkModeEnabledForSDK()){
+            locationLinearLayout.setBackgroundColor(getResources().getColor(R.color.dark_mode_default));
+            sendLocationText.setTextColor(getResources().getColor(R.color.white));
+        }
         googleApiClient = new GoogleApiClient.Builder(getApplicationContext())
                 .addConnectionCallbacks(this)
                 .addOnConnectionFailedListener(this)

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
@@ -290,15 +290,8 @@ public class MobicomLocationActivity extends AppCompatActivity implements OnMapR
     public void onLocationChanged(Location location) {
         try {
             LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, this);
-            boolean reloadMap = false;
             if (location != null) {
-                if (mCurrentLocation == null){
-                    reloadMap = true;
-                }
                 mCurrentLocation = location;
-                if (reloadMap) {
-                    mapFragment.getMapAsync(this);
-                }
             }
         } catch (Exception e) {
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1341,6 +1341,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                     + message.getMessage()
                     + "</body></html>";
         }
+        webView.getSettings().setDomStorageEnabled(true);
         webView.loadDataWithBaseURL(null, styledHtml, "text/html", "charset=UTF-8", null);
     }
 

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1326,7 +1326,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
             lastSentMessage = message;
         }
     }
-  
+
     private void loadHtml(FrameLayout emailLayout, Message message) {
         WebView webView = emailLayout.findViewById(R.id.emailWebView);
         webViews.add(webView);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/MobicomMultimediaPopupAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/MobicomMultimediaPopupAdapter.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 
 import java.util.List;
 
@@ -56,8 +57,9 @@ public class MobicomMultimediaPopupAdapter extends BaseAdapter {
         TextView icon = (TextView) convertView.findViewById(R.id.mobicom_multimedia_icon);
         Typeface iconTypeface = Typeface.createFromAsset(context.getAssets(), "fonts/fontawesome-webfont.ttf");
         icon.setTypeface(iconTypeface);
+        KmThemeHelper themeHelper = KmThemeHelper.getInstance(context,new AlCustomizationSettings());
         TextView text = (TextView) convertView.findViewById(R.id.mobicom_multimedia_text);
-        icon.setTextColor(Color.parseColor(alCustomizationSettings.getAttachmentIconsBackgroundColor()));
+        icon.setTextColor(Color.parseColor(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getAttachmentIconsBackgroundColor().get(1) : alCustomizationSettings.getAttachmentIconsBackgroundColor().get(0)));
         icon.setText(multimediaIcons.get(position));
         text.setText(multimediaText.get(position));
         return convertView;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -9,6 +9,7 @@ import android.graphics.drawable.GradientDrawable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
 
+import android.text.Html;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
@@ -257,8 +258,8 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                 } else if (message.getContentType() == Message.ContentType.PRICE.getValue()) {
                     myholder.messageTextView.setText(EmoticonUtils.getSmiledText(context, ConversationUIService.FINAL_PRICE_TEXT + message.getMessage(), emojiconHandler));
                 } else if (message.getContentType() == Message.ContentType.TEXT_HTML.getValue()) {
-                    KmUtils.setIconInsideTextView(myholder.messageTextView, R.drawable.ic_messageicon, Color.TRANSPARENT, KmUtils.LEFT_POSITION, 20, isDarkMode);                    if (DetailedConversationAdapter.isEmailTypeMessage(message)) {
-                    myholder.messageTextView.setText(DEFAULT_MSG_BODY);
+                    myholder.messageTextView.setText(Html.fromHtml(message.getMessage()));
+                    if (DetailedConversationAdapter.isEmailTypeMessage(message)) {
                         myholder.attachmentIcon.setVisibility(View.VISIBLE);
                         myholder.attachmentIcon.setImageResource(R.drawable.email);
                     }
@@ -557,7 +558,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
 
                 switch (item.getItemId()) {
                     case 0:
-                        if (channel != null) {
+                        if(channel != null) {
                             conversationUIService.deleteChannel(context, channel);
                         }
                         break;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/QuickConversationAdapter.java
@@ -100,13 +100,16 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         this.alCustomizationSettings = alCustomizationSettings;
     }
 
-    public QuickConversationAdapter(final Context context, List<Message> messageList, EmojiconHandler emojiconHandler, final boolean isDarkMode) {
+    public void setDarkMode(boolean isDarkMode) {
+        this.isDarkMode = isDarkMode;
+    }
+
+    public QuickConversationAdapter(final Context context, List<Message> messageList, EmojiconHandler emojiconHandler) {
         this.context = context;
         this.emojiconHandler = emojiconHandler;
         this.contactService = new AppContactService(context);
         this.messageDatabaseService = new MessageDatabaseService(context);
         this.messageList = messageList;
-        this.isDarkMode = isDarkMode;
         conversationUIService = new ConversationUIService((FragmentActivity) context);
         loggedInUserRoleType = MobiComUserPreference.getInstance(context).getUserRoleType();
         loggedInUserId = MobiComUserPreference.getInstance(context).getUserId();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -335,7 +335,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     protected boolean onSelected;
     protected ImageCache imageCache;
     protected RecyclerView messageTemplateView;
-    protected ImageButton cameraButton, locationButton, fileAttachmentButton, multiSelectGalleryButton, videoButton;
+    protected ImageButton cameraButton, locationButton, fileAttachmentButton, multiSelectGalleryButton;
     protected WeakReference<KmRecordButton> recordButtonWeakReference;
     protected RecyclerView recyclerView;
     protected RecyclerViewPositionHelper recyclerViewPositionHelper;
@@ -711,7 +711,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         messageTemplateView = (RecyclerView) list.findViewById(R.id.mobicomMessageTemplateView);
         applozicLabel = list.findViewById(R.id.applozicLabel);
         cameraButton = list.findViewById(R.id.camera_btn);
-        videoButton = list.findViewById(R.id.btn_video_capture);
         locationButton = list.findViewById(R.id.location_btn);
         fileAttachmentButton = list.findViewById(R.id.file_as_attachment_btn);
         multiSelectGalleryButton = list.findViewById(R.id.idMultiSelectGalleryButton);
@@ -1097,10 +1096,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
             if (attachmentOptions.containsKey(":camera")) {
                 cameraButton.setVisibility(attachmentOptions.get(":camera") ? VISIBLE : View.GONE);
-            }
-
-            if (attachmentOptions.containsKey(":video")) {
-                videoButton.setVisibility(attachmentOptions.get(":video") ? VISIBLE : GONE);
             }
 
             if (attachmentOptions.containsKey(":file")) {
@@ -2589,7 +2584,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
     }
 
-    public void loadFile(Uri uri, File file, String mimeType) {
+    public void loadFile(Uri uri, File file) {
         if (uri == null || file == null) {
             KmToast.error(ApplozicService.getContext(getContext()), ApplozicService.getContext(getContext()).getString(R.string.file_not_selected), Toast.LENGTH_LONG).show();
             return;
@@ -2602,9 +2597,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             KmToast.error(ApplozicService.getContext(getContext()), ApplozicService.getContext(getContext()).getString(R.string.info_file_attachment_error), Toast.LENGTH_LONG).show();
             return;
         }
-        if(TextUtils.isEmpty(mimeType)){
-            mimeType = ApplozicService.getContext(getContext()).getContentResolver().getType(uri);
-        }
+        String mimeType = ApplozicService.getContext(getContext()).getContentResolver().getType(uri);
         Cursor returnCursor =
                 ApplozicService.getContext(getContext()).getContentResolver().query(uri, null, null, null, null);
         if (returnCursor != null) {
@@ -4829,28 +4822,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                             public void onAction(boolean didGrant) {
                                 if (didGrant) {
                                     ((ConversationActivity) getActivity()).processCameraAction();
-                                }
-                            }
-                        });
-                    }
-                }
-            }
-        });
-
-        videoButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                AlEventManager.getInstance().sendOnAttachmentClick("video");
-                emoticonsFrameLayout.setVisibility(View.GONE);
-                if (getActivity() != null) {
-                    if (((KmStoragePermissionListener) getActivity()).isPermissionGranted()) {
-                        ((ConversationActivity) getActivity()).processVideoRecording();
-                    } else {
-                        ((KmStoragePermissionListener) getActivity()).checkPermission(new KmStoragePermission() {
-                            @Override
-                            public void onAction(boolean didGrant) {
-                                if (didGrant) {
-                                    ((ConversationActivity) getActivity()).processVideoRecording();
                                 }
                             }
                         });

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
@@ -137,9 +137,7 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
         isCurrentlyInDarkMode = KmThemeHelper.getInstance(getContext(),alCustomizationSettings).isDarkModeEnabledForSDK();
         if (!alCustomizationSettings.isAgentApp()) {
             LinearLayout kmMessageLinearLayout = list.findViewById(R.id.km_message_linear_layout);
-            if (kmMessageLinearLayout != null) {
-                kmMessageLinearLayout.setVisibility(View.GONE);
-            }
+            kmMessageLinearLayout.setVisibility(View.GONE);
         }
 
         recyclerView = (RecyclerView) list.findViewById(R.id.messageList);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/RichMessageActionProcessor.java
@@ -329,19 +329,12 @@ public class RichMessageActionProcessor implements KmRichMessageListener {
             com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmRichMessageModel<List<KmFormPayloadModel>> richMessageModel = new Gson().fromJson(GsonUtils.getJsonFromObject(message.getMetadata(), Map.class), new TypeToken<com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmRichMessageModel>() {
             }.getType());
 
-            List<KmFormPayloadModel> formPayloadModelList = richMessageModel.getFormModelList();
-            if (TextUtils.isEmpty(submitButtonMessage)) {
-                for (KmFormPayloadModel model: formPayloadModelList) {
-                    if (model.isTypeAction()) {
-                        submitButtonMessage = model.getAction().getName();
-                        break;
-                    }
-                }
-            }
             StringBuilder messageToSend = new StringBuilder(submitButtonMessage);
             if (!TextUtils.isEmpty(messageToSend)) {
                 messageToSend.append("\n");
             }
+
+            List<KmFormPayloadModel> formPayloadModelList = richMessageModel.getFormModelList();
 
             for (KmFormPayloadModel model : formPayloadModelList) {
                 //Submit Button

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmAutoSuggestionArrayAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmAutoSuggestionArrayAdapter.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 
 public class KmAutoSuggestionArrayAdapter<T> extends ArrayAdapter<T> {
 
@@ -53,12 +54,13 @@ public class KmAutoSuggestionArrayAdapter<T> extends ArrayAdapter<T> {
 
         LinearLayout autoSuggestionRowLayout = (LinearLayout)convertView.findViewById(R.id.km_auto_suggestion_row_layout);
         TextView nameView = (TextView) convertView.findViewById(R.id.km_name_tv);
+        KmThemeHelper themeHelper = KmThemeHelper.getInstance(getContext(),alCustomizationSettings);
 
-        if (!TextUtils.isEmpty(alCustomizationSettings.getAutoSuggestionButtonBackgroundColor())){
-            autoSuggestionRowLayout.setBackgroundColor(Color.parseColor(alCustomizationSettings.getAutoSuggestionButtonBackgroundColor()));
+        if (!TextUtils.isEmpty(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getAutoSuggestionButtonBackgroundColor().get(1) : alCustomizationSettings.getAutoSuggestionButtonBackgroundColor().get(0))){
+            autoSuggestionRowLayout.setBackgroundColor(Color.parseColor(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getAutoSuggestionButtonBackgroundColor().get(1) : alCustomizationSettings.getAutoSuggestionButtonBackgroundColor().get(0)));
         }
-        if (!TextUtils.isEmpty(alCustomizationSettings.getAutoSuggestionButtonTextColor())){
-           nameView.setTextColor(Color.parseColor(alCustomizationSettings.getAutoSuggestionButtonTextColor()));
+        if (!TextUtils.isEmpty(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getAutoSuggestionButtonTextColor().get(1) : alCustomizationSettings.getAutoSuggestionButtonTextColor().get(0))){
+           nameView.setTextColor(Color.parseColor(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getAutoSuggestionButtonTextColor().get(1) : alCustomizationSettings.getAutoSuggestionButtonTextColor().get(0)));
         }
 
         T source = fullList.get(position);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmCardRMAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmCardRMAdapter.java
@@ -1,6 +1,11 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.adapters;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.ColorFilter;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -110,6 +115,15 @@ public class KmCardRMAdapter extends KmRichMessageAdapter {
         CardViewHolder viewHolder = (CardViewHolder) holder;
         if (payloadList != null) {
             final KmRichMessageModel.KmPayloadModel payloadModel = payloadList.get(position);
+            GradientDrawable drawable = (GradientDrawable) viewHolder.productPrice.getBackground();
+            if (themeHelper.isDarkModeEnabledForSDK()){
+                viewHolder.productName.setTextColor(Color.WHITE);
+                drawable.setColor(Color.BLACK);
+                viewHolder.productPrice.setTextColor(Color.WHITE);
+            } else {
+                drawable.setColor(context.getResources().getColor(R.color.km_white_color));
+            }
+            viewHolder.productPrice.setBackground(drawable);
 
             if (payloadModel.getHeader() != null && !TextUtils.isEmpty(payloadModel.getHeader().getImgSrc())) {
                 Glide.with(context).load(payloadModel.getHeader().getImgSrc()).into(viewHolder.productImage);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmFormItemAdapter.java
@@ -3,6 +3,9 @@ package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.adapters;
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.os.Build;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -41,6 +44,7 @@ import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.KmFor
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmFlowLayout;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views.KmRadioGroup;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmSelectButton;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmToast;
 import com.applozic.mobicommons.commons.core.utils.Utils;
@@ -319,6 +323,21 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
                                 } else {
                                     final CheckBox checkBox = new CheckBox(context);
                                     checkBox.setGravity(Gravity.FILL);
+                                    if (KmThemeHelper.getInstance(context,alCustomizationSettings).isDarkModeEnabledForSDK()){
+                                        checkBox.setTextColor(Color.WHITE);
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                                            checkBox.setButtonTintList(new ColorStateList(
+                                                    new int[][] {
+                                                            new int[] {android.R.attr.state_checked},
+                                                            new int[] {android.R.attr.state_enabled}
+                                                    },
+                                                    new int[] {
+                                                            Color.WHITE,
+                                                            Color.WHITE
+                                                    }
+                                            ));
+                                        }
+                                    }
                                     if (checkedBoxes.contains(index)){
                                         checkBox.setChecked(true);
                                     } else if (unCheckedBoxes.contains(index)){
@@ -633,7 +652,14 @@ public class KmFormItemAdapter extends RecyclerView.Adapter {
             super(itemView);
 
             formLabel = itemView.findViewById(R.id.km_form_label_text);
+            KmThemeHelper themeHelper = KmThemeHelper.getInstance(context,alCustomizationSettings);
+            if (formLabel != null && themeHelper.isDarkModeEnabledForSDK()){
+                formLabel.setTextColor(context.getResources().getColor(R.color.white));
+            }
             formEditText = itemView.findViewById(R.id.km_form_edit_text);
+            if (formEditText != null && themeHelper.isDarkModeEnabledForSDK()){
+                formEditText.setTextColor(context.getResources().getColor(R.color.received_message_bg_color_night));
+            }
             formItemRootLayout = itemView.findViewById(R.id.km_form_item_root_layout);
             formFlowLayout = itemView.findViewById(R.id.km_form_selection_layout);
             formDatePicker = itemView.findViewById(R.id.km_form_date_picker);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmImageRMAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/adapters/KmImageRMAdapter.java
@@ -60,9 +60,9 @@ public class KmImageRMAdapter extends KmRichMessageAdapter {
             if (payloadModel != null) {
                 if (alCustomizationSettings != null) {
                     GradientDrawable bgShape = (GradientDrawable) imageViewHolder.rootLayout.getBackground();
-                    bgShape.setColor(message.isTypeOutbox() ? themeHelper.getSentMessageBackgroundColor() : Color.parseColor(alCustomizationSettings.getReceivedMessageBackgroundColor()));
+                    bgShape.setColor(message.isTypeOutbox() ? themeHelper.getSentMessageBackgroundColor() : Color.parseColor(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getReceivedMessageBackgroundColor().get(1) : alCustomizationSettings.getReceivedMessageBorderColor().get(0)));
                     bgShape.setStroke(3, message.isTypeOutbox() ? themeHelper.getSentMessageBorderColor() :
-                            Color.parseColor(alCustomizationSettings.getReceivedMessageBorderColor()));
+                            Color.parseColor(themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getReceivedMessageBorderColor().get(1) : alCustomizationSettings.getReceivedMessageBorderColor().get(0)));
                 }
                 if (!TextUtils.isEmpty(payloadModel.getUrl())) {
                     Glide.with(context)
@@ -75,7 +75,7 @@ public class KmImageRMAdapter extends KmRichMessageAdapter {
                 if (payloadModel.getCaption() != null && !TextUtils.isEmpty(payloadModel.getCaption().trim())) {
                     imageViewHolder.captionText.setVisibility(View.VISIBLE);
                     imageViewHolder.captionText.setText(payloadModel.getCaption());
-                    imageViewHolder.captionText.setTextColor(Color.parseColor(message.isTypeOutbox() ? alCustomizationSettings.getSentMessageTextColor() : alCustomizationSettings.getReceivedMessageTextColor()));
+                    imageViewHolder.captionText.setTextColor(Color.parseColor(message.isTypeOutbox() ? (themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getSentMessageTextColor().get(1) : alCustomizationSettings.getSentMessageTextColor().get(0)) : (themeHelper.isDarkModeEnabledForSDK() ? alCustomizationSettings.getReceivedMessageTextColor().get(1) : alCustomizationSettings.getReceivedMessageTextColor().get(0))));
                 } else {
                     imageViewHolder.captionText.setVisibility(View.GONE);
                 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/form/KmDropdownItemAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/form/KmDropdownItemAdapter.java
@@ -10,13 +10,19 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 
 import java.util.List;
 
 public class KmDropdownItemAdapter extends ArrayAdapter<KmFormPayloadModel.Options> {
+
+    private Context context;
+
     public KmDropdownItemAdapter(@NonNull Context context, int textViewResourceId, List<KmFormPayloadModel.Options> itemList) {
         super(context, textViewResourceId, itemList);
+        this.context = context;
     }
 
     @NonNull
@@ -31,7 +37,13 @@ public class KmDropdownItemAdapter extends ArrayAdapter<KmFormPayloadModel.Optio
     @Override
     public View getDropDownView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
         TextView label = (TextView) super.getDropDownView(position, convertView, parent);
-        label.setTextColor(Color.BLACK);
+        KmThemeHelper kmThemeHelper = KmThemeHelper.getInstance(context, new AlCustomizationSettings());
+        if (kmThemeHelper.isDarkModeEnabledForSDK()){
+            label.setTextColor(Color.WHITE);
+            label.setBackgroundColor(Color.BLACK);
+        } else {
+            label.setTextColor(Color.BLACK);
+        }
         label.setText(getItem(position).getLabel());
         return label;
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ButtonKmRichMessage.java
@@ -1,6 +1,7 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.types;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -46,7 +47,11 @@ public class ButtonKmRichMessage extends KmRichMessage {
             TextView itemTextView = view.findViewById(R.id.singleTextItem);
 
             KmUtils.setGradientStrokeColor(itemTextView, DimensionsUtils.convertDpToPx(1), themeHelper.getRichMessageThemeColor());
-            itemTextView.setTextColor(themeHelper.getRichMessageThemeColor());
+            if (themeHelper.isDarkModeEnabledForSDK()){
+                itemTextView.setTextColor(Color.WHITE);
+            } else {
+                itemTextView.setTextColor(themeHelper.getRichMessageThemeColor());
+            }
 
             //for 3 and 11 use name, for 6 use title
             String buttonTitle = (model.getTemplateId() == 3 || model.getTemplateId() == 11) ?

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/KmFormRichMessage.java
@@ -1,6 +1,9 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.types;
 
 import android.content.Context;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.GradientDrawable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -43,6 +46,12 @@ public class KmFormRichMessage extends KmRichMessage {
         LinearLayoutManager formLayoutManager = new LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false);
         alFormLayoutRecycler.setLayoutManager(formLayoutManager);
         final KmFormItemAdapter formItemAdapter = new KmFormItemAdapter(context, kmRichMessageModel.getFormModelList(), message.getKeyString(), alCustomizationSettings);
+        GradientDrawable drawable = (GradientDrawable) alFormLayoutRecycler.getBackground();
+        if (themeHelper.isDarkModeEnabledForSDK()){
+            drawable.setColorFilter(context.getResources().getColor(R.color.received_message_bg_color_night), PorterDuff.Mode.MULTIPLY);
+        } else {
+            drawable.clearColorFilter();
+        }
         alFormLayoutRecycler.setAdapter(formItemAdapter);
         alFormLayoutRecycler.removeOnItemTouchListener(formListenerTrue);
         alFormLayoutRecycler.removeOnItemTouchListener(formListenerFalse);
@@ -80,7 +89,11 @@ public class KmFormRichMessage extends KmRichMessage {
                 TextView itemTextView = view.findViewById(R.id.singleTextItem);
 
                 KmUtils.setGradientStrokeColor(itemTextView, DimensionsUtils.convertDpToPx(1), themeHelper.getRichMessageThemeColor());
-                itemTextView.setTextColor(themeHelper.getRichMessageThemeColor());
+                if (themeHelper.isDarkModeEnabledForSDK()){
+                    itemTextView.setTextColor(Color.WHITE);
+                } else {
+                    itemTextView.setTextColor(themeHelper.getRichMessageThemeColor());
+                }
 
                 final KmRMActionModel<KmRMActionModel.SubmitButton> submitButtonModel = (KmRMActionModel<KmRMActionModel.SubmitButton>) actionModelList.get(0);
                 itemTextView.setText(submitButtonModel.getName());

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/types/ListKmRichMessage.java
@@ -105,7 +105,6 @@ public class ListKmRichMessage extends KmRichMessage {
     }
 
     private List<KmRichMessageModel.KmElementModel> getFilteredList(boolean isMessageProcessed, List<KmRichMessageModel.KmElementModel> elementList) {
-       if (elementList == null) return new ArrayList<>();
         List<KmRichMessageModel.KmElementModel> newList = new ArrayList<>();
         for (KmRichMessageModel.KmElementModel element : elementList) {
             if (isMessageProcessed && hideMessage(themeHelper, element.getAction().getType())) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/views/KmRadioGroup.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/views/KmRadioGroup.java
@@ -1,13 +1,19 @@
 package com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.views;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.os.Build;
 import android.util.SparseIntArray;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.RadioButton;
 
+import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
+import com.applozic.mobicomkit.uiwidgets.R;
 import com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.models.v2.KmFormPayloadModel;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 
 import java.util.List;
 
@@ -46,6 +52,21 @@ public class KmRadioGroup {
                     }
                 });
                 radioButton.setText(option.getLabel());
+                if (KmThemeHelper.getInstance(context,new AlCustomizationSettings()).isDarkModeEnabledForSDK()){
+                    radioButton.setTextColor(context.getResources().getColor(R.color.white));
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        radioButton.setButtonTintList(new ColorStateList(
+                                new int[][] {
+                                        new int[] {android.R.attr.state_checked},
+                                        new int[] {android.R.attr.state_enabled}
+                                },
+                                new int[] {
+                                        Color.WHITE,
+                                        Color.WHITE
+                                }
+                        ));
+                    }
+                }
 
                 flowLayout.addView(radioButton);
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -5,8 +5,6 @@ import android.content.DialogInterface;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 
 import androidx.appcompat.widget.Toolbar;
@@ -63,15 +61,10 @@ public class KmWebViewActivity extends AppCompatActivity {
             alCustomizationSettings = new AlCustomizationSettings();
         }
 
-        toolbar = (Toolbar) findViewById(R.id.my_toolbar);
+        toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        KmThemeHelper themeHelper = KmThemeHelper.getInstance(this, alCustomizationSettings);
-        getSupportActionBar().setBackgroundDrawable(new ColorDrawable(themeHelper.getPrimaryColor()));
-        getSupportActionBar().setTitle("");
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().show();
 
-        KmUtils.setStatusBarColor(this, themeHelper.getStatusBarColor());
+        KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, alCustomizationSettings).getStatusBarColor());
 
         webView = findViewById(R.id.paymentWebView);
         loadingProgressBar = findViewById(R.id.loadingProgress);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/KmAttachmentsController.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/KmAttachmentsController.java
@@ -157,7 +157,6 @@ public class KmAttachmentsController {
     public int processFile(Uri selectedFileUri, AlCustomizationSettings alCustomizationSettings, PrePostUIMethods prePostUIMethods) {
         if (selectedFileUri != null) {
             String fileName;
-            long fileSize = 0;
             try {
                 long maxFileSize = alCustomizationSettings.getMaxAttachmentSizeAllowed() * 1024 * 1024;
                 Cursor returnCursor =
@@ -165,7 +164,7 @@ public class KmAttachmentsController {
                 if (returnCursor != null) {
                     int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
                     returnCursor.moveToFirst();
-                    fileSize = returnCursor.getLong(sizeIndex);
+                    Long fileSize = returnCursor.getLong(sizeIndex);
                     returnCursor.close();
                     if (fileSize > maxFileSize) {
                         Utils.printLog(context, TAG, context.getResources().getString(R.string.info_attachment_max_allowed_file_size));
@@ -193,7 +192,7 @@ public class KmAttachmentsController {
                     }
                 }
                 File mediaFile = FileClientService.getFilePath(fileName, context.getApplicationContext(), mimeType);
-                new FileTaskAsync(mediaFile, selectedFileUri, context, prePostUIMethods, FileUtils.isCompressionNeeded(context, selectedFileUri, fileSize, alCustomizationSettings.isImageCompressionEnabled(), alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB())).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                new FileTaskAsync(mediaFile, selectedFileUri, context, prePostUIMethods).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             } catch (Exception e) {
                 e.printStackTrace();
                 return EXCEPTION_OCCURED;

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/callbacks/PrePostUIMethods.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/callbacks/PrePostUIMethods.java
@@ -1,7 +1,5 @@
 package com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks;
 
-import android.net.Uri;
-
 import java.io.File;
 
 /**
@@ -15,5 +13,5 @@ import java.io.File;
 public interface PrePostUIMethods {
     void preTaskUIMethod();
 
-    void postTaskUIMethod(Uri uri, boolean completed, File file);
+    void postTaskUIMethod(boolean completed, File file);
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/utils/KmThemeHelper.java
@@ -1,6 +1,7 @@
 package com.applozic.mobicomkit.uiwidgets.kommunicate.utils;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.text.TextUtils;
 
@@ -70,21 +71,21 @@ public class KmThemeHelper implements KmCallback {
 
     public int getToolbarTitleColor() {
         if (toolbarTitleColor == -1) {
-            toolbarTitleColor = parseColorWithDefault(alCustomizationSettings.getToolbarTitleColor(), context.getResources().getColor(R.color.toolbar_title_color));
+            toolbarTitleColor = parseColorWithDefault(isDarkModeEnabledForSDK() ? alCustomizationSettings.getToolbarTitleColor().get(1) : alCustomizationSettings.getToolbarTitleColor().get(0), context.getResources().getColor(R.color.toolbar_title_color));
         }
         return toolbarTitleColor;
     }
 
     public int getToolbarSubtitleColor() {
         if (toolbarSubtitleColor == -1) {
-            toolbarSubtitleColor = parseColorWithDefault(alCustomizationSettings.getToolbarSubtitleColor(), context.getResources().getColor(R.color.toolbar_subtitle_color));
+            toolbarSubtitleColor = parseColorWithDefault(isDarkModeEnabledForSDK() ? alCustomizationSettings.getToolbarSubtitleColor().get(1) : alCustomizationSettings.getToolbarSubtitleColor().get(0), context.getResources().getColor(R.color.toolbar_subtitle_color));
         }
         return toolbarSubtitleColor;
     }
 
     public int getSentMessageBackgroundColor() {
         if (sentMessageBackgroundColor == -1) {
-            String colorStr = alCustomizationSettings.getSentMessageBackgroundColor();
+            String colorStr = isDarkModeEnabledForSDK() ? alCustomizationSettings.getSentMessageBackgroundColor().get(1) : alCustomizationSettings.getSentMessageBackgroundColor().get(0);
 
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
@@ -142,7 +143,7 @@ public class KmThemeHelper implements KmCallback {
 
     public int getSentMessageBorderColor() {
         if (sentMessageBorderColor == -1) {
-            String colorStr = alCustomizationSettings.getSentMessageBorderColor();
+            String colorStr = isDarkModeEnabledForSDK() ? alCustomizationSettings.getSentMessageBorderColor().get(1) : alCustomizationSettings.getSentMessageBorderColor().get(0);
 
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
@@ -154,7 +155,7 @@ public class KmThemeHelper implements KmCallback {
 
     public int getSendButtonBackgroundColor() {
         if (sendButtonBackgroundColor == -1) {
-            String colorStr = alCustomizationSettings.getSendButtonBackgroundColor();
+            String colorStr = isDarkModeEnabledForSDK() ? alCustomizationSettings.getSendButtonBackgroundColor().get(1) : alCustomizationSettings.getSendButtonBackgroundColor().get(0);
 
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
@@ -166,7 +167,7 @@ public class KmThemeHelper implements KmCallback {
 
     public int getMessageStatusIconColor() {
         if (messageStatusIconColor == -1) {
-            String colorStr = alCustomizationSettings.getMessageStatusIconColor();
+            String colorStr = isDarkModeEnabledForSDK() ? alCustomizationSettings.getMessageStatusIconColor().get(1) : alCustomizationSettings.getMessageStatusIconColor().get(0);
 
             if (TextUtils.isEmpty(colorStr)) {
                 colorStr = appSettingPreferences.getPrimaryColor();
@@ -186,23 +187,28 @@ public class KmThemeHelper implements KmCallback {
 
     public int getToolbarColor() {
         if (toolbarColor == -1) {
-            toolbarColor = parseColorWithDefault(alCustomizationSettings.getToolbarColor(), getPrimaryColor());
+            toolbarColor = parseColorWithDefault(isDarkModeEnabledForSDK() ? alCustomizationSettings.getToolbarColor().get(1) : alCustomizationSettings.getToolbarColor().get(0), getPrimaryColor());
         }
         return toolbarColor;
     }
 
     public int getStatusBarColor() {
         if (statusBarColor == -1) {
-            statusBarColor = parseColorWithDefault(alCustomizationSettings.getStatusBarColor(), getSecondaryColor());
+            statusBarColor = parseColorWithDefault(isDarkModeEnabledForSDK() ? alCustomizationSettings.getStatusBarColor().get(1) : alCustomizationSettings.getStatusBarColor().get(0), getSecondaryColor());
         }
         return statusBarColor;
     }
 
     public int getRichMessageThemeColor() {
         if (richMessageThemeColor == -1) {
-            richMessageThemeColor = parseColorWithDefault(alCustomizationSettings.getRichMessageThemeColor(), getPrimaryColor());
+            richMessageThemeColor = parseColorWithDefault(isDarkModeEnabledForSDK() ?  alCustomizationSettings.getRichMessageThemeColor().get(1) : alCustomizationSettings.getRichMessageThemeColor().get(0), getPrimaryColor());
         }
         return richMessageThemeColor;
+    }
+
+    public boolean isDarkModeEnabledForSDK() {
+        return !alCustomizationSettings.isAgentApp() && alCustomizationSettings.getUseDarkMode() && ((context.getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES);
     }
 
     public static void clearInstance() {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmAwayView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmAwayView.java
@@ -1,6 +1,7 @@
 package com.applozic.mobicomkit.uiwidgets.kommunicate.views;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,8 +12,10 @@ import android.widget.TextView;
 import com.applozic.mobicomkit.api.account.user.User;
 import com.applozic.mobicomkit.api.account.user.UserService;
 import com.applozic.mobicomkit.listners.AlCallback;
+import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.DashedLineView;
 import com.applozic.mobicomkit.uiwidgets.R;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.people.channel.Channel;
 
@@ -148,5 +151,11 @@ public class KmAwayView extends LinearLayout {
                  Utils.printLog(rootLinearLayout.getContext(), TAG, "Error: " + error);
             }
         });
+    }
+
+    public void setupTheme(boolean isDarkModeEnabled, AlCustomizationSettings alCustomizationSettings){
+        setBackgroundColor(isDarkModeEnabled ? getResources().getColor(R.color.dark_mode_default) : Color.WHITE);
+        awayMessageTv.setTextColor(Color.parseColor(isDarkModeEnabled ? alCustomizationSettings.getAwayMessageTextColor().get(1) : alCustomizationSettings.getAwayMessageTextColor().get(0)));
+        askEmailTextView.setTextColor(isDarkModeEnabled ? Color.WHITE : getContext().getResources().getColor(R.color.km_away_message_text_color));
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmTypingView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/views/KmTypingView.java
@@ -22,6 +22,7 @@ import android.widget.TextView;
 
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.utils.KmThemeHelper;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -75,13 +76,19 @@ public class KmTypingView extends LinearLayout {
 
     private void setupBackground() {
         GradientDrawable bgShape;
-            bgShape = (GradientDrawable) parentLayout.getBackground();
+        bgShape = (GradientDrawable) parentLayout.getBackground();
+        AlCustomizationSettings alCustomizationSettings = new AlCustomizationSettings();
 
         if (bgShape != null) {
-            String bgColor = new AlCustomizationSettings().getReceivedMessageBackgroundColor();
+            KmThemeHelper themeHelper = KmThemeHelper.getInstance(getContext(), alCustomizationSettings);
+            String bgColor = themeHelper.isDarkModeEnabledForSDK() ? new AlCustomizationSettings().getReceivedMessageBackgroundColor().get(1) : new AlCustomizationSettings().getReceivedMessageBackgroundColor().get(0);
             bgShape.setColor(Color.parseColor(bgColor));
             bgShape.setStroke(3, Color.parseColor(bgColor));
-
+            if (themeHelper.isDarkModeEnabledForSDK() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                firstDot.getBackground().setTint(Color.WHITE);
+                secondDot.getBackground().setTint(Color.WHITE);
+                thirdDot.getBackground().setTint(Color.WHITE);
+            }
         }
     }
 

--- a/kommunicateui/src/main/res/drawable/icon_attchment_file.xml
+++ b/kommunicateui/src/main/res/drawable/icon_attchment_file.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#7A7878" android:pathData="M16,6V17.5C16,19.71 14.21,21.5 12,21.5C9.79,21.5 8,19.71 8,17.5V5C8,3.62 9.12,2.5 10.5,2.5C11.88,2.5 13,3.62 13,5V15.5C13,16.05 12.55,16.5 12,16.5C11.45,16.5 11,16.05 11,15.5V6H9.5V15.5C9.5,16.88 10.62,18 12,18C13.38,18 14.5,16.88 14.5,15.5V5C14.5,2.79 12.71,1 10.5,1C8.29,1 6.5,2.79 6.5,5V17.5C6.5,20.54 8.96,23 12,23C15.04,23 17.5,20.54 17.5,17.5V6H16Z"/>
-</vector>

--- a/kommunicateui/src/main/res/drawable/icon_camera.xml
+++ b/kommunicateui/src/main/res/drawable/icon_camera.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#7A7878" android:pathData="M20,5H16.83L15,3H9L7.17,5H4C2.9,5 2,5.9 2,7V19C2,20.1 2.9,21 4,21H20C21.1,21 22,20.1 22,19V7C22,5.9 21.1,5 20,5ZM20,19H4V7H8.05L9.88,5H14.12L15.95,7H20V19ZM12,8C9.24,8 7,10.24 7,13C7,15.76 9.24,18 12,18C14.76,18 17,15.76 17,13C17,10.24 14.76,8 12,8ZM12,16C10.35,16 9,14.65 9,13C9,11.35 10.35,10 12,10C13.65,10 15,11.35 15,13C15,14.65 13.65,16 12,16Z"/>
-</vector>

--- a/kommunicateui/src/main/res/drawable/icon_gallery.xml
+++ b/kommunicateui/src/main/res/drawable/icon_gallery.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#7A7878" android:pathData="M19,5V19H5V5H19ZM19,3H5C3.9,3 3,3.9 3,5V19C3,20.1 3.9,21 5,21H19C20.1,21 21,20.1 21,19V5C21,3.9 20.1,3 19,3ZM14.14,11.86L11.14,15.73L9,13.14L6,17H18L14.14,11.86Z"/>
-</vector>

--- a/kommunicateui/src/main/res/drawable/icon_location.xml
+++ b/kommunicateui/src/main/res/drawable/icon_location.xml
@@ -1,6 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#7A7878" android:pathData="M12,2C8.13,2 5,5.13 5,9C5,14.25 12,22 12,22C12,22 19,14.25 19,9C19,5.13 15.87,2 12,2ZM7,9C7,6.24 9.24,4 12,4C14.76,4 17,6.24 17,9C17,11.88 14.12,16.19 12,18.88C9.92,16.21 7,11.85 7,9Z"/>
-    <path android:fillColor="#7A7878" android:pathData="M12,11.5C13.381,11.5 14.5,10.381 14.5,9C14.5,7.619 13.381,6.5 12,6.5C10.619,6.5 9.5,7.619 9.5,9C9.5,10.381 10.619,11.5 12,11.5Z"/>
-</vector>

--- a/kommunicateui/src/main/res/drawable/icon_video_camera.xml
+++ b/kommunicateui/src/main/res/drawable/icon_video_camera.xml
@@ -1,5 +1,0 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#7A7878" android:pathData="M15,8V16H5V8H15ZM16,6H4C3.45,6 3,6.45 3,7V17C3,17.55 3.45,18 4,18H16C16.55,18 17,17.55 17,17V13.5L21,17.5V6.5L17,10.5V7C17,6.45 16.55,6 16,6Z"/>
-</vector>

--- a/kommunicateui/src/main/res/layout/activity_km_location.xml
+++ b/kommunicateui/src/main/res/layout/activity_km_location.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/km_location_linear_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/location_activity_background"
@@ -48,6 +49,7 @@
             android:src="@drawable/km_ic_my_location_white_18dp" />
 
         <TextView
+            android:id="@+id/km_send_location_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"

--- a/kommunicateui/src/main/res/layout/km_activity_payment.xml
+++ b/kommunicateui/src/main/res/layout/km_activity_payment.xml
@@ -1,22 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context="com.applozic.mobicomkit.uiwidgets.conversation.richmessaging.webview.KmWebViewActivity">
-
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/my_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/applozic_dark_black_color"
-        android:elevation="4dp"
-        android:theme="@style/Applozic_FullScreen_Theme"
-        app:popupTheme="@style/Applozic_PopUpTheme"
-        app:subtitleTextAppearance="@style/ToolbarSubtitle"
-        app:titleTextAppearance="@style/ToolbarTitle" />
 
     <FrameLayout
         android:layout_width="match_parent"

--- a/kommunicateui/src/main/res/layout/km_new_channel_custom_message.xml
+++ b/kommunicateui/src/main/res/layout/km_new_channel_custom_message.xml
@@ -10,6 +10,7 @@
     android:paddingBottom="15dp">
 
     <View
+        android:id="@+id/km_transferred_to_left_bg"
         android:layout_width="wrap_content"
         android:layout_height="1dp"
         android:layout_marginStart="3dp"
@@ -20,6 +21,7 @@
         android:background="@color/black" />
 
     <TextView
+        android:id="@+id/km_transferred_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="3dp"
@@ -43,6 +45,7 @@
         android:textStyle="bold" />
 
     <View
+        android:id="@+id/km_transferred_to_right_bg"
         android:layout_width="wrap_content"
         android:layout_height="1dp"
         android:layout_marginStart="3dp"

--- a/kommunicateui/src/main/res/layout/km_rich_message_item.xml
+++ b/kommunicateui/src/main/res/layout/km_rich_message_item.xml
@@ -11,7 +11,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_margin="1.5dp">
 
         <ImageView
             android:id="@+id/productImage"

--- a/kommunicateui/src/main/res/layout/mobicom_image_full_screen.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_image_full_screen.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content"
         android:background="@color/applozic_dark_black_color"
         android:elevation="4dp"
+        android:paddingTop="10dp"
         android:theme="@style/Applozic_FullScreen_Theme"
         app:popupTheme="@style/Applozic_PopUpTheme"
         app:subtitleTextAppearance="@style/ToolbarSubtitle"

--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -25,6 +25,7 @@
     </FrameLayout>
 
     <LinearLayout
+        android:id="@+id/km_message_list_linear_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
@@ -346,7 +347,7 @@
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content">
 
-                <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                <LinearLayout
                     android:id="@+id/individual_message_send_layout"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
@@ -461,7 +462,7 @@
                                 android:maxLines="6"
                                 android:minLines="2"
                                 android:textAlignment="viewStart"
-                                android:textColorHint="#8f8b8b"
+                                android:textColorHint="@color/km_text_color_hint"
                                 android:textSize="14sp" />
 
                         </RelativeLayout>

--- a/kommunicateui/src/main/res/layout/mobicom_message_list.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_message_list.xml
@@ -472,13 +472,12 @@
                             android:layout_width="match_parent"
                             android:layout_height="fill_parent"
                             android:layout_marginTop="3dp"
-                            android:layout_marginBottom="3dp"
                             android:orientation="horizontal">
 
                             <ImageButton
                                 android:id="@+id/emoji_btn"
                                 android:layout_width="20dp"
-                                android:layout_height="20dp"
+                                android:layout_height="18dp"
                                 android:layout_marginStart="16dp"
                                 android:layout_marginLeft="16dp"
                                 android:background="@color/applozic_transparent_color"
@@ -486,50 +485,40 @@
 
                             <ImageButton
                                 android:id="@+id/camera_btn"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:layout_marginStart="16dp"
-                                android:layout_marginLeft="16dp"
+                                android:layout_width="20dp"
+                                android:layout_height="16.3dp"
+                                android:layout_marginStart="29dp"
+                                android:layout_marginLeft="29dp"
                                 android:background="@color/applozic_transparent_color"
-                                android:src="@drawable/icon_camera" />
+                                android:src="@drawable/camera" />
 
-
-
-                            <ImageButton
-                                android:id="@+id/location_btn"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:layout_marginStart="16dp"
-                                android:layout_marginLeft="16dp"
-                                android:background="@color/applozic_transparent_color"
-                                android:src="@drawable/icon_location" />
-
-                            <ImageButton
-                                android:id="@+id/btn_video_capture"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:layout_marginStart="16dp"
-                                android:layout_marginLeft="16dp"
-                                android:background="@color/applozic_transparent_color"
-                                android:src="@drawable/icon_video_camera" />
                             <ImageButton
                                 android:id="@+id/idMultiSelectGalleryButton"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:layout_marginStart="16dp"
-                                android:layout_marginLeft="16dp"
+                                android:layout_width="20dp"
+                                android:layout_height="18dp"
+                                android:layout_marginStart="30dp"
+                                android:layout_marginLeft="30dp"
                                 android:background="@color/applozic_transparent_color"
-                                android:src="@drawable/icon_gallery"
+                                android:src="@drawable/km_multiselectgallery_icon"
                                 android:visibility="gone" />
 
                             <ImageButton
                                 android:id="@+id/file_as_attachment_btn"
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:layout_marginStart="16dp"
-                                android:layout_marginLeft="16dp"
+                                android:layout_width="20dp"
+                                android:layout_height="18.3dp"
+                                android:layout_marginStart="30dp"
+                                android:layout_marginLeft="30dp"
                                 android:background="@color/applozic_transparent_color"
-                                android:src="@drawable/icon_attchment_file" />
+                                android:src="@drawable/attachment" />
+
+                            <ImageButton
+                                android:id="@+id/location_btn"
+                                android:layout_width="20dp"
+                                android:layout_height="20dp"
+                                android:layout_marginStart="29dp"
+                                android:layout_marginLeft="29dp"
+                                android:background="@color/applozic_transparent_color"
+                                android:src="@drawable/locaiton" />
                         </LinearLayout>
                     </LinearLayout>
                 </LinearLayout>

--- a/kommunicateui/src/main/res/values/mobicom_colors.xml
+++ b/kommunicateui/src/main/res/values/mobicom_colors.xml
@@ -15,13 +15,18 @@
     <color name="sent_message_bg_color">#ff33B5E5</color>
     <!--<color name="received_message_bg_color">#ffffffff</color>-->
     <color name="received_message_bg_color">#ffffffff</color>
+    <color name="received_message_bg_color_night">#313131</color>
 
     <!-- <color name="sent_message_bg_color">#ff3EABF6</color>-->
 
     <color name="applozic_send_message_layout_background_color">#ffffffff</color>
     <color name="message_details_text_color">#838b83</color>
     <color name="conversation_list_all_background">#FFFFFFFF</color>
-    <color name="conversation_list_all_background_night">#1D1B20</color>
+    <color name="dark_mode_default">#1D1B20</color>
+    <color name="dark_mode_icon_color_default">#5F46F8</color>
+    <color name="chatbar_text_color">#919EAD</color>
+    <color name="km_text_color_hint">#8f8b8b</color>
+    <color name="km_away_message_text_color">#A9A4A4</color>
     <color name="createdAtTime_background_night">#B3B3B3</color>
     <color name="messageReceiver_background_night">#FAFAFA</color>
     <!-- <color name="conversation_list_all_background">#FFFAFAFA</color> -->


### PR DESCRIPTION
## Summary

- Dark mode support has been integrated into all screens of the Android SDK, along with customization options.
- Going forward, users can customize colors using the applozic-settings.json file by specifying `"customMessageBackgroundColor": ["#e6e5ec","#5c5aa7"]` for both light and dark modes respectively.
- This update maintains backward compatibility, ensuring that existing users who customize via 'applozic-settings.json' won't be impacted. However, their color customizations will be applied for night mode as well which is passed as a JSON string. For example, `"customMessageBackgroundColor": "#e6e5ec"` in this case this color will be used as dark mode color as well as the light mode color.