### PR TITLE
[CM-2441] Update UI Message to Indicate Subscription Requirement in Release Mode | Android SDK

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -59,7 +59,8 @@ object KmUtils {
                 && (MobiComUserPreference.getInstance(context).pricingPackage == PackageType.STARTUP.value
                 || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.START_MONTHLY.value
                 || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.START_YEARLY.value
-                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.TRIAL_ACCOUNT.value)
+                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.TRIAL_ACCOUNT.value
+                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.CHURNED_ACCOUNT.value)
         if (customToolbarLayout != null) {
             customToolbarLayout.visibility = View.GONE
         }
@@ -259,5 +260,6 @@ object KmUtils {
         START_MONTHLY(112),
         START_YEARLY(113),
         TRIAL_ACCOUNT(111),
+        CHURNED_ACCOUNT(100),
     }
 }

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -58,7 +58,8 @@ object KmUtils {
                 && !isDebuggable)
                 && (MobiComUserPreference.getInstance(context).pricingPackage == PackageType.STARTUP.value
                 || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.START_MONTHLY.value
-                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.START_YEARLY.value)
+                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.START_YEARLY.value
+                || MobiComUserPreference.getInstance(context).pricingPackage == PackageType.TRIAL_ACCOUNT.value)
         if (customToolbarLayout != null) {
             customToolbarLayout.visibility = View.GONE
         }
@@ -256,6 +257,7 @@ object KmUtils {
         EARLY_BIRD_MONTHLY(107),
         EARLY_BIRD_YEARLY(108),
         START_MONTHLY(112),
-        START_YEARLY(113)
+        START_YEARLY(113),
+        TRIAL_ACCOUNT(111),
     }
 }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
@@ -123,6 +123,7 @@ import java.util.Set;
 
 import io.kommunicate.async.KmSyncMessageTask;
 import io.kommunicate.usecase.AutoSuggestionsUseCase;
+import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
 import io.sentry.Hint;
@@ -362,6 +363,31 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         return false;
     }
 
+    private void showDisconnectionMessage() {
+        serviceDisconnectionLayout.setVisibility(View.VISIBLE);
+
+        // Hide all messages initially
+        findViewById(R.id.trialUserMessage).setVisibility(View.GONE);
+        findViewById(R.id.mobileNotSupportedInPlan).setVisibility(View.GONE);
+        findViewById(R.id.churnedAccountID).setVisibility(View.GONE);
+
+        String subscriptionDetails = KmAppSettingPreferences.getCurrentSubscriptionDetails();
+        if (subscriptionDetails == null) {
+            findViewById(R.id.mobileNotSupportedInPlan).setVisibility(View.VISIBLE);
+            return;
+        }
+
+        String lowerCaseSub = subscriptionDetails.toLowerCase();
+
+        if (lowerCaseSub.contains("trial")) {
+            findViewById(R.id.trialUserMessage).setVisibility(View.VISIBLE);
+        } else if (lowerCaseSub.contains("churn")) {
+            findViewById(R.id.churnedAccountID).setVisibility(View.VISIBLE);
+        } else {
+            findViewById(R.id.mobileNotSupportedInPlan).setVisibility(View.VISIBLE);
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -403,6 +429,9 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         childFragmentLayout = (RelativeLayout) findViewById(R.id.layout_child_activity);
         contactsGroupId = MobiComUserPreference.getInstance(this).getContactsGroupId();
         serviceDisconnectionLayout = findViewById(R.id.serviceDisconnectionLayout);
+        TextView mobileNotSupportedInPlanMessage = findViewById(R.id.mobileNotSupportedInPlan);
+        TextView trialUserMessage = findViewById(R.id.trialUserMessage);
+        TextView churnedAccountIDMessage = findViewById(R.id.churnedAccountID);
         deviceRootedLayout = findViewById(R.id.deviceRootedLayout);
         if (Utils.hasMarshmallow() && !customizationSettings.isGlobalStoragePermissionDisabled()) {
             applozicPermission.checkRuntimePermissionForStorage();
@@ -414,7 +443,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
         retry = 0;
 
         if (KmUtils.isServiceDisconnected(this, customizationSettings != null && customizationSettings.isAgentApp(), customToolbarLayout)) {
-            serviceDisconnectionLayout.setVisibility(View.VISIBLE);
+            showDisconnectionMessage();
         } else if(KmUtils.isDeviceRooted()) {
             deviceRootedLayout.setVisibility(View.VISIBLE);
         } else {
@@ -587,7 +616,7 @@ public class ConversationActivity extends AppCompatActivity implements MessageCo
 
         try {
             if (KmUtils.isServiceDisconnected(this, customizationSettings != null && customizationSettings.isAgentApp(), customToolbarLayout)) {
-                serviceDisconnectionLayout.setVisibility(View.VISIBLE);
+                showDisconnectionMessage();
             } else {
                 if (intent.getExtras() != null) {
                     if (intent.getExtras().getBoolean(SENT_FROM_NOTIFICATION)) {

--- a/kommunicateui/src/main/res/layout/km_service_disconnection_layout.xml
+++ b/kommunicateui/src/main/res/layout/km_service_disconnection_layout.xml
@@ -32,7 +32,9 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="7dp" />
 
+    <!-- Message 1 -->
     <TextView
+        android:id="@+id/trialUserMessage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
@@ -45,9 +47,55 @@
         android:letterSpacing="0.06"
         android:lineSpacingExtra="7sp"
         android:minLines="3"
-        android:text="@string/account_disconnection_message"
+        android:text="@string/trial_user_disconnection_message"
         android:gravity="center"
         android:textColor="@color/km_service_disconnection_text_color"
         android:textSize="14sp"
-        android:textStyle="normal" />
+        android:textStyle="normal"
+        android:visibility="gone" />
+
+    <!-- Message 2 -->
+    <TextView
+        android:id="@+id/mobileNotSupportedInPlan"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginLeft="39dp"
+        android:layout_marginStart="39dp"
+        android:layout_marginEnd="40dp"
+        android:layout_marginRight="40dp"
+        android:layout_marginTop="10dp"
+        android:fontFamily="sans-serif"
+        android:letterSpacing="0.06"
+        android:lineSpacingExtra="7sp"
+        android:minLines="3"
+        android:text="@string/mobile_not_supported_message"
+        android:gravity="center"
+        android:textColor="@color/km_service_disconnection_text_color"
+        android:textSize="14sp"
+        android:textStyle="normal"
+        android:visibility="gone" />
+
+    <!-- Message 3 -->
+    <TextView
+        android:id="@+id/churnedAccountID"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginLeft="39dp"
+        android:layout_marginStart="39dp"
+        android:layout_marginEnd="40dp"
+        android:layout_marginRight="40dp"
+        android:layout_marginTop="10dp"
+        android:fontFamily="sans-serif"
+        android:letterSpacing="0.06"
+        android:lineSpacingExtra="7sp"
+        android:minLines="3"
+        android:text="@string/churned_user_disconnection_message"
+        android:gravity="center"
+        android:textColor="@color/km_service_disconnection_text_color"
+        android:textSize="14sp"
+        android:textStyle="normal"
+        android:visibility="gone" />
+
 </LinearLayout>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="root_device_message">You can\'t use the Kommunicate SDK in this device as it\'s rooted.</string>
     <string name="trial_user_disconnection_message">Trial users cannot access this feature in release mode. \nPlease upgrade your plan to continue. \nFor further assistance, contact support at support@kommunicate.io.</string>
     <string name="mobile_not_supported_message">Your current plan does not support mobile access. \nPlease update your subscription to gain full access.</string>
-    <string name="churned_user_disconnection_message">The app provider needs to renew their subscription to enable access to messaging features.</string>
+    <string name="churned_user_disconnection_message">Your app provider needs to renew their subscription to enable access to messaging features.</string>
     <string name="powered_by_kommunicate_message">We are powered by Kommunicate.</string>
     <string name="share_using">Share using</string>
     <string name="warning">Warning</string>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="root_device_message">You can\'t use the Kommunicate SDK in this device as it\'s rooted.</string>
     <string name="trial_user_disconnection_message">Trial users cannot access this feature in release mode. \nPlease upgrade your plan to continue. \nFor further assistance, contact support at support@kommunicate.io.</string>
     <string name="mobile_not_supported_message">Your current plan does not support mobile access. \nPlease update your subscription to gain full access.</string>
-    <string name="churned_user_disconnection_message">Your subscription has expired. \nPlease renew it to regain access to messaging features.</string>
+    <string name="churned_user_disconnection_message">The app provider needs to renew their subscription to enable access to messaging features.</string>
     <string name="powered_by_kommunicate_message">We are powered by Kommunicate.</string>
     <string name="share_using">Share using</string>
     <string name="warning">Warning</string>

--- a/kommunicateui/src/main/res/values/strings.xml
+++ b/kommunicateui/src/main/res/values/strings.xml
@@ -43,7 +43,9 @@
     <string name="snap_text">Oh Snap!</string>
     <string name="root_text">Your device is rooted!</string>
     <string name="root_device_message">You can\'t use the Kommunicate SDK in this device as it\'s rooted.</string>
-    <string name="account_disconnection_message">We’re sorry but messaging is not \navailable at the moment,\nPlease contact support for more details.</string>
+    <string name="trial_user_disconnection_message">Trial users cannot access this feature in release mode. \nPlease upgrade your plan to continue. \nFor further assistance, contact support at support@kommunicate.io.</string>
+    <string name="mobile_not_supported_message">Your current plan does not support mobile access. \nPlease update your subscription to gain full access.</string>
+    <string name="churned_user_disconnection_message">Your subscription has expired. \nPlease renew it to regain access to messaging features.</string>
     <string name="powered_by_kommunicate_message">We are powered by Kommunicate.</string>
     <string name="share_using">Share using</string>
     <string name="warning">Warning</string>


### PR DESCRIPTION
## Summary
- Updated the flow for different cases for fallback to suspended screen:  

> 1. Churned Fallback Message.
> 2. Trial Account Fallback Message.
> 3. Plan Not Supporting Mobile. Lite Plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced tailored disconnection messages for trial users, users on unsupported plans, and users with expired subscriptions.
- **Improvements**
	- Enhanced the service disconnection screen to display more specific guidance based on user subscription status.
- **Bug Fixes**
	- Ensured consistent display of appropriate messages when service access is restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->