### PR TITLE
CM-2127 PreChat Labels not visible when Configured from dashboard | Android SDK

### DIFF
--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -102,20 +102,24 @@ public class MainActivity extends AppCompatActivity {
                 progressDialog.setCancelable(false);
                 progressDialog.show();
                 Kommunicate.init(MainActivity.this, APP_ID);
-                Kommunicate.launchConversationWithPreChat(MainActivity.this, progressDialog, new KmCallback() {
-                    @Override
-                    public void onSuccess(Object message) {
-                        finish();
-                        progressDialog.dismiss();
-                    }
+                try {
+                    Kommunicate.launchConversationWithPreChat(MainActivity.this, progressDialog, new KmCallback() {
+                        @Override
+                        public void onSuccess(Object message) {
+                            finish();
+                            progressDialog.dismiss();
+                        }
 
-                    @Override
-                    public void onFailure(Object error) {
-                        progressDialog.dismiss();
-                        createLoginErrorDialog(null, (Exception) error);
+                        @Override
+                        public void onFailure(Object error) {
+                            progressDialog.dismiss();
+                            createLoginErrorDialog(null, (Exception) error);
 
-                    }
-                });
+                        }
+                    });
+                } catch (KmException e) {
+                    throw new RuntimeException(e);
+                }
             }
         });
     }

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -433,22 +433,28 @@ public class KmConversationHelper {
                 }
             }
             if (conversationBuilder.isWithPreChat()) {
-                Kommunicate.launchConversationWithPreChat(conversationBuilder.getContext(), null, new KmCallback() {
-                    @Override
-                    public void onSuccess(Object message) {
-                        if (callback != null) {
-                            callback.onSuccess(message);
+                try {
+                    Kommunicate.launchConversationWithPreChat(conversationBuilder.getContext(), null, new KmCallback() {
+                        @Override
+                        public void onSuccess(Object message) {
+                            if (callback != null) {
+                                callback.onSuccess(message);
+                            }
                         }
-                    }
 
-                    @Override
-                    public void onFailure(Object error) {
-                        if (callback != null) {
-                            callback.onFailure(error);
+                        @Override
+                        public void onFailure(Object error) {
+                            if (callback != null) {
+                                callback.onFailure(error);
+                            }
+                            Utils.printLog(conversationBuilder.getContext(), TAG, "Failed to launch conversation with pre-chat: " + error);
                         }
-                        Utils.printLog(conversationBuilder.getContext(), TAG, "Failed to launch conversation with pre-chat: " + error);
+                    });
+                } catch (KmException e) {
+                    if (callback != null) {
+                        callback.onFailure(e);
                     }
-                });
+                }
             } else {
                 KMUser kmUser;
 

--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -433,23 +433,22 @@ public class KmConversationHelper {
                 }
             }
             if (conversationBuilder.isWithPreChat()) {
-                try {
-                    Kommunicate.launchPrechatWithResult(conversationBuilder.getContext(), new KmPrechatCallback<KMUser>() {
-                        @Override
-                        public void onReceive(KMUser user, Context context, ResultReceiver finishActivityReceiver) {
-                            Kommunicate.login(conversationBuilder.getContext(), user, getLoginHandler(conversationBuilder, getStartConversationHandler(conversationBuilder.isSkipConversationList(), launchConversation, conversationBuilder.getPreFilledMessage(), finishActivityReceiver, callback), callback));
+                Kommunicate.launchConversationWithPreChat(conversationBuilder.getContext(), null, new KmCallback() {
+                    @Override
+                    public void onSuccess(Object message) {
+                        if (callback != null) {
+                            callback.onSuccess(message);
                         }
-
-                        @Override
-                        public void onError(String error) {
-
-                        }
-                    });
-                } catch (KmException e) {
-                    if (callback != null) {
-                        callback.onFailure(e);
                     }
-                }
+
+                    @Override
+                    public void onFailure(Object error) {
+                        if (callback != null) {
+                            callback.onFailure(error);
+                        }
+                        Utils.printLog(conversationBuilder.getContext(), TAG, "Failed to launch conversation with pre-chat: " + error);
+                    }
+                });
             } else {
                 KMUser kmUser;
 

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -230,7 +230,11 @@ public class Kommunicate {
      * @param callback       the callback to update status
      */
 
-    public static void launchConversationWithPreChat(final Context context, final ProgressDialog progressDialog, final KmCallback callback) {
+    public static void launchConversationWithPreChat(final Context context, final ProgressDialog progressDialog, final KmCallback callback) throws KmException  {
+        if (!(context instanceof Activity)) {
+            throw new KmException("This method needs Activity context");
+        }
+
         final KMUser kmUser = getVisitor();
         if (isLoggedIn(context)) {
             String loggedInUserId = MobiComUserPreference.getInstance(context).getUserId();


### PR DESCRIPTION
### Summary

- Earlier the issue was that when the user tried to build conversation with preChat, it used to show default Pre Chat Screen with empty fields
- The function (launchConversationWithPreChat) was not in use and this function (launchConversationWithPreChat) was calling an important function (checkForLeadCollection).
- So I made use of this function in the (createOrLaunchConversation) function in KmConversationHelper.java, where it performs creation as well as the launch of conversation.
- After that, it is working fine, and whenever a user will try to do setwithPreChat, then they will get desired results as attached below

### Images before and after changes

<img src = 'https://github.com/user-attachments/assets/befe9e72-6d8f-42ae-9616-fd883c2e408a' height = 400/>
<img src = 'https://github.com/user-attachments/assets/c7c7bd5f-0fe4-47b2-ad69-7fdb6c31ee30' height = 400/>


