### PR TITLE
[CM-2128] Improve Tap Gesture for attachments | Android SDK 

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -332,7 +332,7 @@ public class KmDocumentView {
 
         mainLayout.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                if (!isDownloadRequire()) { return; } // The following code will not be executed if the file is already downloaded.
+                if (!isDownloadRequire()) { return; } // The following code will not be executed if the file is not downloaded.
                 if (kmStoragePermissionListener.isPermissionGranted()) {
                     playAudio();
                 } else {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -330,6 +330,25 @@ public class KmDocumentView {
             }
         });
 
+        mainLayout.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                if (mimeType == null) { return; } // The following code will not be executed if the file is already downloaded.
+                if (kmStoragePermissionListener.isPermissionGranted()) {
+                    playAudio();
+                } else {
+                    kmStoragePermissionListener.checkPermission(new KmStoragePermission() {
+                        @Override
+                        public void onAction(boolean didGrant) {
+                            if (didGrant) {
+                                playAudio();
+                            }
+                        }
+                    });
+                }
+            }
+
+        });
+
         downloadedLayout.setOnClickListener(new View.OnClickListener() {
 
             public void onClick(View v) {

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/attachmentview/KmDocumentView.java
@@ -332,7 +332,7 @@ public class KmDocumentView {
 
         mainLayout.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                if (mimeType == null) { return; } // The following code will not be executed if the file is already downloaded.
+                if (!isDownloadRequire()) { return; } // The following code will not be executed if the file is already downloaded.
                 if (kmStoragePermissionListener.isPermissionGranted()) {
                     playAudio();
                 } else {


### PR DESCRIPTION
## Summary
- Added a tap gesture of mainLayout if the file is downloaded  
- The attachment bubble will work only when the file is downloaded. User needs to click on download button to download.

## Video

https://github.com/user-attachments/assets/327f9421-dded-4870-8d02-572f95e171f7

