### PR TITLE
[CM-2483] isRead Crash | Android SDK

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/Message.java
@@ -208,7 +208,7 @@ public class Message extends JsonMarker implements Parcelable {
     }
 
     public Boolean isRead() {
-        return read || isTypeOutbox() || getScheduledAt() != null;
+        return (read != null && read) || isTypeOutbox() || getScheduledAt() != null;
     }
 
     public void setRead(Boolean read) {


### PR DESCRIPTION
## Summary 
- Added the fix for isRead Crash. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when opening conversations containing messages without a read status.
  * Improved stability and consistency of message read indicators, including outbox and scheduled messages.
  * Users should experience fewer unexpected app closures and smoother message loading.
  * No changes to visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->