### PR TITLE
Removed Hardcoded Maps API Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.gradle
 /.idea
 /.kotlin
+*.hprof
 local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     alias libs.plugins.android.application
     alias libs.plugins.kotlin.android
+    alias libs.plugins.google.secrets
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,8 +62,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyAGVIsWxU7lkCuoodgI6FGXmDN5J11VJFk"/>
-<!--            android:value="AIzaSyDHQzh-cDfo-aY9_Q1fZFiZtaurg57eY7k" />-->
+            android:value="${GOOGLE_KEY}"/>
 
         <service
             android:name="kommunicate.io.sample.pushnotification.FcmListenerService"

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     alias libs.plugins.kotlin.android  apply false
     alias libs.plugins.jfrog  apply false
     alias libs.plugins.android.library apply false
+    alias libs.plugins.google.secrets apply false
 }
 
 /*artifactoryPublish.skip = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ playServicesLocation = "17.0.0"
 playServicesMaps = "17.0.0"
 silicompressor = "2.2.4"
 swiperefreshlayout = "1.1.0"
+googleSecret = "2.0.1"
 
 [libraries]
 cardview = { module = "androidx.cardview:cardview", version.ref = "cardview" }
@@ -46,3 +47,4 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
 jfrog = { id = "com.jfrog.artifactory", version.ref = "jfrogVersion" }
+google-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "googleSecret"}


### PR DESCRIPTION
In this PR I used the google-secret library for storing the api keys. In this we have to put api key in `local.properties` which is ingored by `.gitignore`. So, API key wont be present in our repo anymore. If we don't put the api key in `local.properties` then App build will fail by throwing this error. 

For the sdk user's they will not face any crash. They have to manage their api key on there own. 
```
Merge Errors Error: Attribute meta-data#com.google.android.geo.API_KEY@value at AndroidManifest.xml:65:13-42 requires a placeholder substitution but no value for <GOOGLE_KEY> is provided. Kommunicate-Android-Chat-SDK.app main manifest (this file), line 64
```