### PR TITLE
Added Root Device Detection in SSL Pinning

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
+++ b/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
@@ -3,6 +3,7 @@ package io.kommunicate.network
 import android.annotation.SuppressLint
 import android.util.Base64
 import io.kommunicate.BuildConfig
+import io.kommunicate.utils.KmUtils
 import java.security.KeyManagementException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -18,6 +19,10 @@ object SSLPinningConfig {
     @JvmStatic
     @Synchronized
     fun createPinnedSSLSocketFactory(): SSLSocketFactory {
+        if(KmUtils.isDeviceRooted()) {
+            throw CertificateException("Unable to Establish Connection, Device is rooted.")
+        }
+
         val expectedPublicKeyHash = arrayOf(
             BuildConfig.apiKommunicateIo,
             BuildConfig.apiEuKommunicateIo,


### PR DESCRIPTION
In this I added a check of root detection in the SSL Pinning. If the device is rooted It will throw the exception and no API calls will happen. This helps us in avoiding the intercepting and changing the certificate. 
The new Root Device Detection logic can't be bypassed and It also checks for frida. 
Alternative approach for this is to write the SSL pinning logic in the NDK in CPP files to avoid is getting bypassed. 

<video src="https://github.com/user-attachments/assets/9e8a313c-b245-4a6f-9353-2f52b40005ae" />

