### PR TITLE
[CM-1978] Added customization for image compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 The changelog for [Kommunicate-Android-Chat-SDK](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK). Also see the
 [releases](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/releases) on Github.
 
+## Unrelease
+1) Added customization for image compression
 ## Kommunicate Android SDK 2.9.4
 1) Added support for iframe in HTML type rich message
 2) Fixed location issues

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -179,6 +179,6 @@
   "disableFormPostSubmit": false,
   "chatBarTopLineViewColor": "",
   "isMultipleAttachmentSelectionEnabled": false,
-  "isImageCompressionEnabled": true,
+  "isImageCompressionEnabled": false,
   "minimumCompressionThresholdForImagesInMB": 5
 }

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -178,5 +178,7 @@
   "toolbarTitleCenterAligned": false,
   "disableFormPostSubmit": false,
   "chatBarTopLineViewColor": "",
-  "isMultipleAttachmentSelectionEnabled": false
+  "isMultipleAttachmentSelectionEnabled": false,
+  "isImageCompressionEnabled": true,
+  "minimumCompressionThresholdForImagesInMB": 5
 }

--- a/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
@@ -1013,4 +1013,41 @@ public class FileUtils {
         return "content".equalsIgnoreCase(uri.getScheme());
     }
 
+    public static Uri compressImage(Uri uri, Context context, String fileName) {
+        try {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inSampleSize = 2;
+            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, options);
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
+
+            File tempFile = File.createTempFile(fileName,null, context.getCacheDir());
+            tempFile.deleteOnExit();
+
+            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+            fileOutputStream.write(outputStream.toByteArray());
+            fileOutputStream.flush();
+            fileOutputStream.close();
+
+            return Uri.fromFile(tempFile);
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public static boolean isCompressionNeeded(Context context, Uri uri, long fileSize, boolean isImageCompressionEnabled, int minimumCompressionThresholdForImagesInMB) {
+        if (!isImageCompressionEnabled) {
+            return false;
+        }
+        String mimeType = FileUtils.getMimeTypeByContentUriOrOther(context,uri);
+        boolean isMemeTypeImage = !TextUtils.isEmpty(mimeType) && mimeType.contains("image/");
+        if (!isMemeTypeImage) {
+            return false;
+        }
+        long limitForCompression = (long) minimumCompressionThresholdForImagesInMB * 1024 * 1024;
+        return fileSize >= limitForCompression;
+    }
+
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -150,6 +150,8 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean disableFormPostSubmit = false;
     private String chatBarTopLineViewColor = "";
     private boolean isMultipleAttachmentSelectionEnabled = false;
+    private boolean isImageCompressionEnabled = false;
+    private int minimumCompressionThresholdForImagesInMB = 5;
 
     public String getStaticTopMessage() {
         return staticTopMessage;
@@ -779,6 +781,14 @@ public class AlCustomizationSettings extends JsonMarker {
 
     public boolean isMultipleAttachmentSelectionEnabled() {
         return isMultipleAttachmentSelectionEnabled;
+    }
+
+    public boolean isImageCompressionEnabled() {
+        return isImageCompressionEnabled;
+    }
+
+    public int getMinimumCompressionThresholdForImagesInMB() {
+        return minimumCompressionThresholdForImagesInMB;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -69,6 +69,7 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
 
             tempFile = File.createTempFile(fileName,null, context.getCacheDir());
+            tempFile.deleteOnExit();
 
             FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
             fileOutputStream.write(outputStream.toByteArray());
@@ -78,14 +79,6 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
             return Uri.fromFile(tempFile);
         } catch (Exception e){
             e.printStackTrace();
-        } finally {
-            if (tempFile != null) {
-                try {
-                    tempFile.delete();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
         }
         return null;
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -1,13 +1,19 @@
 package com.applozic.mobicomkit.uiwidgets.async;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
 
 import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * a async task that will write the given file with the given "uri" to the "file"
@@ -20,13 +26,15 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     Uri uri;
 
     PrePostUIMethods prePostUIMethods;
+    boolean isCompressionNeeded;
 
-    public FileTaskAsync(File file, Uri uri, Context context, PrePostUIMethods prePostUIMethods) {
+    public FileTaskAsync(File file, Uri uri, Context context, PrePostUIMethods prePostUIMethods, boolean isCompressionNeeded) {
         this.context = context;
         this.file = file;
         this.uri = uri;
         this.fileClientService = new FileClientService(context);
         this.prePostUIMethods = prePostUIMethods;
+        this.isCompressionNeeded = isCompressionNeeded;
     }
 
     @Override
@@ -37,6 +45,9 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
 
     @Override
     protected Boolean doInBackground(Void... voids) {
+        if (isCompressionNeeded) {
+            uri = compressImage(uri,context,file.getName());
+        }
         if (fileClientService != null) {
             fileClientService.writeFile(uri, file);
         }
@@ -47,5 +58,35 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     protected void onPostExecute(Boolean completed) {
         super.onPostExecute(completed);
         prePostUIMethods.postTaskUIMethod(completed, file);
+    }
+
+    private Uri compressImage(Uri uri, Context context, String fileName) {
+        File tempFile = null;
+        try {
+            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, null);
+
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
+
+            tempFile = File.createTempFile(fileName,null, context.getCacheDir());
+
+            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+            fileOutputStream.write(outputStream.toByteArray());
+            fileOutputStream.flush();
+            fileOutputStream.close();
+
+            return Uri.fromFile(tempFile);
+        } catch (Exception e){
+            e.printStackTrace();
+        } finally {
+            if (tempFile != null) {
+                try {
+                    tempFile.delete();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -62,7 +62,9 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
 
     private Uri compressImage(Uri uri, Context context, String fileName) {
         try {
-            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, null);
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inSampleSize = 2;
+            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, options);
 
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -8,6 +8,7 @@ import android.os.AsyncTask;
 
 import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
+import com.applozic.mobicommons.file.FileUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -46,7 +47,7 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     @Override
     protected Boolean doInBackground(Void... voids) {
         if (isCompressionNeeded) {
-            uri = compressImage(uri,context,file.getName());
+            uri = FileUtils.compressImage(uri,context, file.getName());
         }
         if (fileClientService != null) {
             fileClientService.writeFile(uri, file);
@@ -57,30 +58,6 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     @Override
     protected void onPostExecute(Boolean completed) {
         super.onPostExecute(completed);
-        prePostUIMethods.postTaskUIMethod(completed, file);
-    }
-
-    private Uri compressImage(Uri uri, Context context, String fileName) {
-        try {
-            BitmapFactory.Options options = new BitmapFactory.Options();
-            options.inSampleSize = 2;
-            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, options);
-
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
-
-            File tempFile = File.createTempFile(fileName,null, context.getCacheDir());
-            tempFile.deleteOnExit();
-
-            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-            fileOutputStream.write(outputStream.toByteArray());
-            fileOutputStream.flush();
-            fileOutputStream.close();
-
-            return Uri.fromFile(tempFile);
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-        return null;
+        prePostUIMethods.postTaskUIMethod(uri, completed, file);
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -61,14 +61,13 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
     }
 
     private Uri compressImage(Uri uri, Context context, String fileName) {
-        File tempFile = null;
         try {
             Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, null);
 
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
 
-            tempFile = File.createTempFile(fileName,null, context.getCacheDir());
+            File tempFile = File.createTempFile(fileName,null, context.getCacheDir());
             tempFile.deleteOnExit();
 
             FileOutputStream fileOutputStream = new FileOutputStream(tempFile);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -7,11 +7,14 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.provider.OpenableColumns;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
@@ -35,6 +38,7 @@ import com.applozic.mobicomkit.contact.AppContactService;
 import com.applozic.mobicomkit.contact.BaseContactService;
 import com.applozic.mobicomkit.uiwidgets.AlCustomizationSettings;
 import com.applozic.mobicomkit.uiwidgets.R;
+import com.applozic.mobicomkit.uiwidgets.async.FileTaskAsync;
 import com.applozic.mobicomkit.uiwidgets.async.KmChannelDeleteTask;
 import com.applozic.mobicomkit.uiwidgets.async.KmChannelLeaveMember;
 import com.applozic.mobicomkit.uiwidgets.conversation.activity.ConversationActivity;
@@ -44,8 +48,10 @@ import com.applozic.mobicomkit.uiwidgets.conversation.fragment.ConversationFragm
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MessageInfoFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MobiComQuickConversationFragment;
 import com.applozic.mobicomkit.uiwidgets.conversation.fragment.MultimediaOptionFragment;
+import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.views.KmToast;
 import com.applozic.mobicomkit.uiwidgets.uilistener.KmFragmentGetter;
+import com.applozic.mobicommons.ApplozicService;
 import com.applozic.mobicommons.commons.core.utils.LocationInfo;
 import com.applozic.mobicommons.commons.core.utils.Utils;
 import com.applozic.mobicommons.file.FileUtils;
@@ -203,14 +209,49 @@ public class ConversationUIService {
                     selectedFileUri = ((ConversationActivity) fragmentActivity).getCapturedImageUri();
                     file = ((ConversationActivity) fragmentActivity).getFileObject();
                 }
+                String mimeType = FileUtils.getMimeTypeByContentUriOrOther(getConversationFragment().getContext(), selectedFileUri);
                 MediaScannerConnection.scanFile(fragmentActivity,
                         new String[]{file.getAbsolutePath()}, null,
                         new MediaScannerConnection.OnScanCompletedListener() {
                             public void onScanCompleted(String path, Uri uri) {
                             }
                         });
-                getConversationFragment().loadFile(selectedFileUri, file);
-                Utils.printLog(fragmentActivity, TAG, "File uri: " + selectedFileUri);
+                Log.d("xcode photo : ",Thread.currentThread().getName());
+                long fileSize = 0;
+                try {
+                    Cursor returnCursor =
+                            getConversationFragment().getContext().getContentResolver().query(selectedFileUri, null, null, null, null);
+                    if (returnCursor != null) {
+                        int sizeIndex = returnCursor.getColumnIndex(OpenableColumns.SIZE);
+                        returnCursor.moveToFirst();
+                        fileSize = returnCursor.getLong(sizeIndex);
+                        returnCursor.close();
+                    }
+                } catch (Exception e){
+                    e.printStackTrace();
+                }
+                String jsonString = FileUtils.loadSettingsJsonFile(getConversationFragment().getContext());
+                AlCustomizationSettings alCustomizationSettings;
+                if (!TextUtils.isEmpty(jsonString)) {
+                    alCustomizationSettings = (AlCustomizationSettings) GsonUtils.getObjectFromJson(jsonString, AlCustomizationSettings.class);
+                } else {
+                    alCustomizationSettings = new AlCustomizationSettings();
+                }
+                if (alCustomizationSettings.isImageCompressionEnabled()) {
+                    new FileTaskAsync(file, selectedFileUri, getConversationFragment().getContext(), new PrePostUIMethods() {
+                        @Override
+                        public void preTaskUIMethod() {}
+
+                        @Override
+                        public void postTaskUIMethod(Uri uri, boolean completed, File file) {
+                            getConversationFragment().loadFile(uri, file, mimeType);
+                            Utils.printLog(fragmentActivity, TAG, "File uri: " + uri);
+                        }
+                    }, FileUtils.isCompressionNeeded(getConversationFragment().getContext(), selectedFileUri, fileSize, true, alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB())).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                } else {
+                    getConversationFragment().loadFile(selectedFileUri, file, null);
+                    Utils.printLog(fragmentActivity, TAG, "File uri: " + selectedFileUri);
+                }
             }
 
             if (requestCode == REQUEST_CODE_CONTACT_GROUP_SELECTION && resultCode == Activity.RESULT_OK) {
@@ -227,7 +268,7 @@ public class ConversationUIService {
                 }
 
                 if (selectedFilePath != null) {
-                    getConversationFragment().loadFile(selectedFilePath, file);
+                    getConversationFragment().loadFile(selectedFilePath, file, null);
                     getConversationFragment().sendMessage("", Message.ContentType.VIDEO_MSG.getValue());
                 }
             }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/ConversationUIService.java
@@ -237,7 +237,8 @@ public class ConversationUIService {
                 } else {
                     alCustomizationSettings = new AlCustomizationSettings();
                 }
-                if (alCustomizationSettings.isImageCompressionEnabled()) {
+                boolean isFileCompressionNeeded = FileUtils.isCompressionNeeded(getConversationFragment().getContext(), selectedFileUri, fileSize, true, alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB());
+                if (isFileCompressionNeeded) {
                     new FileTaskAsync(file, selectedFileUri, getConversationFragment().getContext(), new PrePostUIMethods() {
                         @Override
                         public void preTaskUIMethod() {}
@@ -247,7 +248,7 @@ public class ConversationUIService {
                             getConversationFragment().loadFile(uri, file, mimeType);
                             Utils.printLog(fragmentActivity, TAG, "File uri: " + uri);
                         }
-                    }, FileUtils.isCompressionNeeded(getConversationFragment().getContext(), selectedFileUri, fileSize, true, alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB())).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                    }, true).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                 } else {
                     getConversationFragment().loadFile(selectedFileUri, file, null);
                     Utils.printLog(fragmentActivity, TAG, "File uri: " + selectedFileUri);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/ConversationActivity.java
@@ -483,7 +483,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
             }
 
             @Override
-            public void postTaskUIMethod(boolean completed, File file) {
+            public void postTaskUIMethod(Uri uri, boolean completed, File file) {
                 //TODO: add the progress bar in the feedback fragment commit to here
                 //TODO: conversationUIService.getConversationFragment().hideProgressBar();
                 conversationUIService.sendAttachments(new ArrayList<>(Arrays.asList(Uri.parse(file.getAbsolutePath()))), "");

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/activity/MobiComAttachmentSelectorActivity.java
@@ -208,7 +208,7 @@ public class MobiComAttachmentSelectorActivity extends AppCompatActivity {
             }
 
             @Override
-            public void postTaskUIMethod(boolean completed, File file) {
+            public void postTaskUIMethod(Uri selectedFileUri, boolean completed, File file) {
                 if (progressDialog != null && progressDialog.isShowing()) {
                     progressDialog.dismiss();
                 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -2516,7 +2516,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
     }
 
-    public void loadFile(Uri uri, File file) {
+    public void loadFile(Uri uri, File file, String mimeType) {
         if (uri == null || file == null) {
             KmToast.error(ApplozicService.getContext(getContext()), ApplozicService.getContext(getContext()).getString(R.string.file_not_selected), Toast.LENGTH_LONG).show();
             return;
@@ -2529,7 +2529,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             KmToast.error(ApplozicService.getContext(getContext()), ApplozicService.getContext(getContext()).getString(R.string.info_file_attachment_error), Toast.LENGTH_LONG).show();
             return;
         }
-        String mimeType = ApplozicService.getContext(getContext()).getContentResolver().getType(uri);
+        if(TextUtils.isEmpty(mimeType)){
+            mimeType = ApplozicService.getContext(getContext()).getContentResolver().getType(uri);
+        }
         Cursor returnCursor =
                 ApplozicService.getContext(getContext()).getContentResolver().query(uri, null, null, null, null);
         if (returnCursor != null) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/KmAttachmentsController.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/KmAttachmentsController.java
@@ -193,25 +193,12 @@ public class KmAttachmentsController {
                     }
                 }
                 File mediaFile = FileClientService.getFilePath(fileName, context.getApplicationContext(), mimeType);
-                new FileTaskAsync(mediaFile, selectedFileUri, context, prePostUIMethods, isCompressionNeeded(context, selectedFileUri, fileSize, alCustomizationSettings)).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                new FileTaskAsync(mediaFile, selectedFileUri, context, prePostUIMethods, FileUtils.isCompressionNeeded(context, selectedFileUri, fileSize, alCustomizationSettings.isImageCompressionEnabled(), alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB())).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             } catch (Exception e) {
                 e.printStackTrace();
                 return EXCEPTION_OCCURED;
             }
         }
         return FILE_PROCESSING_DONE;
-    }
-
-    private boolean isCompressionNeeded(Context context, Uri uri, long fileSize, AlCustomizationSettings alCustomizationSettings) {
-        if (!alCustomizationSettings.isImageCompressionEnabled()) {
-            return false;
-        }
-        String mimeType = FileUtils.getMimeTypeByContentUriOrOther(context,uri);
-        boolean isMemeTypeImage = !TextUtils.isEmpty(mimeType) && mimeType.contains("image/");
-        if (!isMemeTypeImage) {
-            return false;
-        }
-        long limitForCompression = (long) alCustomizationSettings.getMinimumCompressionThresholdForImagesInMB() * 1024 * 1024;
-        return fileSize >= limitForCompression;
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/callbacks/PrePostUIMethods.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/callbacks/PrePostUIMethods.java
@@ -1,5 +1,7 @@
 package com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks;
 
+import android.net.Uri;
+
 import java.io.File;
 
 /**
@@ -13,5 +15,5 @@ import java.io.File;
 public interface PrePostUIMethods {
     void preTaskUIMethod();
 
-    void postTaskUIMethod(boolean completed, File file);
+    void postTaskUIMethod(Uri uri, boolean completed, File file);
 }


### PR DESCRIPTION
## Summary

Add these 2 fields inside `applozic-settings.json` to compress a image before sending

```
"isImageCompressionEnabled": true, // default value is false
"minimumCompressionThresholdForImagesInMB": 10 // default value is 5 MB
```

## Images downloaded from dashboard ->

### Uncompressed image (6.2 mb) ->

![0f20aaae-916a-46b9-85a4-441461cf7614_df7d298c8532fdf4e5c126d141c93cda0b252b1b_KM_BUCKET_AWS-ENCRYPTED-pexels-lisa-fotios-1540258](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/7c00dc78-3527-4a99-aac0-b56f27210491)

### Compressed image (964 kb) ->

![0f20aaae-916a-46b9-85a4-441461cf7614_b6e4cc348226f0e1b5cf4e6f7d71c5adf7d4e384_KM_BUCKET_AWS-ENCRYPTED-pexels-lisa-fotios-1540258](https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/139108613/ec3fdcfa-93c6-441e-b0ce-356295d2c113)