### PR TITLE
TDH-3754: Adding Configuration for FAQ

### DIFF
--- a/app/src/main/assets/kommunicate-settings.json
+++ b/app/src/main/assets/kommunicate-settings.json
@@ -187,5 +187,6 @@
   "isVideoCompressionEnabled": false,
   "minimumCompressionThresholdForVideosInMB": 10,
   "hideAttachmentOptionsWithBots": false,
-  "showBackButtonOnFaqPage": true
+  "showBackButtonOnFaqPage": true,
+  "showStatusBarOnFaqPage": true
 }

--- a/app/src/main/assets/kommunicate-settings.json
+++ b/app/src/main/assets/kommunicate-settings.json
@@ -187,6 +187,6 @@
   "isVideoCompressionEnabled": false,
   "minimumCompressionThresholdForVideosInMB": 10,
   "hideAttachmentOptionsWithBots": false,
-  "showBackButtonOnFaqPage": true,
-  "showStatusBarOnFaqPage": true
+  "showBackButtonOnFaqPage": false,
+  "showStatusBarOnFaqPage": false
 }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/CustomizationSettings.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/CustomizationSettings.java
@@ -146,6 +146,7 @@ public class CustomizationSettings extends JsonMarker {
     private boolean javaScriptEnabled = true;
     private boolean hideChatInHelpcenter = true;
     private boolean showBackButtonOnFaqPage = true;
+    private boolean showStatusBarOnFaqPage = true;
     private boolean checkboxAsMultipleButton = false;
     private String staticTopMessage = "";
     private String staticTopIcon = "";
@@ -807,6 +808,10 @@ public class CustomizationSettings extends JsonMarker {
 
     public boolean isShowBackButtonOnFaqPage() {
         return showBackButtonOnFaqPage;
+    }
+
+    public boolean isShowStatusBarOnFaqPage() {
+        return showStatusBarOnFaqPage;
     }
 
     public boolean isToolbarTitleCenterAligned() {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/types/ListKmRichMessage.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/types/ListKmRichMessage.java
@@ -60,9 +60,13 @@ public class ListKmRichMessage extends KmRichMessage {
                         headerText.setVisibility(View.GONE);
                     }
 
-                    if (!TextUtils.isEmpty(payload.getHeaderImgSrc())) {
+                    String headerImageUrl = !TextUtils.isEmpty(payload.getHeaderImgSrc())
+                            ? payload.getHeaderImgSrc()
+                            : payload.getHeaderImageUrl();
+
+                    if (!TextUtils.isEmpty(headerImageUrl)) {
                         headerImage.setVisibility(View.VISIBLE);
-                        Glide.with(context).load(KmAppSettingPreferences.appendSasToken(payload.getHeaderImgSrc())).into(headerImage);
+                        Glide.with(context).load(KmAppSettingPreferences.appendSasToken(headerImageUrl)).into(headerImage);
                     } else {
                         headerImage.setVisibility(View.GONE);
                     }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -11,10 +11,14 @@ import androidx.appcompat.app.AlertDialog;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.WindowManager;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import android.text.TextUtils;
 import android.view.View;
@@ -53,6 +57,7 @@ public class KmWebViewActivity extends KmBaseActivity {
     Toolbar toolbar;
     private Map<String, String> txnData;
     private boolean isPaymentRequest = false;
+    private boolean isHelpCenterFaqPage = false;
     CustomizationSettings customizationSettings;
     private ProgressBar loadingProgressBar;
     private static final String JS_INTERFACE_NAME = "AlWebViewScreen";
@@ -106,6 +111,11 @@ public class KmWebViewActivity extends KmBaseActivity {
                 String helpCenterUrl = alWebViewBundle.getString(KmConstants.KM_HELPCENTER_URL);
 
                 if (!TextUtils.isEmpty(helpCenterUrl)) {
+                    isHelpCenterFaqPage = true;
+                    boolean showFaqStatusBar = customizationSettings.isShowStatusBarOnFaqPage();
+                    boolean showFaqToolbar = customizationSettings.isShowBackButtonOnFaqPage();
+                    applyFaqHeaderVisibility(showFaqToolbar);
+                    applyFaqStatusBarVisibility(showFaqStatusBar);
                     loadUrl(helpCenterUrl);
                     webView.getSettings().setBuiltInZoomControls(false);
                     webView.getSettings().setDisplayZoomControls(false);
@@ -143,6 +153,31 @@ public class KmWebViewActivity extends KmBaseActivity {
         setupInsets();
     }
 
+    private void applyFaqHeaderVisibility(boolean showFaqToolbar) {
+        if (showFaqToolbar || getSupportActionBar() == null) {
+            return;
+        }
+        getSupportActionBar().hide();
+        toolbar.setVisibility(View.GONE);
+    }
+
+    private void applyFaqStatusBarVisibility(boolean showFaqStatusBar) {
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (controller == null) {
+            return;
+        }
+        if (showFaqStatusBar) {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
+            controller.show(WindowInsetsCompat.Type.statusBars());
+        } else {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+            controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            controller.hide(WindowInsetsCompat.Type.statusBars());
+        }
+    }
+
     private void setupDownloadListener(WebView webView) {
         webView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
             try {
@@ -174,6 +209,9 @@ public class KmWebViewActivity extends KmBaseActivity {
     }
 
     private void setupInsets() {
+        if (isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            return;
+        }
         InsetHelper.configureSystemInsets(
                 toolbar,
                 -1,
@@ -188,7 +226,7 @@ public class KmWebViewActivity extends KmBaseActivity {
 
         sb.append(HTML_HEAD_HEAD);
         sb.append(BODY_ONLOAD);
-        sb.append(String.format(FORMID_ACTION));
+        sb.append(String.format(FORMID_ACTION, url, "post"));
 
         for (Map.Entry<String, String> item : postData) {
             sb.append(String.format(INPUT_NAME_HIDDEN, item.getKey(), item.getValue()));
@@ -220,6 +258,22 @@ public class KmWebViewActivity extends KmBaseActivity {
                 }
             });
             alertDialog.show();
+        }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus && isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            applyFaqStatusBarVisibility(false);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            applyFaqStatusBarVisibility(false);
         }
     }
 

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -11,17 +11,14 @@ import androidx.appcompat.app.AlertDialog;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.WindowManager;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 
 import android.text.TextUtils;
 import android.view.View;
+import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.URLUtil;
 import android.webkit.WebResourceRequest;
@@ -30,6 +27,10 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 import android.widget.Toast;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import io.kommunicate.ui.CustomizationSettings;
 import io.kommunicate.ui.R;
@@ -66,10 +67,10 @@ public class KmWebViewActivity extends KmBaseActivity {
     public static final String DEFAULT_REQUEST_TYPE = "application/x-www-form-urlencoded";
     public static final String REQUEST_TYPE_JSON = "json";
     public static final String Al_WEB_VIEW_BUNDLE = "alWebViewBundle";
-    private static final String BODY_ONLOAD = "<body onload='form1.submit()'>";
+    private static final String BODY_ONLOAD = "<body onload=\'form1.submit()\'>";
     private static final String HTML_HEAD_HEAD = "<html><head></head>";
-    private static final String FORMID_ACTION = "<form id='form1' action='%s' method='%s'>";
-    private static final String INPUT_NAME_HIDDEN = "<input name='%s' type='hidden' value='%s' />";
+    private static final String FORMID_ACTION = "<form id=\'form1\' action='%s\' method=\'%s\'>";
+    private static final String INPUT_NAME_HIDDEN = "<input name='%s\' type=\'hidden\' value='%s\' />";
     private static final String FORM_BODY_HTML = "</form></body></html>";
     private static final String text_html = "text/html";
 
@@ -168,11 +169,9 @@ public class KmWebViewActivity extends KmBaseActivity {
         }
         if (showFaqStatusBar) {
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
             controller.show(WindowInsetsCompat.Type.statusBars());
         } else {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
             controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
             controller.hide(WindowInsetsCompat.Type.statusBars());
         }


### PR DESCRIPTION
**Title**  
FAQ WebView: add configurable status-bar visibility, decouple toolbar behavior, and fix form action formatting

**Summary**  
This PR improves FAQ/Helpcenter rendering behavior in `KmWebViewActivity` and adds a new customization setting to control FAQ status-bar visibility without breaking existing integrations.

**Problem**  
- FAQ fullscreen behavior needed a dedicated control for status bar visibility.  
- Toolbar visibility was unintentionally coupled with status-bar visibility.  
- `webViewClientPost()` built form HTML with `String.format(FORMID_ACTION)` but did not pass required `%s` arguments.

**What changed**

1. **New FAQ setting**
- Added `showStatusBarOnFaqPage` in `CustomizationSettings`.
- Added getter: `isShowStatusBarOnFaqPage()`.

2. **Backward-compatible default**
- Default is set to `true` to preserve existing behavior for clients that don’t provide this key in JSON.

3. **FAQ status-bar handling in `KmWebViewActivity`**
- Detect FAQ/helpcenter flow via `KM_HELPCENTER_URL`.
- Apply status-bar visibility using `WindowInsetsControllerCompat` + fullscreen window flag handling.
- Re-apply hide state in lifecycle callbacks (`onWindowFocusChanged`, `onResume`) for device consistency.

4. **Decoupled toolbar behavior**
- FAQ toolbar visibility now depends only on `showBackButtonOnFaqPage`.
- Status-bar visibility now depends only on `showStatusBarOnFaqPage`.

5. **Form markup bug fix**
- Fixed:
  - from: `String.format(FORMID_ACTION)`
  - to: `String.format(FORMID_ACTION, url, "post")`
- This prevents malformed format usage and ensures valid HTML form action/method generation.

6. **Related rich message image robustness**
- In `ListKmRichMessage`, header image loading now falls back from `headerImgSrc` to `headerImageUrl` and still appends SAS token.

**Behavior matrix**

- `showBackButtonOnFaqPage=true`, `showStatusBarOnFaqPage=true`  
  - Toolbar visible, status bar visible (existing-like behavior).
- `showBackButtonOnFaqPage=false`, `showStatusBarOnFaqPage=true`  
  - Toolbar hidden, status bar visible.
- `showBackButtonOnFaqPage=true`, `showStatusBarOnFaqPage=false`  
  - Toolbar visible, status bar hidden.
- `showBackButtonOnFaqPage=false`, `showStatusBarOnFaqPage=false`  
  - Toolbar hidden, status bar hidden.

**Compatibility**
- Non-breaking: new setting defaults to `true`.
- Existing customers with no new JSON key keep prior status-bar behavior.

**Files changed**
- `kommunicateui/src/main/java/io/kommunicate/ui/CustomizationSettings.java`
- `kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java`
- `kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/types/ListKmRichMessage.java`

**Validation**
- Compiled successfully:
  - `./gradlew :kommunicateui:compileDebugJavaWithJavac`

**Config usage (optional for consumers)**
```json
{
  "showBackButtonOnFaqPage": false,
  "showStatusBarOnFaqPage": false
}
```