### PR TITLE
Added null check in CustomBotName

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -183,10 +183,13 @@ object KmUtils {
     @JvmStatic
     fun getCustomBotName(message: Message?, context: Context): String? {
         if (message != null) {
-            val metadata: Map<String, String> = GsonUtils.getObjectFromJson<Any>(
-                ApplozicClient.getInstance(context).messageMetaData,
-                MutableMap::class.java
-            ) as Map<String, String>
+            val metadata: Map<String, String> = ApplozicClient.getInstance(context).messageMetaData?.let {
+                GsonUtils.getObjectFromJson<Any>(
+                    it,
+                    MutableMap::class.java
+                ) as Map<String, String>
+            } ?: return null
+
             if (
                 metadata.containsKey(KmSettings.KM_CHAT_CONTEXT)
                 && metadata[Kommunicate.KM_CHAT_CONTEXT]!!.contains(BOT_CUSTOMIZATION)


### PR DESCRIPTION
Sentary issue: https://kommunicate-yi.sentry.io/issues/6202425549/?environment=production&project=4508040676835328&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in bot name retrieval process
  - Prevented potential null pointer exceptions when processing message metadata

- **Refactor**
  - Enhanced safety checks when extracting custom bot names from message metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->