### PR TITLE
Changed Logic for Image compression

### DIFF
--- a/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
@@ -133,13 +133,6 @@ public class FileUtils {
         }
     };
 
-    public static boolean deleteFile(Uri uri) {
-        if (uri.getPath() == null) {
-            return false;
-        }
-        return new File(uri.getPath()).delete();
-    }
-
     private FileUtils() {
     } //private constructor to enforce Singleton pattern
 
@@ -161,6 +154,28 @@ public class FileUtils {
         } else {
             // No extension.
             return "";
+        }
+    }
+
+    public static boolean deleteFile(Uri uri) {
+        if (uri == null) {
+            Log.w(TAG, "Cannot delete file: Uri is null");
+            return false;
+        }
+        if (uri.getPath() == null) {
+            Log.w(TAG, "Cannot delete file: Uri path is null");
+            return false;
+        }
+        File file = new File(uri.getPath());
+        try {
+            boolean deleted = file.delete();
+            if (!deleted) {
+                Log.w(TAG, "Failed to delete file: " + uri.getPath());
+            }
+            return deleted;
+        } catch (SecurityException e) {
+            Log.e(TAG, "Security exception while deleting file: " + uri.getPath(), e);
+            return false;
         }
     }
 
@@ -1028,29 +1043,44 @@ public class FileUtils {
     }
 
     public static Uri compressImage(Uri uri, Context context, String fileName) {
+        Bitmap originalBitmap = null;
+        ByteArrayOutputStream outputStream = null;
+        FileOutputStream fileOutputStream = null;
         try {
             // Load and compress the bitmap
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inSampleSize = 2;
-            Bitmap originalBitmap = BitmapFactory.decodeStream(
+            originalBitmap = BitmapFactory.decodeStream(
                     context.getContentResolver().openInputStream(uri), null, options);
 
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
 
             // Write the compressed bitmap to a cache file
             File cacheFile = new File(context.getCacheDir(), fileName);
-            FileOutputStream fileOutputStream = new FileOutputStream(cacheFile);
+            fileOutputStream = new FileOutputStream(cacheFile);
             fileOutputStream.write(outputStream.toByteArray());
             fileOutputStream.flush();
-            fileOutputStream.close();
 
             // Return the URI
             return Uri.fromFile(cacheFile);
         } catch (Exception e) {
             e.printStackTrace();
+            return null;
+        } finally {
+           if (originalBitmap != null && !originalBitmap.isRecycled()) {
+              originalBitmap.recycle();
+           }
+            try {
+                if (outputStream != null) {
+                    outputStream.close();
+                }
+                if (fileOutputStream != null) {
+                    fileOutputStream.close();
+                }
+            } catch (IOException e) {
+                Log.e(TAG, "Error closing output stream", e);
+            }
         }
-        return null;
     }
 
     public static Uri compressVideo(Context context, Uri uri, File file) {

--- a/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
+++ b/kommunicate/src/main/java/com/applozic/mobicommons/file/FileUtils.java
@@ -133,6 +133,13 @@ public class FileUtils {
         }
     };
 
+    public static boolean deleteFile(Uri uri) {
+        if (uri.getPath() == null) {
+            return false;
+        }
+        return new File(uri.getPath()).delete();
+    }
+
     private FileUtils() {
     } //private constructor to enforce Singleton pattern
 
@@ -1022,22 +1029,24 @@ public class FileUtils {
 
     public static Uri compressImage(Uri uri, Context context, String fileName) {
         try {
+            // Load and compress the bitmap
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inSampleSize = 2;
-            Bitmap originalBitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(uri), null, options);
+            Bitmap originalBitmap = BitmapFactory.decodeStream(
+                    context.getContentResolver().openInputStream(uri), null, options);
 
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             originalBitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream);
 
-            File tempFile = File.createTempFile(fileName, null, context.getCacheDir());
-            tempFile.deleteOnExit();
-
-            FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+            // Write the compressed bitmap to a cache file
+            File cacheFile = new File(context.getCacheDir(), fileName);
+            FileOutputStream fileOutputStream = new FileOutputStream(cacheFile);
             fileOutputStream.write(outputStream.toByteArray());
             fileOutputStream.flush();
             fileOutputStream.close();
 
-            return Uri.fromFile(tempFile);
+            // Return the URI
+            return Uri.fromFile(cacheFile);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -66,6 +66,7 @@ public class FileTaskAsync extends AsyncTask<Void, Integer, Boolean> {
         }
         if (fileClientService != null) {
             fileClientService.writeFile(uri, file);
+            FileUtils.deleteFile(uri);
         }
         return true;
     }

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/async/FileTaskAsync.java
@@ -1,28 +1,15 @@
 package com.applozic.mobicomkit.uiwidgets.async;
 
-import static android.os.Environment.getExternalStoragePublicDirectory;
-
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Environment;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.applozic.mobicomkit.api.attachment.FileClientService;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.callbacks.PrePostUIMethods;
 import com.applozic.mobicommons.file.FileUtils;
-import com.iceteck.silicompressorr.SiliCompressor;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Locale;
 
 /**
  * a async task that will write the given file with the given "uri" to the "file"


### PR DESCRIPTION
1. Changed the logic for thumbnail creation: In that instead of creating the temp file compressed the image using bitmat compress and `ParcelFileDescriptor`.
2. Changed the logic for Image attachment : Instead of creation of the temp file using function `createTempFile` created new  File and the added the compressed image in that. And after the useage of compressed image delete that temp file cache dir.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to delete files using their URI.
	- Enhanced image compression process, now returning a cache file URI.
	- Streamlined thumbnail generation by eliminating temporary file creation.

- **Bug Fixes**
	- Improved error handling in thumbnail generation.

- **Refactor**
	- Updated file handling processes to enhance performance and concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->