### PR TITLE
TDH-3337: Markdown Support

### DIFF
--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     implementation libs.core.ktx
     implementation 'net.zetetic:sqlcipher-android:4.9.0@aar'
     implementation 'androidx.sqlite:sqlite-framework:2.2.0'
+    implementation "io.noties.markwon:core:4.6.2"
+    implementation "io.noties.markwon:html:4.6.2"
     api libs.org.eclipse.paho.client.mqttv3
     api libs.localbroadcastmanager
     api libs.appcompat

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/notification/NotificationService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/notification/NotificationService.java
@@ -9,14 +9,23 @@ import android.graphics.BitmapFactory;
 import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
+import android.text.TextUtils;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
-import android.text.Html;
-import android.text.TextUtils;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.List;
 
+import io.kommunicate.R;
+import io.kommunicate.commons.commons.core.utils.Utils;
+import io.kommunicate.commons.json.GsonUtils;
+import io.kommunicate.commons.people.channel.Channel;
+import io.kommunicate.commons.people.channel.ChannelUtils;
+import io.kommunicate.commons.people.contact.Contact;
 import io.kommunicate.devkit.KommunicateSettings;
 import io.kommunicate.devkit.SettingsSharedPreference;
 import io.kommunicate.devkit.api.MobiComKitConstants;
@@ -28,21 +37,11 @@ import io.kommunicate.devkit.api.conversation.database.MessageDatabaseService;
 import io.kommunicate.devkit.channel.service.ChannelService;
 import io.kommunicate.devkit.contact.AppContactService;
 import io.kommunicate.devkit.listners.ConstantsHandler;
-import io.kommunicate.commons.commons.core.utils.Utils;
-import io.kommunicate.commons.json.GsonUtils;
-import io.kommunicate.commons.people.channel.Channel;
-import io.kommunicate.commons.people.channel.ChannelUtils;
-import io.kommunicate.commons.people.contact.Contact;
-
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.List;
+import io.noties.markwon.Markwon;
+import io.noties.markwon.html.HtmlPlugin;
 
 import static io.kommunicate.devkit.api.notification.VideoCallNotificationHelper.CALL_AUDIO_ONLY;
 import static io.kommunicate.devkit.api.notification.VideoCallNotificationHelper.CALL_ID;
-
-import io.kommunicate.R;
 
 /**
  * Created with IntelliJ IDEA.
@@ -84,6 +83,7 @@ public class NotificationService {
     private static final String group_Id = "groupId";
     private static final String take_Order = "takeOrder";
     private static final String ACTIVITY_OPEN = "activity.open.on.notification";
+    private Markwon markwon;
 
     public NotificationService(int iconResourceID, Context context, int wearable_action_label, int wearable_action_title, int wearable_send_icon) {
         this.context = context;
@@ -98,6 +98,7 @@ public class NotificationService {
         this.notificationDisableThreshold = settingsSharedPreference.getNotificationMuteThreshold();
         this.notificationFilePath = KommunicateSettings.getInstance(context).getCustomNotificationSound();
         this.notificationIconColor = Utils.getMetaDataValueForResources(context,NOTIFICATION_SMALL_ICON_COLOR);
+        this.markwon = Markwon.builder(context).usePlugin(HtmlPlugin.create()).build();
 
         notificationChannels = new NotificationChannels(context, notificationFilePath);
 
@@ -561,12 +562,8 @@ public class NotificationService {
         notificationManager.notify(message.getGroupId() != null ? String.valueOf(message.getGroupId()).hashCode() : message.getContactIds().hashCode(), incomingCallNotification);
     }
 
-    public String getSpannedText(CharSequence message) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            return Html.fromHtml(message.toString(), Html.FROM_HTML_MODE_COMPACT).toString();
-        } else {
-            return Html.fromHtml(message.toString()).toString();
-        }
+    public CharSequence getSpannedText(CharSequence message) {
+        return markwon.toMarkdown(message.toString());
     }
 
     public String getText(int index) {

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    //api project(':kommunicate')
-    api 'io.kommunicate.sdk:kommunicate:2.14.5'
+    api project(':kommunicate')
+    //api 'io.kommunicate.sdk:kommunicate:2.14.5'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location
@@ -61,6 +61,8 @@ dependencies {
     implementation libs.constraintlayout
     implementation libs.core.ktx
     implementation libs.multidex
+    implementation "io.noties.markwon:core:4.6.2"
+    implementation "io.noties.markwon:html:4.6.2"
 }
 
 task sourcesJar(type: Jar) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/DetailedConversationAdapter.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/DetailedConversationAdapter.java
@@ -52,7 +52,36 @@ import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.vectordrawable.graphics.drawable.AnimatorInflaterCompat;
 
+import com.bumptech.glide.Glide;
+import com.google.gson.reflect.TypeToken;
+
+import org.json.JSONObject;
+
+import java.io.File;
+import java.lang.reflect.Type;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import de.hdodenhof.circleimageview.CircleImageView;
+import io.kommunicate.commons.commons.core.utils.DateUtils;
+import io.kommunicate.commons.commons.core.utils.LocationUtils;
+import io.kommunicate.commons.commons.core.utils.Utils;
+import io.kommunicate.commons.commons.image.ImageCache;
+import io.kommunicate.commons.commons.image.ImageLoader;
+import io.kommunicate.commons.commons.image.ImageUtils;
+import io.kommunicate.commons.emoticon.EmojiconHandler;
+import io.kommunicate.commons.emoticon.EmoticonUtils;
+import io.kommunicate.commons.file.FileUtils;
+import io.kommunicate.commons.json.GsonUtils;
+import io.kommunicate.commons.people.channel.Channel;
+import io.kommunicate.commons.people.contact.Contact;
 import io.kommunicate.devkit.KommunicateSettings;
 import io.kommunicate.devkit.api.MobiComKitConstants;
 import io.kommunicate.devkit.api.account.user.MobiComUserPreference;
@@ -72,7 +101,6 @@ import io.kommunicate.devkit.contact.MobiComVCFParser;
 import io.kommunicate.devkit.contact.VCFContactData;
 import io.kommunicate.ui.CustomizationSettings;
 import io.kommunicate.ui.KmFontManager;
-import io.kommunicate.ui.KommunicateSetting;
 import io.kommunicate.ui.R;
 import io.kommunicate.ui.attachmentview.KmDocumentView;
 import io.kommunicate.ui.conversation.ConversationUIService;
@@ -90,39 +118,10 @@ import io.kommunicate.ui.uilistener.ContextMenuClickListener;
 import io.kommunicate.ui.uilistener.KmStoragePermission;
 import io.kommunicate.ui.uilistener.KmStoragePermissionListener;
 import io.kommunicate.ui.utils.KmViewHelper;
-import io.kommunicate.commons.commons.core.utils.DateUtils;
-import io.kommunicate.commons.commons.core.utils.LocationUtils;
-import io.kommunicate.commons.commons.core.utils.Utils;
-import io.kommunicate.commons.commons.image.ImageCache;
-import io.kommunicate.commons.commons.image.ImageLoader;
-import io.kommunicate.commons.commons.image.ImageUtils;
-import io.kommunicate.commons.emoticon.EmojiconHandler;
-import io.kommunicate.commons.emoticon.EmoticonUtils;
-import io.kommunicate.commons.file.FileUtils;
-import io.kommunicate.commons.json.GsonUtils;
-import io.kommunicate.commons.people.channel.Channel;
-import io.kommunicate.commons.people.contact.Contact;
-import com.bumptech.glide.Glide;
-import com.google.gson.reflect.TypeToken;
-
-import org.json.JSONObject;
-
-import java.io.File;
-import java.lang.reflect.Type;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Objects;
-
-import androidx.vectordrawable.graphics.drawable.AnimatorInflaterCompat;
-
-import de.hdodenhof.circleimageview.CircleImageView;
 import io.kommunicate.utils.KmAppSettingPreferences;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
+import io.noties.markwon.Markwon;
 import io.sentry.Hint;
 import io.sentry.Sentry;
 
@@ -175,6 +174,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
     private List<WebView> webViews = new ArrayList<>();
     private boolean useInnerTimeStampDesign;
     private boolean isDarkModeEnabled = false;
+    private Markwon markwon;
     private static final String IMAGE = "image";
     private static final String VIDEO = "video";
     private static final String AUDIO = "audio";
@@ -260,6 +260,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         this.imageCache = ImageCache.getInstance(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         this.messageList = messageList;
         this.customizationSettings = customizationSettings;
+        this.markwon = Markwon.create(context);
         geoApiKey = KommunicateSettings.getInstance(context).getGeoApiKey();
         contactImageLoader = new ImageLoader(context, ImageUtils.getLargestScreenDimension((Activity) context)) {
             @Override
@@ -468,7 +469,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                         }
                     }
                 }
-            } else if (type == 6)  {
+            } else if (type == 6) {
                 MyViewHolder6 myViewholder6 = (MyViewHolder6) holder;
                 if (message.getMetadata() != null) {
                     String json = message.getMetadata().get(FEEDBACK);
@@ -483,10 +484,10 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                     if (KmAppSettingPreferences.getRatingBase() != 3) {
                         switch (ratingValue) {
                             case 1:
-                                myViewholder6.imageViewFeedbackRating.setImageDrawable(ContextCompat.getDrawable(context,  R.drawable.star));
+                                myViewholder6.imageViewFeedbackRating.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.star));
                                 break;
                             case 2:
-                                myViewholder6.imageViewFeedbackRating.setImageDrawable(ContextCompat.getDrawable(context,  R.drawable.ic_two_star_filled));
+                                myViewholder6.imageViewFeedbackRating.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_two_star_filled));
                                 break;
                             case 4:
                                 myViewholder6.imageViewFeedbackRating.setImageDrawable(ContextCompat.getDrawable(context, R.drawable.ic_four_star_filled));
@@ -572,8 +573,8 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         dialogMessage.setText(message);
 
         ImageButton btnClose = dialog.findViewById(R.id.dialog_close);
-        btnClose.setOnClickListener( view -> {
-                dialog.dismiss();
+        btnClose.setOnClickListener(view -> {
+            dialog.dismiss();
         });
 
         dialog.show();
@@ -1259,7 +1260,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                 } else {
                     myHolder.mapImageView.setVisibility(View.GONE);
                     myHolder.chatLocation.setVisibility(View.GONE);
-                    myHolder.messageTextView.setText(EmoticonUtils.getSmiledText(context, message.getMessage(), emojiconHandler));
+                    markwon.setMarkdown(myHolder.messageTextView, EmoticonUtils.getSmiledText(context, message.getMessage(), emojiconHandler).toString());
                 }
 
                 if (myHolder.messageTextLayout != null) {
@@ -1401,18 +1402,19 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
 
             if (showSourceURls(message, position)) {
                 String json = message.getMetadata().get(SOURCE_URL);
-                if(json == null) {
+                if (json == null) {
                     return;
                 }
                 myHolder.sourceText.setVisibility(View.VISIBLE);
                 myHolder.urlsLayout.setVisibility(View.VISIBLE);
                 myHolder.sourceUrlDivider.setVisibility(View.VISIBLE);
 
-                Type listType = new TypeToken<List<SourceUrl>>() {}.getType();
+                Type listType = new TypeToken<List<SourceUrl>>() {
+                }.getType();
                 List<SourceUrl> links = GsonUtils.getObjectFromJson(json, listType);
 
                 myHolder.urlsLayout.removeAllViews();
-                for(SourceUrl url : links) {
+                for (SourceUrl url : links) {
                     SpannableString content = new SpannableString(url.getTitle());
                     content.setSpan(new UnderlineSpan(), 0, content.length(), 0);
 
@@ -1420,7 +1422,7 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
                             .from(myHolder.urlsLayout.getContext())
                             .inflate(R.layout.km_link_view, null, false);
 
-                    TextView tv =  view.findViewById(R.id.src_urls_textview);
+                    TextView tv = view.findViewById(R.id.src_urls_textview);
                     tv.setText(content);
 
                     view.setOnClickListener((data) -> {
@@ -2135,4 +2137,3 @@ public class DetailedConversationAdapter extends RecyclerView.Adapter implements
         }
     }
 }
-

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/QuickConversationAdapter.java
@@ -5,13 +5,11 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
-
-import androidx.fragment.app.FragmentActivity;
-import androidx.recyclerview.widget.RecyclerView;
-
+import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
+import android.util.LruCache;
 import android.view.ContextMenu;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -25,6 +23,25 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.fragment.app.FragmentActivity;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import de.hdodenhof.circleimageview.CircleImageView;
+import io.kommunicate.commons.commons.core.utils.DateUtils;
+import io.kommunicate.commons.commons.image.ImageLoader;
+import io.kommunicate.commons.commons.image.ImageUtils;
+import io.kommunicate.commons.emoticon.EmojiconHandler;
+import io.kommunicate.commons.emoticon.EmoticonUtils;
+import io.kommunicate.commons.people.channel.Channel;
+import io.kommunicate.commons.people.channel.ChannelUtils;
+import io.kommunicate.commons.people.contact.Contact;
 import io.kommunicate.devkit.api.account.user.MobiComUserPreference;
 import io.kommunicate.devkit.api.conversation.Message;
 import io.kommunicate.devkit.api.conversation.database.MessageDatabaseService;
@@ -40,24 +57,8 @@ import io.kommunicate.ui.conversation.ConversationUIService;
 import io.kommunicate.ui.conversation.activity.MobiComKitActivityInterface;
 import io.kommunicate.ui.instruction.InstructionUtil;
 import io.kommunicate.ui.utils.KmViewHelper;
-import io.kommunicate.commons.commons.core.utils.DateUtils;
-import io.kommunicate.commons.commons.image.ImageLoader;
-import io.kommunicate.commons.commons.image.ImageUtils;
-import io.kommunicate.commons.emoticon.EmojiconHandler;
-import io.kommunicate.commons.emoticon.EmoticonUtils;
-import io.kommunicate.commons.people.channel.Channel;
-import io.kommunicate.commons.people.channel.ChannelUtils;
-import io.kommunicate.commons.people.contact.Contact;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
-import de.hdodenhof.circleimageview.CircleImageView;
 import io.kommunicate.utils.KmUtils;
+import io.noties.markwon.Markwon;
 
 /**
  * Created by adarsh on 4/7/15.
@@ -94,6 +95,8 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
     private int loggedInUserRoleType;
     private String loggedInUserId;
     private boolean isDarkMode;
+    private Markwon markwon;
+    private LruCache<String, Spannable> markdownCache;
 
     public void setAlCustomizationSettings(CustomizationSettings customizationSettings) {
         this.customizationSettings = customizationSettings;
@@ -109,6 +112,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         this.contactService = new AppContactService(context);
         this.messageDatabaseService = new MessageDatabaseService(context);
         this.messageList = messageList;
+        this.markwon = Markwon.create(context);
         conversationUIService = new ConversationUIService((FragmentActivity) context);
         loggedInUserRoleType = MobiComUserPreference.getInstance(context).getUserRoleType();
         loggedInUserId = MobiComUserPreference.getInstance(context).getUserId();
@@ -129,6 +133,14 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         channelImageLoader.addImageCache(((FragmentActivity) context).getSupportFragmentManager(), 0.1f);
         channelImageLoader.setImageFadeIn(false);
         highlightTextSpan = new TextAppearanceSpan(context, R.style.searchTextHiglight);
+        final int maxMemory = (int) (Runtime.getRuntime().maxMemory());
+        final int cacheSize = maxMemory / 8;
+        markdownCache = new LruCache<String, Spannable>(cacheSize) {
+            @Override
+            protected int sizeOf(String key, Spannable value) {
+                return value.toString().getBytes().length;
+            }
+        };
     }
 
     @Override
@@ -277,7 +289,12 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                 }
                 else {
                     String messageSubString = (!TextUtils.isEmpty(message.getMessage()) ? message.getMessage().substring(0, Math.min(message.getMessage().length(), 50)) : "");
-                    myholder.messageTextView.setText(EmoticonUtils.getSmiledText(context, messageSubString, emojiconHandler));
+                    Spannable markdown = markdownCache.get(message.getKeyString());
+                    if (markdown == null) {
+                        markdown = (Spannable) markwon.toMarkdown(EmoticonUtils.getSmiledText(context, messageSubString, emojiconHandler).toString());
+                        markdownCache.put(message.getKeyString(), markdown);
+                    }
+                    myholder.messageTextView.setText(markdown);
                     showConversationSourceIcon(channel, myholder.attachmentIcon);
                     KmUtils.setIconInsideTextView(myholder.messageTextView);
                 }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/QuickConversationAdapter.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/adapter/QuickConversationAdapter.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.TextAppearanceSpan;
 import android.util.LruCache;
@@ -96,7 +97,7 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
     private String loggedInUserId;
     private boolean isDarkMode;
     private Markwon markwon;
-    private LruCache<String, Spannable> markdownCache;
+    private LruCache<String, Spanned> markdownCache;
 
     public void setAlCustomizationSettings(CustomizationSettings customizationSettings) {
         this.customizationSettings = customizationSettings;
@@ -135,9 +136,9 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
         highlightTextSpan = new TextAppearanceSpan(context, R.style.searchTextHiglight);
         final int maxMemory = (int) (Runtime.getRuntime().maxMemory());
         final int cacheSize = maxMemory / 8;
-        markdownCache = new LruCache<String, Spannable>(cacheSize) {
+        markdownCache = new LruCache<String, Spanned>(cacheSize) {
             @Override
-            protected int sizeOf(String key, Spannable value) {
+            protected int sizeOf(String key, Spanned value) {
                 return value.toString().getBytes().length;
             }
         };
@@ -289,9 +290,9 @@ public class QuickConversationAdapter extends RecyclerView.Adapter implements Fi
                 }
                 else {
                     String messageSubString = (!TextUtils.isEmpty(message.getMessage()) ? message.getMessage().substring(0, Math.min(message.getMessage().length(), 50)) : "");
-                    Spannable markdown = markdownCache.get(message.getKeyString());
+                    Spanned markdown = markdownCache.get(message.getKeyString());
                     if (markdown == null) {
-                        markdown = (Spannable) markwon.toMarkdown(EmoticonUtils.getSmiledText(context, messageSubString, emojiconHandler).toString());
+                        markdown = markwon.toMarkdown(EmoticonUtils.getSmiledText(context, messageSubString, emojiconHandler).toString());
                         markdownCache.put(message.getKeyString(), markdown);
                     }
                     myholder.messageTextView.setText(markdown);


### PR DESCRIPTION
## Enhanced Message Formatting with Markdown Support

This PR introduces rich text formatting for messages by adding support for Markdown in conversation views and both Markdown and HTML in notifications. It also includes performance optimizations to ensure a smooth user experience.

## Key Changes:

- Markdown support for messages.
-  Conversation List Screen
-  Conversation Detail Screen
-  Added Cache to improve performance
-  Notification Message- both HTML/Markdown
-  Performance Optimization for Quick Conversation:

     - An LruCache has been implemented in the QuickConversationAdapter.
     - This cache stores parsed Markdown text, significantly improving scrolling performance by avoiding redundant parsing of messages as the user navigates the list. The cache size is set to 1/8th of the available app memory and is calculated in bytes for accuracy.

### Tests 

### Conversation List
<img width="375" height="171" alt="Screenshot 2026-02-16 at 5 14 46 PM" src="https://github.com/user-attachments/assets/e457c4c8-7947-4e75-901a-fa7a201e7129" />

### Conversation Details
<img width="300" height="750" alt="Screenshot_20260216_171418" src="https://github.com/user-attachments/assets/3cb12971-a59b-460f-898f-a861d1f53ab6" /> 

### Notification

<img width="300" height="750" alt="Screenshot_20260216_171347" src="https://github.com/user-attachments/assets/906cc7d2-a984-4f41-905f-45ee31907b60" />
