### PR TITLE
TDH-3960: Performance Optimizations 

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/database/KmDatabaseHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/database/KmDatabaseHelper.java
@@ -55,16 +55,12 @@ public class KmDatabaseHelper extends MobiComDatabaseHelper {
 
     @Override
     public SQLiteDatabase getReadableDatabase() {
-        SQLiteDatabase database = super.getReadableDatabase();
-        database.enableWriteAheadLogging();
-        return database;
+        return super.getReadableDatabase();
     }
 
     @Override
     public SQLiteDatabase getWritableDatabase() {
-        SQLiteDatabase database = super.getWritableDatabase();
-        database.enableWriteAheadLogging();
-        return database;
+        return super.getWritableDatabase();
     }
 
     @Override

--- a/kommunicate/src/main/java/io/kommunicate/devkit/database/MobiComDatabaseHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/database/MobiComDatabaseHelper.java
@@ -257,7 +257,9 @@ public class MobiComDatabaseHelper extends SQLiteOpenHelper {
     }
 
     public MobiComDatabaseHelper(Context context, String name, SQLiteDatabase.CursorFactory factory, int version) {
-        super(context, name, MobiComKitClientService.getApplicationKey(context), factory, version, 0, null, null, false);        System.loadLibrary("sqlcipher");
+        super(context, name, MobiComKitClientService.getApplicationKey(context), factory, version, 0, null, null, false);
+        setWriteAheadLoggingEnabled(true);
+        System.loadLibrary("sqlcipher");
         AppSpecificSettings appSpecificSettings = AppSpecificSettings.getInstance(context);
         int currentRetryCount = appSpecificSettings.getCurrentDatabaseMigrationRetryCount();
         if (!DBUtils.isDatabaseEncrypted(context, name) && currentRetryCount < MAX_DATABASE_MIGRATION_RETRY_COUNT) {
@@ -284,16 +286,12 @@ public class MobiComDatabaseHelper extends SQLiteOpenHelper {
 
     public SQLiteDatabase getReadableDatabase() {
         // The password is now handled by the constructor.
-        SQLiteDatabase database = super.getReadableDatabase();
-        database.enableWriteAheadLogging();
-        return database;
+        return super.getReadableDatabase();
     }
 
     public SQLiteDatabase getWritableDatabase() {
         // The password is now handled by the constructor.
-        SQLiteDatabase database = super.getWritableDatabase();
-        database.enableWriteAheadLogging();
-        return database;
+        return super.getWritableDatabase();
     }
 
     @Override

--- a/kommunicate/src/main/java/io/kommunicate/services/KmChannelService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmChannelService.java
@@ -32,14 +32,12 @@ public class KmChannelService {
     }
 
     public String getUserInSupportGroup(Integer channelKey) {
+        Cursor cursor = null;
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
 
-            Cursor cursor = db.query(CHANNEL_USER_X, null, CHANNEL_KEY_ROLE, new String[]{String.valueOf(channelKey), String.valueOf(3)}, null, null, null);
+            cursor = db.query(CHANNEL_USER_X, null, CHANNEL_KEY_ROLE, new String[]{String.valueOf(channelKey), String.valueOf(3)}, null, null, null);
             List<ChannelUserMapper> channelUserMappers = getListOfUsers(cursor);
-
-            cursor.close();
-            dbHelper.close();
 
             if (channelUserMappers == null || channelUserMappers.isEmpty()) {
                 return "";
@@ -48,6 +46,8 @@ public class KmChannelService {
 
         } catch (Exception e) {
             e.printStackTrace();
+        } finally {
+            closeCursor(cursor);
         }
         return null;
     }
@@ -56,15 +56,13 @@ public class KmChannelService {
         Cursor cursor = null;
         try {
             SQLiteDatabase db = dbHelper.getReadableDatabase();
-            cursor = db.query(CHANNEL_USER_X, null, CHANNEL_KEY_ROLE, new String[]{String.valueOf(channelKey), String.valueOf(3)}, null, null, null);
+            cursor = db.query(CHANNEL_USER_X, null, CHANNEL_KEY_ROLE, new String[]{String.valueOf(channelKey), String.valueOf(role)}, null, null, null);
 
             return getListOfUserIds(cursor);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            if (cursor != null && !cursor.isClosed()) {
-                cursor.close();
-            }
+            closeCursor(cursor);
         }
         return null;
     }
@@ -81,9 +79,7 @@ public class KmChannelService {
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
+            closeCursor(cursor);
         }
         return userIdList;
     }
@@ -100,11 +96,15 @@ public class KmChannelService {
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
+            closeCursor(cursor);
         }
         return channelUserMapper;
+    }
+
+    private static void closeCursor(Cursor cursor) {
+        if (cursor != null && !cursor.isClosed()) {
+            cursor.close();
+        }
     }
 
     public static ChannelUserMapper getChannelUser(Cursor cursor) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -3789,10 +3789,18 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         }
         updateSupportGroupTitleAndImageAndHideSubtitle(channel);
 
+        String conversationAssigneeId = channel.getConversationAssignee();
+        if (TextUtils.isEmpty(conversationAssigneeId)) {
+            return;
+        }
+
         UserDetailUseCase.executeWithExecutor(
                 requireContext(),
-                channel.getConversationAssignee(),
+                conversationAssigneeId,
                 contactCallback -> {
+                    if (contactCallback == null) {
+                        return;
+                    }
                     conversationAssignee = contactCallback;
                     updateSupportGroupTitleAndImageAndHideSubtitle(channel);
                     switchContactStatus(contactCallback, contactCallback.isUserOnline());


### PR DESCRIPTION
## Summary

   1. ### Moving AWL enabling code to single palace to avoid locks

Fixes a background ANR caused by repeatedly calling enableWriteAheadLogging() from getReadableDatabase() / getWritableDatabase().
WAL is now enabled once through setWriteAheadLoggingEnabled(true) during database helper setup, so normal DB reads/writes no longer trigger SQLCipher’s lock-heavy WAL enable path. Also cleaned cursor handling in the support-group user lookup path.

 2. ### Fixes a crash when support-group details are processed without a conversation assignee.

`channel.getConversationAssignee()` can be null/empty for valid transient states, such as a new unassigned conversation, delayed local sync, reassignment, missing metadata, or broadcast updates arriving before the full channel refresh. We now skip the user-detail fetch when no assignee ID is available, and safely handle null user-detail callbacks.

Verified with:

```bash
./gradlew :kommunicateui:compileDebugJavaWithJavac
```