### PR TITLE
Adding proactive check for groupId/ContactIds in message

### DIFF
--- a/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/com/applozic/mobicomkit/uiwidgets/conversation/fragment/MobiComQuickConversationFragment.java
@@ -443,6 +443,11 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
         if (message == null || messageDatabaseService == null) {
             return;
         }
+        //proactive checks for NPE error
+        if( TextUtils.isEmpty(message.getContactIds()) && message.getGroupId()==null){
+            Utils.printLog(getActivity(), "AL", "Not updating as message does not have ContactIds or groupId");
+            return;
+        }
         List<Message> lastMessage = new ArrayList<>();
         if (message.getGroupId() != null) {
             lastMessage = messageDatabaseService.getLatestMessageByChannelKey(message.getGroupId());


### PR DESCRIPTION
### Summary  

- Do not try to update UI if message  does not groupId or contactIds in payload.

### Exception 
```
Fatal Exception: java.lang.IllegalArgumentException: the bind value at index 1 is null
       at net.sqlcipher.database.SQLiteProgram.bindString(SQLiteProgram.java:258)
       at net.sqlcipher.database.SQLiteQuery.bindString(SQLiteQuery.java:192)
       at net.sqlcipher.database.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:66)
       at net.sqlcipher.database.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:2016)
       at net.sqlcipher.database.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1799)
       at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1751)
       at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1883)
       at com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService.getLatestMessage(MessageDatabaseService.java:877)
       at com.applozic.mobicomkit.uiwidgets.conversation.fragment.MobiComQuickConversationFragment.updateLastMessage(MobiComQuickConversationFragment.java:450)
       at com.applozic.mobicomkit.uiwidgets.conversation.ConversationUIService.updateLastMessage(ConversationUIService.java:526)
       at com.applozic.mobicomkit.uiwidgets.conversation.ConversationUIService.syncMessages(ConversationUIService.java:517)
       at com.applozic.mobicomkit.uiwidgets.conversation.MobiComKitBroadcastReceiver.onReceive(MobiComKitBroadcastReceiver.java:95)
       at androidx.localbroadcastmanager.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:313)
       at androidx.localbroadcastmanager.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:121)
       at android.os.Handler.dispatchMessage(Handler.java:112)
       at android.os.Looper.loopOnce(Looper.java:288)
       at android.os.Looper.loop(Looper.java:393)
       at android.app.ActivityThread.main(ActivityThread.java:9564)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)
 
```