### PR TITLE
[CM-1185] - Delete For All option fix | Android Agent App

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/adapter/DetailedConversationAdapter.java
@@ -1260,7 +1260,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                                 menuItems[i].equals(context.getResources().getString(R.string.copy))) {
                             continue;
                         }
-                        if (menuItems[i].equals(context.getResources().getString(R.string.delete_for_all)) && (!message.isTypeOutbox() || !alCustomizationSettings.isAgentApp())) {
+                        if (menuItems[i].equals(context.getResources().getString(R.string.delete_for_all))) {
                             continue;
                         }
                         if (((channel != null && Channel.GroupType.OPEN.getValue().equals(channel.getType())) || message.isCall() || (message.hasAttachment() && !message.isAttachmentDownloaded()) || message.isVideoOrAudioCallMessage()) && (menuItems[i].equals(context.getResources().getString(R.string.forward)) ||

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4652,7 +4652,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 conversationService.sendMessage(messageToResend, messageIntentClass);
                 break;
             case 3:
-                if (alCustomizationSettings.isAgentApp()) {
+                if (alCustomizationSettings.isAgentApp() && message.isTypeOutbox()) {
                     deleteForAll(message, position);
                 } else {
                     String messageKeyString = message.getKeyString();

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -4641,21 +4641,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 }
                 break;
             case 1:
-                new MessageDeleteTask(getContext(), message.getKeyString(), true, new AlCallback() {
-                    @Override
-                    public void onSuccess(Object response) {
-                        if (getContext() != null) {
-                            deleteMessageFromDeviceList(message.getKeyString());
-                            recyclerDetailConversationAdapter.notifyItemRangeChanged(position - 1, messageList.size());
-                            KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
-                        }
-                    }
-
-                    @Override
-                    public void onError(Object error) {
-                        KmToast.error(ApplozicService.getContext(getContext()), "Error while deleting Message", Toast.LENGTH_SHORT).show();
-                    }
-                }).execute();
+                deleteForAll(message, position);
                 break;
             case 2:
                 messageDatabaseService.deleteMessageFromDb(message);
@@ -4666,10 +4652,14 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 conversationService.sendMessage(messageToResend, messageIntentClass);
                 break;
             case 3:
-                String messageKeyString = message.getKeyString();
-                new DeleteConversationAsyncTask(conversationService, message, contact).execute();
-                deleteMessageFromDeviceList(messageKeyString);
-                recyclerDetailConversationAdapter.notifyItemRangeChanged(position - 1, messageList.size());
+                if (alCustomizationSettings.isAgentApp()) {
+                    deleteForAll(message, position);
+                } else {
+                    String messageKeyString = message.getKeyString();
+                    new DeleteConversationAsyncTask(conversationService, message, contact).execute();
+                    deleteMessageFromDeviceList(messageKeyString);
+                    recyclerDetailConversationAdapter.notifyItemRangeChanged(position - 1, messageList.size());
+                }
                 break;
             case 4:
                 String messageJson = GsonUtils.getJsonFromObject(message, Message.class);
@@ -4820,6 +4810,24 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 Utils.printLog(getContext(), TAG, "Default switch case.");
         }
         return true;
+    }
+
+    private void deleteForAll(Message message, int position) {
+        new MessageDeleteTask(getContext(), message.getKeyString(), true, new AlCallback() {
+            @Override
+            public void onSuccess(Object response) {
+                if (getContext() != null) {
+                    deleteMessageFromDeviceList(message.getKeyString());
+                    recyclerDetailConversationAdapter.notifyItemRangeChanged(position - 1, messageList.size());
+                    KmToast.makeText(getContext(), "Message Deleted", Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onError(Object error) {
+                KmToast.error(ApplozicService.getContext(getContext()), "Error while deleting Message", Toast.LENGTH_SHORT).show();
+            }
+        }).execute();
     }
 
     public void processAttachmentIconsClick() {


### PR DESCRIPTION
Removed the `Delete for all` option from the agent app. Now we have only `Delete` option. However funtionality for this `Delete` option will work similar to:
- `Delete for all` if the `message.isTypeOutbox`  is `true`
- `Delete` if the `message.isTypeOutbox` is `false`

| Before | After |
|---|---|
| <img width="250" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/f0501a84-e375-43d6-8039-5abaf4ff76b7" /> | <img width="250" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/e143bc81-5ef8-40c6-b7ab-780ac4ba17eb" /> |
