### PR TITLE
[CM-2206] Language Code update in ChatContext | Android SDK

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
+++ b/kommunicate/src/main/java/com/applozic/mobicomkit/Applozic.java
@@ -1,6 +1,6 @@
 package com.applozic.mobicomkit;
 
-import static io.kommunicate.utils.KmConstants.KM_USER_LANGUAGE_CODE;
+import static io.kommunicate.utils.KmConstants.KM_USER_LOCALE;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -74,7 +74,7 @@ public class Applozic {
         }
         AlPrefSettings.getInstance(context).setDeviceDefaultLanguageToBot(deviceLanguage);
         Map<String, String> localeMetadata = new HashMap<>();
-        localeMetadata.put(KM_USER_LANGUAGE_CODE,deviceLanguage);
+        localeMetadata.put(KM_USER_LOCALE,deviceLanguage);
         KmSettings.updateChatContext(context,localeMetadata);
     }
 


### PR DESCRIPTION
## Summary 
- Updated the key for language change from `kmUserLanguageCode` to `kmUserLocale`.  (Similar to iOS and Web)