### PR TITLE
[CM-2485] BusinessHoursDetailUseCase: Null teamId crash | Android

### DIFF
--- a/kommunicateui/src/main/java/io/kommunicate/ui/usecase/BusinessHoursDetailUseCase.kt
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/usecase/BusinessHoursDetailUseCase.kt
@@ -81,10 +81,13 @@ class BusinessHoursDetailUseCase(
         @JvmStatic
         fun executeWithExecutor(
             context: Context,
-            teamId: String,
+            teamId: String?,
             callback: TaskListener<BusinessSettingsResponse>
-        ): UseCaseExecutor<BusinessHoursDetailUseCase, APIResult<BusinessSettingsResponse>> {
-
+        ): UseCaseExecutor<BusinessHoursDetailUseCase, APIResult<BusinessSettingsResponse>>? {
+            if (teamId == null) {
+                callback.onFailure(IllegalArgumentException("teamId cannot be null"))
+                return null
+            }
             val kmUserDetailUseCase = BusinessHoursDetailUseCase(context, teamId)
             val executor = UseCaseExecutor(
                 kmUserDetailUseCase,


### PR DESCRIPTION
## Summary
- Added a null check for teamId in executeWithExecutor.
- If teamId is null, trigger the callback with IllegalArgumentException.
- Return null to prevent further execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes when a team isn’t selected by validating input and failing gracefully with an error message.
* **Improvements**
  * Added input validation for team selection to ensure business hours details load only when valid data is provided.
  * More reliable execution flow with clearer failure handling, improving app stability and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->