### PR TITLE
[CM-1950] Enable DOM storage 

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1317,6 +1317,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         WebView webView = emailLayout.findViewById(R.id.emailWebView);
         webViews.add(webView);
         webView.getSettings().setJavaScriptEnabled(alCustomizationSettings.isJavaScriptEnabled());
+        webView.getSettings().setDomStorageEnabled(true);
         webView.loadDataWithBaseURL(null, message.getMessage(), "text/html", "charset=UTF-8", null);
     }
 


### PR DESCRIPTION
## Summary

- The DOM API was disabled within the webview we utilized for loading HTML content. Consequently, iframes were unable to render, as this API is essential for storing data in the browser's local storage.