### PR TITLE
[CM-1904] Image full screen view improvement

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/FullScreenImageActivity.java
@@ -65,6 +65,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.mobicom_image_full_screen);
         Toolbar toolbar = (Toolbar) findViewById(R.id.my_toolbar);
         setSupportActionBar(toolbar);

--- a/kommunicateui/src/main/res/layout/mobicom_image_full_screen.xml
+++ b/kommunicateui/src/main/res/layout/mobicom_image_full_screen.xml
@@ -12,7 +12,6 @@
         android:layout_height="wrap_content"
         android:background="@color/applozic_dark_black_color"
         android:elevation="4dp"
-        android:paddingTop="10dp"
         android:theme="@style/Applozic_FullScreen_Theme"
         app:popupTheme="@style/Applozic_PopUpTheme"
         app:subtitleTextAppearance="@style/ToolbarSubtitle"


### PR DESCRIPTION
## Summary

- Fixed toolbar of full screen imageview colliding with the status bar on devices having notch in the screen.

## How was the code tested ?

- Tested with both type of devices i.e, devices having notch screen and devices which are not having notch screen.
- Tested with devices having screen size 5" inch to 6.67" inches.

## Screenshots

<img width="350" height="700" alt="Screenshot 2024-02-02 at 5 05 22 PM" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/38705368-3de3-46f4-893c-66f79fa190da">

<img width="350" height="700" alt="Screenshot 2024-02-02 at 5 05 22 PM" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/a0f72470-4e4f-4ace-bd68-6caae1f9c990">