### PR TITLE
[CM-2413] Real Time Assignment Status Update Flow Migrate | Android SDK

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
@@ -265,6 +265,8 @@ public class MobiComMessageService {
         boolean syncChannel = false;
         boolean syncChannelForMetadata = false;
         boolean syncGroupOfTwoForBlockList = false;
+        Set<String> syncChannelKeys = new HashSet<>();
+        Set<String> syncChannelForMetadataKeys = new HashSet<>();
 
         Utils.printLog(context, TAG, "Starting syncMessages for lastSyncTime: " + userpref.getLastSyncTime());
         SyncMessageFeed syncMessageFeed = messageClientService.getMessageFeed(userpref.getLastSyncTime(), false);
@@ -291,9 +293,9 @@ public class MobiComMessageService {
                 for (int i = messageList.size() - 1; i >= 0; i--) {
                     if (Message.ContentType.CHANNEL_CUSTOM_MESSAGE.getValue().equals(messageList.get(i).getContentType())) {
                         if (messageList.get(i).isGroupMetaDataUpdated()) {
-                            ChannelService.getInstance(context).syncInfoChannels(true, messageList.get(i).getClientGroupId());
+                            syncChannelForMetadataKeys.add(messageList.get(i).getClientGroupId());
                         } else if (channelLastSyncTime == 0L || messageList.get(i).getCreatedAtTime() > channelLastSyncTime) {
-                            ChannelService.getInstance(context).syncInfoChannels(false, messageList.get(i).getClientGroupId());
+                            syncChannelKeys.add(messageList.get(i).getClientGroupId());
                         }
                         //Todo: fix this, what if there are mulitple messages.
                         ChannelService.isUpdateTitle = true;
@@ -303,6 +305,14 @@ public class MobiComMessageService {
                     }
                     processMessage(messageList.get(i), messageList.get(i).getTo(), ((messageList.size() - 1) - i));
                     MobiComUserPreference.getInstance(context).setLastInboxSyncTime(messageList.get(i).getCreatedAtTime());
+                }
+
+                for (String channelkey : syncChannelKeys) {
+                    ChannelService.getInstance(context).syncInfoChannels(false, channelkey);
+                }
+
+                for (String channelkey : syncChannelForMetadataKeys) {
+                    ChannelService.getInstance(context).syncInfoChannels(true, channelkey);
                 }
 
                 if (syncChannel) {

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
@@ -291,9 +291,9 @@ public class MobiComMessageService {
                 for (int i = messageList.size() - 1; i >= 0; i--) {
                     if (Message.ContentType.CHANNEL_CUSTOM_MESSAGE.getValue().equals(messageList.get(i).getContentType())) {
                         if (messageList.get(i).isGroupMetaDataUpdated()) {
-                            syncChannelForMetadata = true;
+                            ChannelService.getInstance(context).syncInfoChannels(true, messageList.get(i).getClientGroupId());
                         } else if (channelLastSyncTime == 0L || messageList.get(i).getCreatedAtTime() > channelLastSyncTime) {
-                            syncChannel = true;
+                            ChannelService.getInstance(context).syncInfoChannels(false, messageList.get(i).getClientGroupId());
                         }
                         //Todo: fix this, what if there are mulitple messages.
                         ChannelService.isUpdateTitle = true;
@@ -459,9 +459,9 @@ public class MobiComMessageService {
         Long channelLastSyncTime = Long.parseLong(MobiComUserPreference.getInstance(context).getChannelSyncTime());
         if (Message.ContentType.CHANNEL_CUSTOM_MESSAGE.getValue().equals(message.getContentType())) {
             if (message.isGroupMetaDataUpdated()) {
-                ChannelService.getInstance(context).syncChannels(true);
+                ChannelService.getInstance(context).syncInfoChannels(true, message.getClientGroupId());
             } else if (channelLastSyncTime == 0L || message.getCreatedAtTime() > channelLastSyncTime) {
-                ChannelService.getInstance(context).syncChannels(false);
+                ChannelService.getInstance(context).syncInfoChannels(false, message.getClientGroupId());
             }
         }
         Channel channel = ChannelService.getInstance(context).getChannelInfo(message.getGroupId());

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/MobiComMessageService.java
@@ -307,6 +307,8 @@ public class MobiComMessageService {
                     MobiComUserPreference.getInstance(context).setLastInboxSyncTime(messageList.get(i).getCreatedAtTime());
                 }
 
+                syncChannelKeys.removeAll(syncChannelForMetadataKeys);
+                
                 for (String channelkey : syncChannelKeys) {
                     ChannelService.getInstance(context).syncInfoChannels(false, channelkey);
                 }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelClientService.java
@@ -26,6 +26,7 @@ import java.net.URLEncoder;
 import java.util.List;
 import java.util.Set;
 
+import io.kommunicate.devkit.sync.SyncChannelInfoFeed;
 import io.kommunicate.models.InQueueData;
 
 /**
@@ -35,6 +36,7 @@ public class ChannelClientService extends MobiComKitClientService {
     private static final String CHANNEL_INFO_URL = "/rest/ws/group/info";
     // private static final String CHANNEL_SYNC_URL = "/rest/ws/group/list";
     private static final String CHANNEL_SYNC_URL = "/rest/ws/group/v5/list";
+    private static final String CHANNEL_INFO_SYNC_URL = "/rest/ws/group/v2/info";
     private static final String CREATE_CHANNEL_URL = "/rest/ws/group/v2.1/create";
     private static final String IN_QUEUE_MESSAGE_URL = "/rest/ws/group/waiting/list?teamId=";
     private static final String CREATE_MULTIPLE_CHANNEL_URL = "/rest/ws/group/create/multiple";
@@ -92,6 +94,10 @@ public class ChannelClientService extends MobiComKitClientService {
 
     public String getChannelSyncUrl() {
         return getBaseUrl() + CHANNEL_SYNC_URL;
+    }
+
+    public String getSingleChannelInfoSyncUrl() {
+        return getBaseUrl() + CHANNEL_INFO_SYNC_URL;
     }
 
     public String getCreateChannelUrl() {
@@ -230,6 +236,20 @@ public class ChannelClientService extends MobiComKitClientService {
                     appli_json);
             Utils.printLog(context, TAG, "Channel sync call response: " + response);
             return (SyncChannelFeed) GsonUtils.getObjectFromJson(response, SyncChannelFeed.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public SyncChannelInfoFeed getSingelChannelFeed(String channelKey) {
+        String url = getSingleChannelInfoSyncUrl() + "?" +
+                GROUP_ID
+                + "=" + channelKey;
+        try {
+            String response = httpRequestUtils.getResponse(url, appli_json,
+                    appli_json);
+            Utils.printLog(context, TAG, "Channel Info sync call response for channelKey " + channelKey + " : " + response);
+            return (SyncChannelInfoFeed) GsonUtils.getObjectFromJson(response, SyncChannelInfoFeed.class);
         } catch (Exception e) {
             return null;
         }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelClientService.java
@@ -241,7 +241,11 @@ public class ChannelClientService extends MobiComKitClientService {
         }
     }
 
-    public SyncChannelInfoFeed getSingelChannelFeed(String channelKey) {
+    public SyncChannelInfoFeed getSingleChannelFeed(String channelKey) {
+        if (TextUtils.isEmpty(channelKey)) {
+            Utils.printLog(context, TAG, "Channel key is empty or null");
+            return null;
+        }
         String url = getSingleChannelInfoSyncUrl() + "?" +
                 GROUP_ID
                 + "=" + channelKey;
@@ -251,6 +255,7 @@ public class ChannelClientService extends MobiComKitClientService {
             Utils.printLog(context, TAG, "Channel Info sync call response for channelKey " + channelKey + " : " + response);
             return (SyncChannelInfoFeed) GsonUtils.getObjectFromJson(response, SyncChannelInfoFeed.class);
         } catch (Exception e) {
+            Utils.printLog(context, TAG, "Error getting channel info: " + e.getMessage());
             return null;
         }
     }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelService.java
@@ -32,6 +32,7 @@ import io.kommunicate.commons.AppContextService;
 import io.kommunicate.commons.people.channel.Channel;
 import io.kommunicate.commons.people.channel.ChannelUserMapper;
 import io.kommunicate.commons.task.CoreTask;
+import io.kommunicate.devkit.sync.SyncChannelInfoFeed;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -254,6 +255,27 @@ public class ChannelService {
             if (syncChannelFeed.getResponse() != null) {
                 processChannelList(syncChannelFeed.getResponse());
 
+                BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService
+                        .INTENT_ACTIONS.CHANNEL_SYNC.toString());
+            }
+            if(!TextUtils.isEmpty(syncChannelFeed.getGeneratedAt())) {
+                userpref.setChannelSyncTime(syncChannelFeed.getGeneratedAt());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public synchronized void syncInfoChannels(boolean isMetadataUpdate, String channelKey) {
+        try {
+            final MobiComUserPreference userpref = MobiComUserPreference.getInstance(context);
+            SyncChannelInfoFeed syncChannelFeed = channelClientService.getSingelChannelFeed(channelKey);
+            if (syncChannelFeed == null || !syncChannelFeed.isSuccess()) {
+                return;
+            }
+
+            if (syncChannelFeed.getResponse() != null) {
+                processChannelFeedForSync(syncChannelFeed.getResponse());
                 BroadcastService.sendUpdate(context, isMetadataUpdate, BroadcastService
                         .INTENT_ACTIONS.CHANNEL_SYNC.toString());
             }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/channel/service/ChannelService.java
@@ -269,7 +269,7 @@ public class ChannelService {
     public synchronized void syncInfoChannels(boolean isMetadataUpdate, String channelKey) {
         try {
             final MobiComUserPreference userpref = MobiComUserPreference.getInstance(context);
-            SyncChannelInfoFeed syncChannelFeed = channelClientService.getSingelChannelFeed(channelKey);
+            SyncChannelInfoFeed syncChannelFeed = channelClientService.getSingleChannelFeed(channelKey);
             if (syncChannelFeed == null || !syncChannelFeed.isSuccess()) {
                 return;
             }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/sync/SyncChannelInfoFeed.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/sync/SyncChannelInfoFeed.java
@@ -1,0 +1,50 @@
+package io.kommunicate.devkit.sync;
+
+import io.kommunicate.commons.json.JsonMarker;
+import io.kommunicate.devkit.feed.ChannelFeed;
+
+public class SyncChannelInfoFeed extends JsonMarker {
+
+    private static final String SUCCESS = "success";
+
+    private String status;
+    private String generatedAt;
+    private ChannelFeed response; // Changed from groupPxys to ChannelFeed
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public void setGeneratedAt(String generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+
+    public ChannelFeed getResponse() {
+        return response;
+    }
+
+    public void setResponse(ChannelFeed response) {
+        this.response = response;
+    }
+
+    public boolean isSuccess() {
+        return SUCCESS.equals(status);
+    }
+
+    @Override
+    public String toString() {
+        return "SyncChannelInfoFeed{" +
+                "status='" + status + '\'' +
+                ", generatedAt='" + generatedAt + '\'' +
+                ", response=" + response +
+                '}';
+    }
+}


### PR DESCRIPTION
## Summary
- Migrated the **v5 Sync** Api Call `chat.kommuniate.io/rest/ws/group/v5/list` to **v2 Info** with group ID param `chat.kommunicate.io/rest/ws/group/v2/info`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for fetching and synchronizing detailed information for individual channels, enabling more targeted and immediate channel updates.
- **Bug Fixes**
  - Improved reliability and accuracy of channel metadata synchronization by updating the sync mechanism to operate on a per-channel basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->