### PR TITLE
Release 2.16.1 

### DIFF
--- a/app/src/main/assets/kommunicate-settings.json
+++ b/app/src/main/assets/kommunicate-settings.json
@@ -187,5 +187,6 @@
   "isVideoCompressionEnabled": false,
   "minimumCompressionThresholdForVideosInMB": 10,
   "hideAttachmentOptionsWithBots": false,
-  "showBackButtonOnFaqPage": true
+  "showBackButtonOnFaqPage": true,
+  "showStatusBarOnFaqPage": true
 }

--- a/app/src/main/assets/kommunicate-settings.json
+++ b/app/src/main/assets/kommunicate-settings.json
@@ -187,6 +187,6 @@
   "isVideoCompressionEnabled": false,
   "minimumCompressionThresholdForVideosInMB": 10,
   "hideAttachmentOptionsWithBots": false,
-  "showBackButtonOnFaqPage": true,
-  "showStatusBarOnFaqPage": true
+  "showBackButtonOnFaqPage": false,
+  "showStatusBarOnFaqPage": false
 }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -16,7 +16,7 @@ android {
         targetSdkVersion 35
         minSdkVersion 21
         versionCode 1
-        versionName "2.16.0"
+        versionName "2.16.1"
         buildToolsVersion = '34.0.0'
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api project(':kommunicate')
-    //api 'io.kommunicate.sdk:kommunicate:2.14.5'
+    //api project(':kommunicate')
+    api 'io.kommunicate.sdk:kommunicate:2.16.0'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/src/main/java/io/kommunicate/ui/CustomizationSettings.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/CustomizationSettings.java
@@ -146,6 +146,7 @@ public class CustomizationSettings extends JsonMarker {
     private boolean javaScriptEnabled = true;
     private boolean hideChatInHelpcenter = true;
     private boolean showBackButtonOnFaqPage = true;
+    private boolean showStatusBarOnFaqPage = true;
     private boolean checkboxAsMultipleButton = false;
     private String staticTopMessage = "";
     private String staticTopIcon = "";
@@ -807,6 +808,10 @@ public class CustomizationSettings extends JsonMarker {
 
     public boolean isShowBackButtonOnFaqPage() {
         return showBackButtonOnFaqPage;
+    }
+
+    public boolean isShowStatusBarOnFaqPage() {
+        return showStatusBarOnFaqPage;
     }
 
     public boolean isToolbarTitleCenterAligned() {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/types/ListKmRichMessage.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/types/ListKmRichMessage.java
@@ -60,9 +60,13 @@ public class ListKmRichMessage extends KmRichMessage {
                         headerText.setVisibility(View.GONE);
                     }
 
-                    if (!TextUtils.isEmpty(payload.getHeaderImgSrc())) {
+                    String headerImageUrl = !TextUtils.isEmpty(payload.getHeaderImgSrc())
+                            ? payload.getHeaderImgSrc()
+                            : payload.getHeaderImageUrl();
+
+                    if (!TextUtils.isEmpty(headerImageUrl)) {
                         headerImage.setVisibility(View.VISIBLE);
-                        Glide.with(context).load(KmAppSettingPreferences.appendSasToken(payload.getHeaderImgSrc())).into(headerImage);
+                        Glide.with(context).load(KmAppSettingPreferences.appendSasToken(headerImageUrl)).into(headerImage);
                     } else {
                         headerImage.setVisibility(View.GONE);
                     }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -11,10 +11,14 @@ import androidx.appcompat.app.AlertDialog;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.WindowManager;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import android.text.TextUtils;
 import android.view.View;
@@ -53,6 +57,7 @@ public class KmWebViewActivity extends KmBaseActivity {
     Toolbar toolbar;
     private Map<String, String> txnData;
     private boolean isPaymentRequest = false;
+    private boolean isHelpCenterFaqPage = false;
     CustomizationSettings customizationSettings;
     private ProgressBar loadingProgressBar;
     private static final String JS_INTERFACE_NAME = "AlWebViewScreen";
@@ -106,6 +111,11 @@ public class KmWebViewActivity extends KmBaseActivity {
                 String helpCenterUrl = alWebViewBundle.getString(KmConstants.KM_HELPCENTER_URL);
 
                 if (!TextUtils.isEmpty(helpCenterUrl)) {
+                    isHelpCenterFaqPage = true;
+                    boolean showFaqStatusBar = customizationSettings.isShowStatusBarOnFaqPage();
+                    boolean showFaqToolbar = customizationSettings.isShowBackButtonOnFaqPage();
+                    applyFaqHeaderVisibility(showFaqToolbar);
+                    applyFaqStatusBarVisibility(showFaqStatusBar);
                     loadUrl(helpCenterUrl);
                     webView.getSettings().setBuiltInZoomControls(false);
                     webView.getSettings().setDisplayZoomControls(false);
@@ -143,6 +153,31 @@ public class KmWebViewActivity extends KmBaseActivity {
         setupInsets();
     }
 
+    private void applyFaqHeaderVisibility(boolean showFaqToolbar) {
+        if (showFaqToolbar || getSupportActionBar() == null) {
+            return;
+        }
+        getSupportActionBar().hide();
+        toolbar.setVisibility(View.GONE);
+    }
+
+    private void applyFaqStatusBarVisibility(boolean showFaqStatusBar) {
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (controller == null) {
+            return;
+        }
+        if (showFaqStatusBar) {
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
+            controller.show(WindowInsetsCompat.Type.statusBars());
+        } else {
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+            controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            controller.hide(WindowInsetsCompat.Type.statusBars());
+        }
+    }
+
     private void setupDownloadListener(WebView webView) {
         webView.setDownloadListener((url, userAgent, contentDisposition, mimetype, contentLength) -> {
             try {
@@ -174,6 +209,9 @@ public class KmWebViewActivity extends KmBaseActivity {
     }
 
     private void setupInsets() {
+        if (isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            return;
+        }
         InsetHelper.configureSystemInsets(
                 toolbar,
                 -1,
@@ -188,7 +226,7 @@ public class KmWebViewActivity extends KmBaseActivity {
 
         sb.append(HTML_HEAD_HEAD);
         sb.append(BODY_ONLOAD);
-        sb.append(String.format(FORMID_ACTION));
+        sb.append(String.format(FORMID_ACTION, url, "post"));
 
         for (Map.Entry<String, String> item : postData) {
             sb.append(String.format(INPUT_NAME_HIDDEN, item.getKey(), item.getValue()));
@@ -220,6 +258,22 @@ public class KmWebViewActivity extends KmBaseActivity {
                 }
             });
             alertDialog.show();
+        }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus && isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            applyFaqStatusBarVisibility(false);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            applyFaqStatusBarVisibility(false);
         }
     }
 

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -56,6 +56,7 @@ public class KmWebViewActivity extends KmBaseActivity {
 
     WebView webView;
     Toolbar toolbar;
+    View webViewContainer;
     private Map<String, String> txnData;
     private boolean isPaymentRequest = false;
     private boolean isHelpCenterFaqPage = false;
@@ -88,6 +89,7 @@ public class KmWebViewActivity extends KmBaseActivity {
         configureSentryWithKommunicateUI(this, customizationSettings.toString());
 
         toolbar = (Toolbar) findViewById(R.id.my_toolbar);
+        webViewContainer = findViewById(R.id.webViewContainer);
         setSupportActionBar(toolbar);
         KmThemeHelper themeHelper = KmThemeHelper.getInstance(this, customizationSettings);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(themeHelper.getPrimaryColor()));
@@ -209,6 +211,19 @@ public class KmWebViewActivity extends KmBaseActivity {
 
     private void setupInsets() {
         if (isHelpCenterFaqPage && !customizationSettings.isShowStatusBarOnFaqPage()) {
+            return;
+        }
+        if (isHelpCenterFaqPage && !customizationSettings.isShowBackButtonOnFaqPage()) {
+            InsetHelper.configureInset(
+                    webViewContainer,
+                    InsetHelper.systemTypeMask | InsetHelper.cameraTypeMask,
+                    0,
+                    0,
+                    -1,
+                    0,
+                    true,
+                    null
+            );
             return;
         }
         InsetHelper.configureSystemInsets(

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -11,17 +11,14 @@ import androidx.appcompat.app.AlertDialog;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
-import android.view.WindowManager;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
 import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
 
 import android.text.TextUtils;
 import android.view.View;
+import android.view.WindowManager;
 import android.webkit.CookieManager;
 import android.webkit.URLUtil;
 import android.webkit.WebResourceRequest;
@@ -30,6 +27,10 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 import android.widget.Toast;
+
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import io.kommunicate.ui.CustomizationSettings;
 import io.kommunicate.ui.R;
@@ -66,10 +67,10 @@ public class KmWebViewActivity extends KmBaseActivity {
     public static final String DEFAULT_REQUEST_TYPE = "application/x-www-form-urlencoded";
     public static final String REQUEST_TYPE_JSON = "json";
     public static final String Al_WEB_VIEW_BUNDLE = "alWebViewBundle";
-    private static final String BODY_ONLOAD = "<body onload='form1.submit()'>";
+    private static final String BODY_ONLOAD = "<body onload=\'form1.submit()\'>";
     private static final String HTML_HEAD_HEAD = "<html><head></head>";
-    private static final String FORMID_ACTION = "<form id='form1' action='%s' method='%s'>";
-    private static final String INPUT_NAME_HIDDEN = "<input name='%s' type='hidden' value='%s' />";
+    private static final String FORMID_ACTION = "<form id=\'form1\' action='%s\' method=\'%s\'>";
+    private static final String INPUT_NAME_HIDDEN = "<input name='%s\' type=\'hidden\' value='%s\' />";
     private static final String FORM_BODY_HTML = "</form></body></html>";
     private static final String text_html = "text/html";
 
@@ -168,11 +169,9 @@ public class KmWebViewActivity extends KmBaseActivity {
         }
         if (showFaqStatusBar) {
             getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
             controller.show(WindowInsetsCompat.Type.statusBars());
         } else {
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
             controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
             controller.hide(WindowInsetsCompat.Type.statusBars());
         }

--- a/kommunicateui/src/main/res/layout/km_activity_payment.xml
+++ b/kommunicateui/src/main/res/layout/km_activity_payment.xml
@@ -19,6 +19,7 @@
         app:titleTextAppearance="@style/ToolbarTitle" />
 
     <FrameLayout
+        android:id="@+id/webViewContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION

### UI Release Version 2.16.1

#### FAQ WebView: Configurable status-bar visibility

- showBackButtonOnFaqPage=true, showStatusBarOnFaqPage=true
Toolbar visible, status bar visible (existing-like behavior).
- showBackButtonOnFaqPage=false, showStatusBarOnFaqPage=true
Toolbar hidden, status bar visible.
- showBackButtonOnFaqPage=true, showStatusBarOnFaqPage=false
Toolbar visible, status bar hidden.
- showBackButtonOnFaqPage=false, showStatusBarOnFaqPage=false
Toolbar hidden, status bar hidden.

#### Form markup bug fix
Fixed:
from: String.format(FORMID_ACTION)
to: String.format(FORMID_ACTION, url, "post")
This prevents malformed format usage and ensures valid HTML form action/method generation.
#### Related rich message image robustness
In ListKmRichMessage, header image loading now falls back from headerImgSrc to headerImageUrl and still appends SAS token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable status bar visibility for the Help Center FAQ page

* **Improvements**
  * FAQ UI settings updated to hide the back button and control the status bar on the FAQ page
  * List message headers now load images from multiple sources for better compatibility

* **Bug Fixes**
  * Webview behavior refined for FAQ pages (toolbar/status bar visibility and inset handling); form post HTML generation corrected

* **Other**
  * Minor layout ID added for web view container

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kommunicate-io/Kommunicate-Android-Chat-SDK/pull/658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->