### PR TITLE
[CM-1452] - Attachment options visibility customization

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -182,5 +182,5 @@
   "isMultipleAttachmentSelectionEnabled": false,
   "isImageCompressionEnabled": false,
   "minimumCompressionThresholdForImagesInMB": 5,
-  "hideAttachmentOptionsBeforeHandover": false
+  "hideAttachmentOptionsWithBots": false
 }

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -181,5 +181,6 @@
   "chatBarTopLineViewColor": "",
   "isMultipleAttachmentSelectionEnabled": false,
   "isImageCompressionEnabled": false,
-  "minimumCompressionThresholdForImagesInMB": 5
+  "minimumCompressionThresholdForImagesInMB": 5,
+  "hideAttachmentOptionsBeforeHandover": false
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -153,7 +153,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean isImageCompressionEnabled = false;
     private int minimumCompressionThresholdForImagesInMB = 5;
 
-    private boolean hideAttachmentOptionsBeforeHandover = false;
+    private boolean hideAttachmentOptionsWithBots = false;
 
     public String getStaticTopMessage() {
         return staticTopMessage;
@@ -804,8 +804,8 @@ public class AlCustomizationSettings extends JsonMarker {
         return minimumCompressionThresholdForImagesInMB;
     }
 
-    public boolean getHideAttachmentOptionsBeforeHandover() {
-        return hideAttachmentOptionsBeforeHandover;
+    public boolean getHideAttachmentOptionsWithBots() {
+        return hideAttachmentOptionsWithBots;
     }
 
     @Override

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/AlCustomizationSettings.java
@@ -32,7 +32,7 @@ public class AlCustomizationSettings extends JsonMarker {
     private String receivedMessageTextColor = "#646262";
     private String messageEditTextTextColor = "#000000";
     private String messageEditTextBackgroundColor = "";
-    private String autoSuggestionButtonBackgroundColor= "";
+    private String autoSuggestionButtonBackgroundColor = "";
     private String autoSuggestionButtonTextColor = "";
     private String sentMessageLinkTextColor = "#FFFFFFFF";
     private String receivedMessageLinkTextColor = "#5fba7d";
@@ -153,6 +153,8 @@ public class AlCustomizationSettings extends JsonMarker {
     private boolean isImageCompressionEnabled = false;
     private int minimumCompressionThresholdForImagesInMB = 5;
 
+    private boolean hideAttachmentOptionsBeforeHandover = false;
+
     public String getStaticTopMessage() {
         return staticTopMessage;
     }
@@ -164,17 +166,19 @@ public class AlCustomizationSettings extends JsonMarker {
     public String getMenuIconOnConversationScreen() {
         return menuIconOnConversationScreen;
     }
+
     public boolean isCheckboxAsMultipleButton() {
         return checkboxAsMultipleButton;
     }
+
     public boolean isRateConversationMenuOption() {
         return rateConversationMenuOption;
     }
-        
+
     public boolean isRestartConversationButtonVisibility() {
         return restartConversationButtonVisibility;
     }
-    
+
     public boolean isJavaScriptEnabled() {
         return javaScriptEnabled;
     }
@@ -619,8 +623,14 @@ public class AlCustomizationSettings extends JsonMarker {
     public String getMessageEditTextBackgroundColor() {
         return messageEditTextBackgroundColor;
     }
-    public String getAutoSuggestionButtonBackgroundColor() { return autoSuggestionButtonBackgroundColor; }
-    public String getAutoSuggestionButtonTextColor() { return autoSuggestionButtonTextColor; }
+
+    public String getAutoSuggestionButtonBackgroundColor() {
+        return autoSuggestionButtonBackgroundColor;
+    }
+
+    public String getAutoSuggestionButtonTextColor() {
+        return autoSuggestionButtonTextColor;
+    }
 
     public boolean isShowStartNewConversation() {
         return showStartNewConversation;
@@ -649,9 +659,11 @@ public class AlCustomizationSettings extends JsonMarker {
     public boolean isAgentApp() {
         return isAgentApp;
     }
-    public boolean isUseDeviceDefaultLanguage(){
+
+    public boolean isUseDeviceDefaultLanguage() {
         return useDeviceDefaultLanguage;
     }
+
     public boolean isShowTypingIndicatorWhileFetchingResponse() {
         return showTypingIndicatorWhileFetchingResponse;
     }
@@ -719,6 +731,7 @@ public class AlCustomizationSettings extends JsonMarker {
     public String getToolbarTitleColor() {
         return toolbarTitleColor;
     }
+
     public String getChatBarTopLineViewColor() {
         return chatBarTopLineViewColor;
     }
@@ -791,6 +804,10 @@ public class AlCustomizationSettings extends JsonMarker {
         return minimumCompressionThresholdForImagesInMB;
     }
 
+    public boolean getHideAttachmentOptionsBeforeHandover() {
+        return hideAttachmentOptionsBeforeHandover;
+    }
+
     @Override
     public String toString() {
         return "AlCustomizationSettings{" +
@@ -855,7 +872,7 @@ public class AlCustomizationSettings extends JsonMarker {
                 ", toolbarTitleColor=" + toolbarTitleColor +
                 ", toolbarSubtitleColor=" + toolbarSubtitleColor +
                 ", useDeviceDefaultLanguage=" + useDeviceDefaultLanguage +
-                ", showTypingIndicatorWhileFetchingResponse=" + showTypingIndicatorWhileFetchingResponse+
+                ", showTypingIndicatorWhileFetchingResponse=" + showTypingIndicatorWhileFetchingResponse +
                 '}';
     }
 }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -397,7 +397,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     protected Map<String, String> autoSuggestHeaders;
     protected String autoSuggestUrl;
     private Set<Message> botDelayMessageList;
-    private boolean isBotAssignee = true;
 
     public void setEmojiIconHandler(EmojiconHandler emojiIconHandler) {
         this.emojiIconHandler = emojiIconHandler;
@@ -2028,6 +2027,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             } else {
                 userNotAbleToChatLayout.setVisibility(View.GONE);
                 toggleMessageSendLayoutVisibility();
+                toggleAttachmentLayoutVisibility();
             }
         }
 
@@ -2578,7 +2578,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     public synchronized boolean updateMessageList(Message message, boolean update) {
-        updateBotTransferStatus(message);
         boolean toAdd = !messageList.contains(message);
         loadMore = true;
         if (update) {
@@ -4158,8 +4157,6 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     for (int i = 1; i <= nextMessageList.size() - 1; i++) {
                         long dayDifference = DateUtils.daysBetween(new Date(nextMessageList.get(i - 1).getCreatedAtTime()), new Date(nextMessageList.get(i).getCreatedAtTime()));
 
-                        updateBotTransferStatus(nextMessageList.get(i));
-
                         if (dayDifference >= 1) {
                             Message message = new Message();
                             message.setTempDateType(Short.valueOf("100"));
@@ -4460,18 +4457,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
     }
 
-    public void updateBotTransferStatus(Message message) {
-        if (isBotAssignee && !TextUtils.isEmpty(message.getMetadata().get("LOCALIZATION_VALUE"))) {
-            isBotAssignee = false;
-            updateAttachmentOptionsVisibility();
-        }
-    }
+    private void toggleAttachmentLayoutVisibility() {
+        if (alCustomizationSettings.getHideAttachmentOptionsWithBots() && attachmentIconLayout != null) {
+            Contact assigneeContact = appContactService.getContactById(channel.getConversationAssignee());
+            boolean isBotAssignee = User.RoleType.BOT.getValue().equals(assigneeContact.getRoleType());
 
-    private void updateAttachmentOptionsVisibility() {
-        if (!isBotAssignee && alCustomizationSettings.getHideAttachmentOptionsWithBots()) {
-            if (attachmentIconLayout != null) {
-                attachmentIconLayout.setVisibility(VISIBLE);
-            }
+            attachmentIconLayout.setVisibility(isBotAssignee ? GONE : VISIBLE);
         }
     }
 
@@ -4967,6 +4958,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             } else {
                 kmFeedbackView.setVisibility(View.GONE);
                 toggleMessageSendLayoutVisibility();
+                toggleAttachmentLayoutVisibility();
                 mainDivider.setVisibility(VISIBLE);
             }
         }
@@ -5416,6 +5408,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
 
         toggleMessageSendLayoutVisibility();
+        toggleAttachmentLayoutVisibility();
     }
 
     protected void toggleMessageSendLayoutVisibility() {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -202,8 +202,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.Timer;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -399,7 +397,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     protected Map<String, String> autoSuggestHeaders;
     protected String autoSuggestUrl;
     private Set<Message> botDelayMessageList;
-    private boolean isHandoverHappened = false;
+    private boolean isBotAssignee = true;
 
     public void setEmojiIconHandler(EmojiconHandler emojiIconHandler) {
         this.emojiIconHandler = emojiIconHandler;
@@ -1027,8 +1025,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
         emoticonsBtn.setVisibility(View.GONE);
 
-        boolean hideAttachmentOptionsBeforeHandover = alCustomizationSettings.getHideAttachmentOptionsBeforeHandover();
-        if (hideAttachmentOptionsBeforeHandover) {
+        boolean hideAttachmentOptionsWithBots = alCustomizationSettings.getHideAttachmentOptionsWithBots();
+        if (hideAttachmentOptionsWithBots) {
             attachmentIconLayout.setVisibility(GONE);
         }
 
@@ -2580,7 +2578,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     }
 
     public synchronized boolean updateMessageList(Message message, boolean update) {
-        updateHandoverStatus(message);
+        updateBotTransferStatus(message);
         boolean toAdd = !messageList.contains(message);
         loadMore = true;
         if (update) {
@@ -4160,7 +4158,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     for (int i = 1; i <= nextMessageList.size() - 1; i++) {
                         long dayDifference = DateUtils.daysBetween(new Date(nextMessageList.get(i - 1).getCreatedAtTime()), new Date(nextMessageList.get(i).getCreatedAtTime()));
 
-                        updateHandoverStatus(nextMessageList.get(i));
+                        updateBotTransferStatus(nextMessageList.get(i));
 
                         if (dayDifference >= 1) {
                             Message message = new Message();
@@ -4462,15 +4460,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
     }
 
-    public void updateHandoverStatus(Message message) {
-        if (!isHandoverHappened && !TextUtils.isEmpty(message.getMetadata().get("LOCALIZATION_VALUE"))) {
-            isHandoverHappened = true;
-            updateAttachmentOptionsVisibilityAfterHandover();
+    public void updateBotTransferStatus(Message message) {
+        if (isBotAssignee && !TextUtils.isEmpty(message.getMetadata().get("LOCALIZATION_VALUE"))) {
+            isBotAssignee = false;
+            updateAttachmentOptionsVisibility();
         }
     }
 
-    private void updateAttachmentOptionsVisibilityAfterHandover() {
-        if (isHandoverHappened && alCustomizationSettings.getHideAttachmentOptionsBeforeHandover()) {
+    private void updateAttachmentOptionsVisibility() {
+        if (!isBotAssignee && alCustomizationSettings.getHideAttachmentOptionsWithBots()) {
             if (attachmentIconLayout != null) {
                 attachmentIconLayout.setVisibility(VISIBLE);
             }


### PR DESCRIPTION
Exposed a customization in `applozic-settings.json` as `"hideAttachmentOptionsBeforeHandover": false` so that Attachments Options can be hidden when bot handles the chat. Once handoff happened (human assignee) Attachment Options should be visible.