### PR TITLE
[CM-1966] Fix location issue in Android SDK

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobicomLocationActivity.java
@@ -281,8 +281,15 @@ public class MobicomLocationActivity extends AppCompatActivity implements OnMapR
     public void onLocationChanged(Location location) {
         try {
             LocationServices.FusedLocationApi.removeLocationUpdates(googleApiClient, this);
+            boolean reloadMap = false;
             if (location != null) {
+                if (mCurrentLocation == null){
+                    reloadMap = true;
+                }
                 mCurrentLocation = location;
+                if (reloadMap) {
+                    mapFragment.getMapAsync(this);
+                }
             }
         } catch (Exception e) {
         }


### PR DESCRIPTION
## Summary

When the user clicks on the location button but his location is not enabled, android provides a pop up from which the user can go to location settings and can enable location. In this case, when the user comes back to the app after enabling location he was not able to send location which is fixed now.