### PR TITLE
[CM-2448] Crash : Table already exist | Android SDK

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/database/DatabaseMigrationHelper.kt
+++ b/kommunicate/src/main/java/io/kommunicate/database/DatabaseMigrationHelper.kt
@@ -13,13 +13,10 @@ object DatabaseMigrationHelper {
 
     // Check if table exists in destination DB
     private fun tableExists(db: SQLiteDatabase, tableName: String): Boolean {
-        val cursor = db.rawQuery(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        return db.rawQuery(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
             arrayOf(tableName)
-        )
-        val exists = cursor.moveToFirst()
-        cursor.close()
-        return exists
+        ).use { cursor -> cursor.moveToFirst() }
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- Added a check to verify if table name exist then skip. 
- This will resist if there is any chance of creating a same table again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved database migration to prevent errors by skipping tables that already exist in the destination database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->