### PR TITLE
[CM-2475] Crash : Message.<init> Parcelisation | Android SDK

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
@@ -149,7 +149,9 @@ public class Message extends JsonMarker implements Parcelable {
         for (int i = 0; i < metadataSize; i++) {
             String key = in.readString();
             String value = in.readString();
-            metadata.put(key, value);
+            if (key != null) {
+                metadata.put(key, value);
+            }
         }
         status = (short) in.readInt();
         hidden = in.readByte() != 0;

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
@@ -144,7 +144,13 @@ public class Message extends JsonMarker implements Parcelable {
         topicId = in.readString();
         connected = in.readByte() != 0;
         contentType = (short) in.readInt();
-        metadata = in.readHashMap(String.class.getClassLoader());
+        int metadataSize = in.readInt();
+        metadata = new HashMap<>();
+        for (int i = 0; i < metadataSize; i++) {
+            String key = in.readString();
+            String value = in.readString();
+            metadata.put(key, value);
+        }
         status = (short) in.readInt();
         hidden = in.readByte() != 0;
         replyMessage = in.readInt();
@@ -896,7 +902,16 @@ public class Message extends JsonMarker implements Parcelable {
         dest.writeString(topicId);
         dest.writeByte((byte) (connected ? 1 : 0));
         dest.writeInt(contentType);
-        dest.writeMap(metadata);
+//        dest.writeMap(metadata);
+        if (metadata != null) {
+            dest.writeInt(metadata.size());
+            for (Map.Entry<String, String> entry : metadata.entrySet()) {
+                dest.writeString(entry.getKey());
+                dest.writeString(entry.getValue());
+            }
+        } else {
+            dest.writeInt(0);
+        }
         dest.writeInt(status);
         dest.writeByte((byte) (hidden ? 1 : 0));
         dest.writeInt(replyMessage);


### PR DESCRIPTION
## Summary:

* Replaced usage of `writeMap` and `readHashMap` for the `metadata` field.
* Implemented explicit serialization and deserialization of key-value pairs in `metadata`.
* Enhances compatibility across Android components when passing `Message` objects.
* Improves reliability and control over the parceling process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when transferring message metadata, ensuring more consistent handling of message details across different parts of the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->