### PR TITLE
Migrated AppSettingAsyncTask to AppSettingUseCase and Added Session Caching in APP Settings API call

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import io.kommunicate.async.KmAppSettingTask;
 import io.kommunicate.async.KmConversationCreateTask;
 import io.kommunicate.async.KmConversationInfoTask;
 import io.kommunicate.callbacks.KMLoginHandler;
@@ -46,6 +45,7 @@ import io.kommunicate.callbacks.KmPrechatCallback;
 import io.kommunicate.callbacks.KmStartConversationHandler;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.preference.KmDefaultSettingPreference;
+import io.kommunicate.usecase.AppSettingUseCase;
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmConstants;
@@ -890,7 +890,7 @@ public class KmConversationHelper {
         }
     }
     public static void refreshAppSettings(Context context) {
-        new KmAppSettingTask(context,MobiComKitClientService.getApplicationKey(context), new KmCallback() {
+        AppSettingUseCase.executeWithExecutor(context, MobiComKitClientService.getApplicationKey(context), new KmCallback() {
             @Override
             public void onSuccess(Object message) {
                 KmAppSettingModel kmAppSettings = (KmAppSettingModel) message;
@@ -902,7 +902,7 @@ public class KmConversationHelper {
             public void onFailure(Object error) {
                 Utils.printLog(context, TAG, "Failed to fetch AppSettings" + error);
             }
-        }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        });
     }
 
     public static void getConversationById(Context context, String conversationId, final KmCallback callback) {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -1036,8 +1036,10 @@ public class Kommunicate {
     }
 
     public static void isChatWidgetDisabled(final KmChatWidgetCallback callback) {
-        AppSettingUseCase.executeWithExecutor(ApplozicService.getAppContext(),
+        AppSettingUseCase.executeWithExecutor(
+                ApplozicService.getAppContext(),
                 MobiComKitClientService.getApplicationKey(ApplozicService.getAppContext()),
+                true,
                 new KmCallback() {
                     @Override
                     public void onSuccess(Object message) {

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -27,6 +27,8 @@ import com.applozic.mobicomkit.broadcast.BroadcastService;
 import com.applozic.mobicomkit.contact.database.ContactDatabase;
 import com.applozic.mobicomkit.exception.ApplozicException;
 import com.applozic.mobicomkit.feed.ChannelFeedApiResponse;
+
+import io.kommunicate.usecase.AppSettingUseCase;
 import io.kommunicate.usecase.KMUserLoginUseCase;
 import com.applozic.mobicommons.ALSpecificSettings;
 import com.applozic.mobicommons.ApplozicService;
@@ -51,7 +53,6 @@ import java.util.Map;
 import io.kommunicate.async.GetUserListAsyncTask;
 import io.kommunicate.async.KMFaqTask;
 import io.kommunicate.async.KMHelpDocsKeyTask;
-import io.kommunicate.async.KmAppSettingTask;
 import io.kommunicate.async.KmAwayMessageTask;
 import io.kommunicate.async.KmConversationCreateTask;
 import io.kommunicate.async.KmConversationInfoTask;
@@ -336,7 +337,7 @@ public class Kommunicate {
             @Override
             public void onFailure(Object error) {
                 if (callback != null) {
-                    callback.onFailure(new Exception("Failed to create user as visitor", (Throwable) error));
+                    callback.onFailure(error);
                 }
             }
         });
@@ -351,7 +352,7 @@ public class Kommunicate {
      * @param callback       callback to update the status
      */
     public static void checkForLeadCollection(final Context context, final ProgressDialog progressDialog, final KMUser kmUser, final KmCallback callback) {
-        new KmAppSettingTask(context, Applozic.getInstance(context).getApplicationKey(), new KmCallback() {
+        AppSettingUseCase.executeWithExecutor(context, Applozic.getInstance(context).getApplicationKey(), new KmCallback() {
             @Override
             public void onSuccess(Object message) {
                 final KmAppSettingModel appSettingModel = (KmAppSettingModel) message;
@@ -375,7 +376,7 @@ public class Kommunicate {
                 loginUserWithKmCallBack(context, kmUser, callback);
 
             }
-        }).execute();
+        });
     }
 
     /**
@@ -667,7 +668,7 @@ public class Kommunicate {
                 }
             };
 
-            new KmAppSettingTask(chatBuilder.getContext(), MobiComKitClientService.getApplicationKey(chatBuilder.getContext()), callback).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            AppSettingUseCase.executeWithExecutor(chatBuilder.getContext(), MobiComKitClientService.getApplicationKey(chatBuilder.getContext()), callback);
         } else {
             final String clientChannelKey = !TextUtils.isEmpty(chatBuilder.getClientConversationId()) ? chatBuilder.getClientConversationId() : (chatBuilder.isSingleChat() ? getClientGroupId(MobiComUserPreference.getInstance(chatBuilder.getContext()).getUserId(), chatBuilder.getAgentIds(), chatBuilder.getBotIds()) : null);
             if (!TextUtils.isEmpty(clientChannelKey)) {
@@ -933,7 +934,7 @@ public class Kommunicate {
         user.setUserId(generateUserId());
         user.setAuthenticationTypeId(User.AuthenticationType.APPLOZIC.getValue());
 
-        new KmAppSettingTask(
+        AppSettingUseCase.executeWithExecutor(
                 ApplozicService.getAppContext(),
                 MobiComKitClientService.getApplicationKey(ApplozicService.getAppContext()),
                 new KmCallback() {
@@ -955,7 +956,7 @@ public class Kommunicate {
                         callback.onFailure(error);
                     }
                 }
-        ).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        );
     }
 
     private static void updateMetadataForAnonymousUser(KMUser user){
@@ -1035,9 +1036,7 @@ public class Kommunicate {
     }
 
     public static void isChatWidgetDisabled(final KmChatWidgetCallback callback) {
-        final KmAppSettingModel appSettingModel = new KmAppSettingModel();
-
-        new KmAppSettingTask(ApplozicService.getAppContext(),
+        AppSettingUseCase.executeWithExecutor(ApplozicService.getAppContext(),
                 MobiComKitClientService.getApplicationKey(ApplozicService.getAppContext()),
                 new KmCallback() {
                     @Override
@@ -1058,7 +1057,6 @@ public class Kommunicate {
                             callback.onResult(false);
                         }
                     }
-                }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-
+                });
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/async/KmAppSettingTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmAppSettingTask.java
@@ -5,10 +5,13 @@ import android.os.AsyncTask;
 
 import java.lang.ref.WeakReference;
 
+import annotations.CleanUpRequired;
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.models.KmAppSettingModel;
 import io.kommunicate.utils.KmAppSettingPreferences;
 
+@Deprecated
+@CleanUpRequired(reason = "Migrated KmAppSettingTask to AppSettingUseCase")
 public class KmAppSettingTask extends AsyncTask<Void, Void, KmAppSettingModel> {
 
     private WeakReference<Context> context;

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
@@ -62,7 +62,8 @@ public class KmUserLoginTask extends UserLoginTask {
                 response = userClientService.loginKmUser(user);
             } else {
                 new UserClientService(context.get()).clearDataAndPreference();
-                KmAppSettingPreferences.fetchAppSetting(context.get(), Applozic.getInstance(context.get()).getApplicationKey());
+                // TODO: CLEANUP, Remove below approach.
+//                KmAppSettingPreferences.fetchAppSetting(context.get(), Applozic.getInstance(context.get()).getApplicationKey());
                 response = new RegisterUserClientService(context.get()).createAccount(user);
             }
         } catch (Exception e) {

--- a/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
+++ b/kommunicate/src/main/java/io/kommunicate/async/KmUserLoginTask.java
@@ -62,7 +62,7 @@ public class KmUserLoginTask extends UserLoginTask {
                 response = userClientService.loginKmUser(user);
             } else {
                 new UserClientService(context.get()).clearDataAndPreference();
-                // TODO: CLEANUP, Remove below approach.
+                // TODO: CLEANUP, App settings are now handled by AppSettingUseCase
 //                KmAppSettingPreferences.fetchAppSetting(context.get(), Applozic.getInstance(context.get()).getApplicationKey());
                 response = new RegisterUserClientService(context.get()).createAccount(user);
             }

--- a/kommunicate/src/main/java/io/kommunicate/models/SessionCache.kt
+++ b/kommunicate/src/main/java/io/kommunicate/models/SessionCache.kt
@@ -1,10 +1,11 @@
 package io.kommunicate.models
 
 import java.util.Calendar
+import java.util.concurrent.ConcurrentHashMap
 
 object SessionCache {
-    private val sessionData: MutableMap<String, Any> = mutableMapOf()
-    private val expireTimeData: MutableMap<String, Long> = mutableMapOf()
+    private val sessionData: MutableMap<String, Any> = ConcurrentHashMap()
+    private val expireTimeData: MutableMap<String, Long> = ConcurrentHashMap()
 
     /**
      * Add or update a value in the session cache.

--- a/kommunicate/src/main/java/io/kommunicate/models/SessionCache.kt
+++ b/kommunicate/src/main/java/io/kommunicate/models/SessionCache.kt
@@ -1,0 +1,62 @@
+package io.kommunicate.models
+
+import java.util.Calendar
+
+object SessionCache {
+    private val sessionData: MutableMap<String, Any> = mutableMapOf()
+    private val expireTimeData: MutableMap<String, Long> = mutableMapOf()
+
+    /**
+     * Add or update a value in the session cache.
+     * @param key The key for the value.
+     * @param value The value to cache.
+     */
+    fun <T> put(key: String, value: T, expireDuration: Long) {
+        sessionData[key] = value as Any
+        expireTimeData[key] = Calendar.getInstance().timeInMillis + expireDuration
+    }
+
+    /**
+     * Retrieve a value from the session cache if it doesn't expire.
+     * @param key The key for the value.
+     * @return The cached value, or null if not found.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> get(key: String): T? {
+        val data: T = sessionData[key] as? T ?: return null
+        val expireTimeEpoch = expireTimeData.getOrElse(key) { 0L }
+        val currTimeEpoch = Calendar.getInstance().timeInMillis
+        return if (expireTimeEpoch > currTimeEpoch) {
+            data
+        }else {
+            remove(key)
+            null
+        }
+    }
+
+    /**
+     * Check if a key exists in the session cache.
+     * @param key The key to check.
+     * @return True if the key exists, false otherwise.
+     */
+    fun containsKey(key: String): Boolean {
+        return sessionData.containsKey(key) && expireTimeData.containsKey(key)
+    }
+
+    /**
+     * Remove a value from the session cache.
+     * @param key The key to remove.
+     */
+    fun remove(key: String) {
+        sessionData.remove(key)
+        expireTimeData.remove(key)
+    }
+
+    /**
+     * Clear all session data.
+     */
+    fun clear() {
+        sessionData.clear()
+        expireTimeData.clear()
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/usecase/AppSettingUseCase.kt
+++ b/kommunicate/src/main/java/io/kommunicate/usecase/AppSettingUseCase.kt
@@ -70,7 +70,7 @@ class AppSettingUseCase(
             appId: String,
             callback: KmCallback? = null
         ): UseCaseExecutor<AppSettingUseCase, APIResult<KmAppSettingModel>> {
-            return executeWithExecutor(context, appId, callback, false)
+            return executeWithExecutor(context, appId, false, callback)
         }
 
         /**
@@ -90,8 +90,8 @@ class AppSettingUseCase(
         fun executeWithExecutor(
             context: Context,
             appId: String,
+            updateCache: Boolean = false,
             callback: KmCallback? = null,
-            updateCache: Boolean = false
         ): UseCaseExecutor<AppSettingUseCase, APIResult<KmAppSettingModel>> {
 
             val kmAppSettingUseCase = AppSettingUseCase(context, appId, updateCache)

--- a/kommunicate/src/main/java/io/kommunicate/usecase/AppSettingUseCase.kt
+++ b/kommunicate/src/main/java/io/kommunicate/usecase/AppSettingUseCase.kt
@@ -1,0 +1,117 @@
+package io.kommunicate.usecase
+
+import android.content.Context
+import io.kommunicate.callbacks.KmCallback
+import io.kommunicate.models.KmAppSettingModel
+import io.kommunicate.models.SessionCache
+import io.kommunicate.utils.APIResult
+import io.kommunicate.utils.KmAppSettingPreferences
+import io.kommunicate.utils.UseCaseExecutor
+import io.kommunicate.utils.onFailure
+import io.kommunicate.utils.onSuccess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.util.Calendar
+
+/**
+ * Use case for fetching the app settings for a given app ID in the Kommunicate SDK.
+ *
+ * @property context The Android context for accessing resources and services.
+ * @property appId The application ID for fetching the app settings.
+ */
+class AppSettingUseCase(
+    private val context: Context,
+    private val appId: String,
+    private val updateCache: Boolean = false
+) : UseCase<APIResult<KmAppSettingModel>> {
+
+    override suspend fun execute(): APIResult<KmAppSettingModel> = withContext(Dispatchers.IO) {
+        try {
+            val cachedSettings = SessionCache.get<KmAppSettingModel>(CACHE_KEY)
+            if (!updateCache && cachedSettings != null) {
+                return@withContext APIResult.success(cachedSettings)
+            }
+
+            KmAppSettingPreferences.clearInstance()
+            KmAppSettingPreferences.lastFetchTime = Calendar.getInstance().timeInMillis
+            val appSettingModel = KmAppSettingPreferences.fetchAppSetting(context, appId)
+                ?: return@withContext APIResult.failed("Unable to fetch app settings. Null value received")
+
+            if (appSettingModel.isSuccess) {
+                SessionCache.put(CACHE_KEY, appSettingModel, CACHE_REFRESH_TIME)
+                APIResult.success(appSettingModel)
+            } else {
+                APIResult.failed("Failed to fetch app settings. ${appSettingModel.code}")
+            }
+        } catch (e: Exception) {
+            APIResult.failedWithException(e)
+        }
+    }
+
+    companion object {
+        private const val CACHE_REFRESH_TIME: Long = 5 * 60 * 1000
+        private const val CACHE_KEY = "KmAppSettingModel"
+
+        /**
+         * Executes the use case with the given [UseCaseExecutor]. This helper function invokes the
+         * coroutine internally; don't invoke explicitly.
+         *
+         * This method provides a simpler way to execute the use case and handle success or failure
+         * using a provided [KmCallback].
+         *
+         * @param context The Android context for accessing resources and services.
+         * @param appId The application ID for fetching the app settings.
+         * @param callback The callback to handle success or failure responses.
+         * @return [UseCaseExecutor] for cancelling the coroutine.
+         */
+        @JvmStatic
+        fun executeWithExecutor(
+            context: Context,
+            appId: String,
+            callback: KmCallback? = null
+        ): UseCaseExecutor<AppSettingUseCase, APIResult<KmAppSettingModel>> {
+            return executeWithExecutor(context, appId, callback, false)
+        }
+
+        /**
+         * Executes the use case with the given [UseCaseExecutor]. This helper function invokes the
+         * coroutine internally; don't invoke explicitly.
+         *
+         * This method provides a simpler way to execute the use case and handle success or failure
+         * using a provided [KmCallback].
+         *
+         * @param context The Android context for accessing resources and services.
+         * @param appId The application ID for fetching the app settings.
+         * @param callback The callback to handle success or failure responses.
+         * @param updateCache If sent to true then it makes the API call and update the cache.
+         * @return [UseCaseExecutor] for cancelling the coroutine.
+         */
+        @JvmStatic
+        fun executeWithExecutor(
+            context: Context,
+            appId: String,
+            callback: KmCallback? = null,
+            updateCache: Boolean = false
+        ): UseCaseExecutor<AppSettingUseCase, APIResult<KmAppSettingModel>> {
+
+            val kmAppSettingUseCase = AppSettingUseCase(context, appId, updateCache)
+            val executor = UseCaseExecutor(
+                kmAppSettingUseCase,
+                { result: APIResult<KmAppSettingModel> ->
+                    result.onSuccess { appSettingModel: KmAppSettingModel? ->
+                        callback?.onSuccess(appSettingModel)
+                    }
+                    result.onFailure { errorMessage: Exception ->
+                        callback?.onFailure(errorMessage)
+                    }
+                },
+                { exception: java.lang.Exception? ->
+                    callback?.onFailure(exception)
+                },
+                Dispatchers.IO
+            )
+            executor.invoke()
+            return executor
+        }
+    }
+}

--- a/kommunicate/src/main/java/io/kommunicate/usecase/KMUserLoginUseCase.kt
+++ b/kommunicate/src/main/java/io/kommunicate/usecase/KMUserLoginUseCase.kt
@@ -42,7 +42,11 @@ class KMUserLoginUseCase(
                 userClientService.loginKmUser(user)
             } else {
                 userClientService.clearDataAndPreference()
-                KmAppSettingPreferences.fetchAppSetting(context, Applozic.getInstance(context).applicationKey)
+                AppSettingUseCase(
+                    context,
+                    Applozic.getInstance(context).applicationKey,
+                    false
+                ).execute()
                 registerUserClientService.createAccount(user)
             }
 

--- a/kommunicate/src/main/java/io/kommunicate/usecase/KMUserLoginUseCase.kt
+++ b/kommunicate/src/main/java/io/kommunicate/usecase/KMUserLoginUseCase.kt
@@ -43,9 +43,9 @@ class KMUserLoginUseCase(
             } else {
                 userClientService.clearDataAndPreference()
                 AppSettingUseCase(
-                    context,
-                    Applozic.getInstance(context).applicationKey,
-                    false
+                    context = context,
+                    appId = Applozic.getInstance(context).applicationKey,
+                    updateCache = true // Forces to update the cache
                 ).execute()
                 registerUserClientService.createAccount(user)
             }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmAppSettingPreferences.kt
@@ -2,16 +2,15 @@ package io.kommunicate.utils
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.os.AsyncTask
 import annotations.CleanUpRequired
 import com.applozic.mobicomkit.Applozic
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference
 import com.applozic.mobicommons.ApplozicService
 import com.applozic.mobicommons.json.GsonUtils
-import io.kommunicate.async.KmAppSettingTask
 import io.kommunicate.callbacks.KmCallback
 import io.kommunicate.models.KmAppSettingModel
 import io.kommunicate.services.KmService
+import io.kommunicate.usecase.AppSettingUseCase
 
 object KmAppSettingPreferences {
 
@@ -31,6 +30,7 @@ object KmAppSettingPreferences {
     private const val ROOT_DETECTION = "ROOT_DETECTION"
     private const val SSL_PINNING = "SSL_PINNING"
     private const val RATING_BASE = "RATING_BASE"
+    private const val LAST_FETCH_TIME = "LAST_FETCH_TIME"
 
     @JvmStatic
     @CleanUpRequired(
@@ -116,6 +116,13 @@ object KmAppSettingPreferences {
             preferences.edit().putInt(RATING_BASE, base).apply()
         }
 
+    @JvmStatic
+    var lastFetchTime: Long
+        get() = preferences.getLong(LAST_FETCH_TIME, 0L)
+        set(base) {
+            preferences.edit().putLong(LAST_FETCH_TIME, base).apply()
+        }
+
     @Suppress("UNCHECKED_CAST")
     var uploadOverrideHeader: HashMap<String, String>
         get() = GsonUtils.getObjectFromJson<Any>(
@@ -149,8 +156,8 @@ object KmAppSettingPreferences {
     @CleanUpRequired(
         reason = "Not used anywhere"
     )
-    fun fetchAppSettingAsync(context: Context?) {
-        KmAppSettingTask(
+    fun fetchAppSettingAsync(context: Context) {
+        AppSettingUseCase.executeWithExecutor(
             context,
             Applozic.getInstance(context).applicationKey,
             object : KmCallback {
@@ -159,7 +166,7 @@ object KmAppSettingPreferences {
 
                 override fun onFailure(error: Any) {
                 }
-            }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
+            })
     }
 
     @JvmStatic

--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/widgets/KmChatWidget.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/kommunicate/widgets/KmChatWidget.java
@@ -32,10 +32,10 @@ import com.applozic.mobicommons.commons.image.ImageUtils;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.graphics.drawable.DrawableCompat;
 import io.kommunicate.Kommunicate;
-import io.kommunicate.async.KmAppSettingTask;
 import io.kommunicate.callbacks.KMLoginHandler;
 import io.kommunicate.callbacks.KmCallback;
 import io.kommunicate.models.KmAppSettingModel;
+import io.kommunicate.usecase.AppSettingUseCase;
 import io.kommunicate.users.KMUser;
 
 /**
@@ -166,7 +166,7 @@ public class KmChatWidget {
 
     private void configureWidgetFromDashboard() {
         fetchingSettings = true;
-        new KmAppSettingTask(mContext, Applozic.getInstance(mContext).getApplicationKey(), new KmCallback() {
+        AppSettingUseCase.executeWithExecutor(mContext, Applozic.getInstance(mContext).getApplicationKey(), new KmCallback() {
             @Override
             public void onSuccess(Object message) {
                 fetchingSettings = false;
@@ -210,7 +210,7 @@ public class KmChatWidget {
                 fetchingSettings = false;
                 Utils.printLog(mContext, TAG, "Failed to fetch AppSetting");
             }
-        }).execute();
+        });
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Replaced `KmAppSettingTask` with a new `AppSettingUseCase` across multiple components
  - Introduced a new `SessionCache` for managing cached session data with expiration handling

- **New Features**
  - Added session caching mechanism with support for key-value storage and expiration tracking

- **Deprecation**
  - Marked `KmAppSettingTask` as deprecated, recommending migration to `AppSettingUseCase`

- **Performance**
  - Streamlined application settings retrieval process
  - Improved asynchronous task execution for app settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->