### PR TITLE
Fixed: Unable to create single threaded conversation programatically

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -817,8 +817,9 @@ public class KmConversationHelper {
         refreshAppSettings(conversationBuilder.getContext());
         sharedPreferences = conversationBuilder.getContext().getSharedPreferences(MobiComUserPreference.AL_USER_PREF_KEY, Context.MODE_PRIVATE);
         if (sharedPreferences != null) {
-            boolean isSingleThreaded = sharedPreferences.getBoolean(SINGLE_THREADED,false);
-            conversationBuilder.setSingleConversation(isSingleThreaded);
+            boolean isSingleThreadedFromServer = sharedPreferences.getBoolean(SINGLE_THREADED,false);
+            boolean isShowSingleThreaded = isSingleThreadedFromServer || conversationBuilder.isSingleConversation();
+            conversationBuilder.setSingleConversation(isShowSingleThreaded);
             final String clientChannelKey = !TextUtils.isEmpty(conversationBuilder.getClientConversationId()) ? conversationBuilder.getClientConversationId() : (conversationBuilder.isSingleConversation() ? getClientGroupId(conversationBuilder.getUserIds(), null, conversationBuilder.getBotIds(), conversationBuilder.getContext()) : null);
             if (!TextUtils.isEmpty(clientChannelKey) && clientChannelKey != null) {
                 conversationBuilder.setClientConversationId(clientChannelKey);


### PR DESCRIPTION
Added the check for single theaded conversation is set programatically.
states
1. enable on server and enable on app -> conversation is single threaded.
2. enable on server and disable on app -> conversation is single threaded.
3. disable on server and enable on app -> conversation is single threaded.
4. disable on server and disable on app -> conversation is  not single threaded. (Bheaviour similar from IOS)

