### PR TITLE
DarkMode missing flag

### DIFF
--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -87,7 +87,7 @@
   "statusBarColor": "",
   "richMessageThemeColor": "",
   "restrictMessageTypingWithBots": false,
-  "useDarkMode": true,
+  "useDarkMode": false,
   "enableFaqOption": [
     true,
     false

--- a/app/src/main/assets/applozic-settings.json
+++ b/app/src/main/assets/applozic-settings.json
@@ -87,6 +87,7 @@
   "statusBarColor": "",
   "richMessageThemeColor": "",
   "restrictMessageTypingWithBots": false,
+  "useDarkMode": true,
   "enableFaqOption": [
     true,
     false


### PR DESCRIPTION
Added `useDarkMode` missing flag in `applozic-settings.json`.

true:
- SDK theme will toggle dark/light mode depending upon android theme

false (default):
- SDK theme will be in light mode irrespective of android theme