### PR TITLE
[CM-2039] Remove image and video preview screen | Android SDK

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -2620,23 +2620,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
         attachmentLayout.setVisibility(VISIBLE);
         if (mimeType != null && (mimeType.startsWith("image") || mimeType.startsWith("video"))) {
-            if (mimeType.startsWith("image")) {
-                sendMessage();
-            } else {
-                attachedFile.setVisibility(View.GONE);
-                int reqWidth = mediaContainer.getWidth();
-                int reqHeight = mediaContainer.getHeight();
-                if (reqWidth == 0 || reqHeight == 0) {
-                    DisplayMetrics displaymetrics = new DisplayMetrics();
-                    if (getActivity() != null) {
-                        getActivity().getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
-                    }
-                    reqHeight = displaymetrics.heightPixels;
-                    reqWidth = displaymetrics.widthPixels;
-                }
-                previewThumbnail = FileUtils.getPreview(filePath, reqWidth, reqHeight, alCustomizationSettings.isImageCompression(), mimeType);
-                mediaContainer.setImageBitmap(previewThumbnail);
-            }
+            sendMessage();
         } else {
             attachedFile.setVisibility(VISIBLE);
             mediaContainer.setImageBitmap(null);

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComConversationFragment.java
@@ -2620,19 +2620,23 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
         attachmentLayout.setVisibility(VISIBLE);
         if (mimeType != null && (mimeType.startsWith("image") || mimeType.startsWith("video"))) {
-            attachedFile.setVisibility(View.GONE);
-            int reqWidth = mediaContainer.getWidth();
-            int reqHeight = mediaContainer.getHeight();
-            if (reqWidth == 0 || reqHeight == 0) {
-                DisplayMetrics displaymetrics = new DisplayMetrics();
-                if (getActivity() != null) {
-                    getActivity().getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
+            if (mimeType.startsWith("image")) {
+                sendMessage();
+            } else {
+                attachedFile.setVisibility(View.GONE);
+                int reqWidth = mediaContainer.getWidth();
+                int reqHeight = mediaContainer.getHeight();
+                if (reqWidth == 0 || reqHeight == 0) {
+                    DisplayMetrics displaymetrics = new DisplayMetrics();
+                    if (getActivity() != null) {
+                        getActivity().getWindowManager().getDefaultDisplay().getMetrics(displaymetrics);
+                    }
+                    reqHeight = displaymetrics.heightPixels;
+                    reqWidth = displaymetrics.widthPixels;
                 }
-                reqHeight = displaymetrics.heightPixels;
-                reqWidth = displaymetrics.widthPixels;
+                previewThumbnail = FileUtils.getPreview(filePath, reqWidth, reqHeight, alCustomizationSettings.isImageCompression(), mimeType);
+                mediaContainer.setImageBitmap(previewThumbnail);
             }
-            previewThumbnail = FileUtils.getPreview(filePath, reqWidth, reqHeight, alCustomizationSettings.isImageCompression(), mimeType);
-            mediaContainer.setImageBitmap(previewThumbnail);
         } else {
             attachedFile.setVisibility(VISIBLE);
             mediaContainer.setImageBitmap(null);


### PR DESCRIPTION
Removed Image + Video Preview screen in the capture image/video flow.

<table>
  <tr>
    <th colspan="3"><b> Before <b/></th>
  </tr>
  <tr>
    <td> <img width="120" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/8a217b8a-8257-4d44-958e-7c1aa2e44db8" /></td>
    <td> <img width="120" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/206bb2d0-05d5-483f-b5e7-87a6699c1915"/> </td>
    <td> <img width="120" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/bb62d643-7ff8-4084-8962-06a9984e33f3"/> </td>
  </tr>
</table>


<table>
  <tr>
    <th colspan="3"><b> After<b/></th>
  </tr>
  <tr>
    <td> <img width="120" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/8a217b8a-8257-4d44-958e-7c1aa2e44db8" /></td>
    <td> <img width="120" src="https://github.com/Kommunicate-io/Kommunicate-Android-Chat-SDK/assets/162960364/206bb2d0-05d5-483f-b5e7-87a6699c1915"/> </td>
  </tr>
</table>