### PR TITLE
TDH 3975 Fix NPE in MobicomLocationActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"<<YOUR_APP_ID>>"'
+        buildConfigField "String", "APP_ID", '"1de229e1897fa19317af97b7b6acdee7c"'
         multiDexEnabled true
     }
 
@@ -54,7 +54,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api project(':kommunicateui')
-    //implementation 'io.kommunicate.sdk:kommunicateui:2.15.0'
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,9 +8,9 @@ android {
     namespace "io.kommunicate.app"
     defaultConfig {
         applicationId "io.kommunicate.app"
-        compileSdk 34
+        compileSdk 35
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"14d472eeccd935b18a4b759285e327309"'
+        buildConfigField "String", "APP_ID", '"<<YOUR_APP_ID>>"'
         multiDexEnabled true
     }
 
@@ -53,8 +53,8 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api project(':kommunicateui')
-//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
+//    api project(':kommunicateui')
+    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"14d472eeccd935b18a4b759285e327309"'
+        buildConfigField "String", "APP_ID", '"<<YOUR_APP_ID>>"'
         multiDexEnabled true
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"<YOUR_APP_ID>"'
+        buildConfigField "String", "APP_ID", '"1de229e1897fa19317af97b7b6acdee7c"'
         multiDexEnabled true
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"1de229e1897fa19317af97b7b6acdee7c"'
+        buildConfigField "String", "APP_ID", '"14d472eeccd935b18a4b759285e327309"'
         multiDexEnabled true
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,8 +53,8 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-//    api project(':kommunicateui')
-    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
+    api project(':kommunicateui')
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api project(':kommunicateui')
-//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.3'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        compileSdk 34
+        compileSdk 35
         targetSdkVersion 35
         versionCode 1
         versionName "2.16.2"

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -18,7 +18,7 @@ android {
         compileSdk 35
         targetSdkVersion 35
         versionCode 1
-        versionName "2.16.2"
+        versionName "2.16.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "KOMMUNICATE_VERSION", "\"" + versionName + "\""
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/database/MessageDatabaseService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/conversation/database/MessageDatabaseService.java
@@ -1157,7 +1157,7 @@ public class MessageDatabaseService {
                         "AND m.type not in (6, 7) AND m.channelKey = 0 " +
                         "group by m.contactNumbers " +
                         ") temp " +
-                        (lastFetchTime != null && lastFetchTime > 0 ? " where temp.maxCreatedAt < " + lastFetchTime : "") +
+                        (lastFetchTime != null && lastFetchTime > 0 ? " where temp.maxCreatedAt < ?" : "") +
                         " ORDER BY temp.maxCreatedAt DESC";
                 selectionArgs.add(String.valueOf(status));
                 if (lastFetchTime != null && lastFetchTime > 0) {

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -172,8 +172,9 @@ object KmUtils {
     @JvmStatic
     fun setStatusBarColor(activity: Activity, color: Int) {
         val window = activity.window
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.decorView.setBackgroundColor(color)
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
+        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        window.statusBarColor = color
     }
 
     @JvmStatic

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.text.TextUtils
 import android.util.Log
 import android.view.View

--- a/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/KmUtils.kt
@@ -17,6 +17,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.view.WindowCompat
 import io.kommunicate.devkit.SettingsSharedPreference
 import io.kommunicate.devkit.api.account.user.MobiComUserPreference
 import io.kommunicate.devkit.api.account.user.User
@@ -171,9 +172,8 @@ object KmUtils {
     @JvmStatic
     fun setStatusBarColor(activity: Activity, color: Int) {
         val window = activity.window
-        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-        window.statusBarColor = color
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.decorView.setBackgroundColor(color)
     }
 
     @JvmStatic

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -12,7 +12,7 @@ android {
         abortOnError false
     }
     defaultConfig {
-        compileSdk 34
+        compileSdk 35
         targetSdkVersion 35
         minSdkVersion 21
         versionCode 1
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-//    api project(':kommunicate')
-    api 'io.kommunicate.sdk:kommunicate:2.16.2'
+    api project(':kommunicate')
+//    api 'io.kommunicate.sdk:kommunicate:2.16.2'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -16,7 +16,7 @@ android {
         targetSdkVersion 35
         minSdkVersion 21
         versionCode 1
-        versionName "2.16.2"
+        versionName "2.16.3"
         buildToolsVersion = '34.0.0'
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
@@ -45,7 +45,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 //    api project(':kommunicate')
-    api 'io.kommunicate.sdk:kommunicate:2.16.2'
+    api 'io.kommunicate.sdk:kommunicate:2.16.3'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    //api project(':kommunicate')
-    api 'io.kommunicate.sdk:kommunicate:2.16.2'
+    api project(':kommunicate')
+//    api 'io.kommunicate.sdk:kommunicate:2.16.2'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -44,8 +44,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    api project(':kommunicate')
-//    api 'io.kommunicate.sdk:kommunicate:2.16.2'
+//    api project(':kommunicate')
+    api 'io.kommunicate.sdk:kommunicate:2.16.2'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     //api project(':kommunicate')
-    api 'io.kommunicate.sdk:kommunicate:2.16.0'
+    api 'io.kommunicate.sdk:kommunicate:2.16.2'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/src/main/java/io/kommunicate/ui/activities/KmBaseActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/activities/KmBaseActivity.java
@@ -17,6 +17,9 @@ public abstract class KmBaseActivity extends AppCompatActivity {
             controller.setAppearanceLightStatusBars(lightStatusBar);
             controller.setAppearanceLightNavigationBars(lightStatusBar);
         }
+        if (statusBarColor != 0) {
+            getWindow().getDecorView().setBackgroundColor(statusBarColor);
+        }
     }
 
     protected void setupEdgeToEdge(CustomizationSettings customizationSettings, boolean lightStatusBar, int statusBarColor) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
@@ -400,10 +400,13 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
             customizationSettings = new CustomizationSettings();
         }
         themeHelper = KmThemeHelper.getInstance(this, customizationSettings);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            setupEdgeToEdge(customizationSettings, shouldUseLightSystemBars(customizationSettings), themeHelper.getStatusBarColor());
-        }
-        KmUtils.setStatusBarColor(this, themeHelper.getStatusBarColor());
+
+        setupEdgeToEdge(
+                customizationSettings,
+                shouldUseLightSystemBars(customizationSettings),
+                themeHelper.getStatusBarColor()
+        );
+
         setupActivityResultCallback();
         configureSentryWithKommunicateUI(this, customizationSettings.toString());
         if (!TextUtils.isEmpty(customizationSettings.getChatBackgroundImageName())) {
@@ -598,7 +601,11 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
     private void setupModes() {
         toolbar.setBackgroundColor(themeHelper.getToolbarColor());
         customToolbarLayout.setBackgroundColor(themeHelper.getToolbarColor());
-        KmUtils.setStatusBarColor(this, themeHelper.getStatusBarColor());
+        setupEdgeToEdge(
+                customizationSettings,
+                shouldUseLightSystemBars(customizationSettings),
+                themeHelper.getStatusBarColor()
+        );
         setToolbarTitleSubtitleColorFromSettings();
     }
 

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
@@ -3,14 +3,12 @@ package io.kommunicate.ui.conversation.activity;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.location.Location;
@@ -1185,31 +1183,8 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
             Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 
             cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, capturedImageUri);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                ClipData clip =
-                        ClipData.newUri(getContentResolver(), "a Photo", capturedImageUri);
-
-                cameraIntent.setClipData(clip);
-                cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-            } else {
-                List<ResolveInfo> resInfoList =
-                        getPackageManager()
-                                .queryIntentActivities(cameraIntent, PackageManager.MATCH_DEFAULT_ONLY);
-
-                for (ResolveInfo resolveInfo : resInfoList) {
-                    String packageName = resolveInfo.activityInfo.packageName;
-                    grantUriPermission(packageName, capturedImageUri,
-                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                    grantUriPermission(packageName, capturedImageUri,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
-            }
+            cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            cameraIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             if (cameraIntent.resolveActivity(getApplicationContext().getPackageManager()) != null) {
                 if (mediaFile != null) {
@@ -1243,7 +1218,6 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
     }
 
     public void showVideoCapture() {
-
         try {
             Intent videoIntent = new Intent(MediaStore.ACTION_VIDEO_CAPTURE);
             String timeStamp = new SimpleDateFormat(DATE_FORMAT).format(new Date());
@@ -1254,32 +1228,8 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
             videoFileUri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", mediaFile);
 
             videoIntent.putExtra(MediaStore.EXTRA_OUTPUT, videoFileUri);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                videoIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                videoIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                ClipData clip =
-                        ClipData.newUri(getContentResolver(), "a Video", videoFileUri);
-
-                videoIntent.setClipData(clip);
-                videoIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                videoIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-            } else {
-                List<ResolveInfo> resInfoList =
-                        getPackageManager()
-                                .queryIntentActivities(videoIntent, PackageManager.MATCH_DEFAULT_ONLY);
-
-                for (ResolveInfo resolveInfo : resInfoList) {
-                    String packageName = resolveInfo.activityInfo.packageName;
-                    grantUriPermission(packageName, videoFileUri,
-                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                    grantUriPermission(packageName, videoFileUri,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-                }
-            }
+            videoIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            videoIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             if (videoIntent.resolveActivity(getApplicationContext().getPackageManager()) != null) {
                 if (mediaFile != null) {
@@ -1287,11 +1237,9 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
                     startActivityForResult(videoIntent, MultimediaOptionFragment.REQUEST_CODE_CAPTURE_VIDEO_ACTIVITY);
                 }
             }
-
         } catch (Exception e) {
             e.printStackTrace();
         }
-
     }
 
     @Override

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
@@ -19,14 +19,16 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.Window;
-import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -36,6 +38,7 @@ import io.kommunicate.devkit.api.conversation.Message;
 import io.kommunicate.devkit.broadcast.ConnectivityReceiver;
 import io.kommunicate.ui.R;
 
+import io.kommunicate.ui.activities.KmBaseActivity;
 import io.kommunicate.ui.conversation.TouchImageView;
 import io.kommunicate.ui.conversation.richmessaging.models.KmRichMessageModel;
 import io.kommunicate.ui.conversation.richmessaging.KmRichMessage;
@@ -43,6 +46,7 @@ import io.kommunicate.commons.commons.core.utils.Utils;
 import io.kommunicate.commons.commons.image.ImageUtils;
 import io.kommunicate.commons.file.FileUtils;
 import io.kommunicate.commons.json.GsonUtils;
+
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
 import com.bumptech.glide.request.RequestOptions;
@@ -56,7 +60,7 @@ import java.util.List;
 /**
  * Created by devashish on 22/9/14.
  */
-public class FullScreenImageActivity extends AppCompatActivity {
+public class FullScreenImageActivity extends KmBaseActivity {
     TouchImageView mediaImageView;
     ImageView gifImageView;
     private Message message;
@@ -67,7 +71,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        setupEdgeToEdge(true);
         setContentView(R.layout.image_full_screen);
         configureSentryWithKommunicateUI(this, "");
         Toolbar toolbar = (Toolbar) findViewById(R.id.my_toolbar);
@@ -86,7 +90,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
         if (payload != null) {
             TextView captionText = findViewById(R.id.captionText);
             KmRichMessageModel.KmPayloadModel payloadModel = (KmRichMessageModel.KmPayloadModel) GsonUtils.getObjectFromJson(payload, KmRichMessageModel.KmPayloadModel.class);
-            if(payloadModel.getUrl().endsWith("gif")) {
+            if (payloadModel.getUrl().endsWith("gif")) {
                 Glide.with(this)
                         .asGif()
                         .load(payloadModel.getUrl())
@@ -98,8 +102,7 @@ public class FullScreenImageActivity extends AppCompatActivity {
                                 gifImageView.setImageDrawable(gifDrawable);
                             }
                         });
-            }
-            else {
+            } else {
                 Glide.with(this)
                         .asBitmap()
                         .load(payloadModel.getUrl())
@@ -127,13 +130,12 @@ public class FullScreenImageActivity extends AppCompatActivity {
 
             if (message != null && message.getFilePaths() != null && !message.getFilePaths().isEmpty() && message.getFileMetas() != null) {
                 try {
-                    if(message.getFileMetas().getContentType().contains("gif")) {
+                    if (message.getFileMetas().getContentType().contains("gif")) {
                         Glide.with(this)
                                 .asGif()
                                 .load(message.getFilePaths().get(0))
                                 .into(gifImageView);
-                    }
-                    else {
+                    } else {
                         Bitmap imageBitmap = ImageUtils.decodeSampledBitmapFromPath(message.getFilePaths().get(0));
                         mediaImageView.setImageBitmap(imageBitmap);
                     }
@@ -142,17 +144,13 @@ public class FullScreenImageActivity extends AppCompatActivity {
                 }
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
-
-                    @Override
-                    public void onSystemUiVisibilityChange(int visibility) {
-                        if (visibility == 0) {
-                            getSupportActionBar().show();
-                        }
-                    }
-                });
-            }
+            ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
+                boolean systemBarsVisible = insets.isVisible(WindowInsetsCompat.Type.systemBars());
+                if (systemBarsVisible) {
+                    getSupportActionBar().show();
+                }
+                return insets;
+            });
             progressBar.setVisibility(View.GONE);
 
             connectivityReceiver = new ConnectivityReceiver();
@@ -188,28 +186,17 @@ public class FullScreenImageActivity extends AppCompatActivity {
     }
 
     private void showUi() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            getWindow().getDecorView().setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
-
-        } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-                requestWindowFeature(Window.FEATURE_ACTION_BAR_OVERLAY);
-            }
-            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (controller != null) {
+            controller.show(WindowInsetsCompat.Type.systemBars());
         }
     }
 
     private void hideUi() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            getWindow().getDecorView().setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                            | View.SYSTEM_UI_FLAG_FULLSCREEN);
-        } else {
-            requestWindowFeature(Window.FEATURE_NO_TITLE);
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        WindowInsetsControllerCompat controller = WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        if (controller != null) {
+            controller.setSystemBarsBehavior(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            controller.hide(WindowInsetsCompat.Type.systemBars());
         }
     }
 

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
@@ -3,11 +3,8 @@ package io.kommunicate.ui.conversation.activity;
 import static io.kommunicate.ui.utils.SentryUtils.configureSentryWithKommunicateUI;
 
 import android.annotation.TargetApi;
-import android.content.ClipData;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
@@ -55,7 +52,6 @@ import com.bumptech.glide.request.target.ImageViewTarget;
 import com.bumptech.glide.request.transition.Transition;
 
 import java.io.File;
-import java.util.List;
 
 /**
  * Created by devashish on 22/9/14.
@@ -223,29 +219,7 @@ public class FullScreenImageActivity extends KmBaseActivity {
 
             Uri uri = FileProvider.getUriForFile(this, Utils.getMetaDataValue(this, MobiComKitConstants.PACKAGE_NAME) + ".provider", new File(message.getFilePaths().get(0)));
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                ClipData clip =
-                        ClipData.newUri(getContentResolver(), "a Photo", uri);
-
-                shareIntent.setClipData(clip);
-                shareIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-
-            } else {
-                List<ResolveInfo> resInfoList =
-                        getPackageManager()
-                                .queryIntentActivities(shareIntent, PackageManager.MATCH_DEFAULT_ONLY);
-
-                for (ResolveInfo resolveInfo : resInfoList) {
-                    String packageName = resolveInfo.activityInfo.packageName;
-                    grantUriPermission(packageName, uri,
-                            Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                    grantUriPermission(packageName, uri,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                }
-            }
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
             shareIntent.setType(FileUtils.getMimeType(new File(message.getFilePaths().get(0))));

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/FullScreenImageActivity.java
@@ -6,7 +6,6 @@ import android.annotation.TargetApi;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.graphics.Bitmap;
-import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.net.ConnectivityManager;
 import android.net.Uri;
@@ -33,6 +32,7 @@ import android.widget.TextView;
 import io.kommunicate.devkit.api.MobiComKitConstants;
 import io.kommunicate.devkit.api.conversation.Message;
 import io.kommunicate.devkit.broadcast.ConnectivityReceiver;
+import io.kommunicate.ui.CustomizationSettings;
 import io.kommunicate.ui.R;
 
 import io.kommunicate.ui.activities.KmBaseActivity;
@@ -43,6 +43,7 @@ import io.kommunicate.commons.commons.core.utils.Utils;
 import io.kommunicate.commons.commons.image.ImageUtils;
 import io.kommunicate.commons.file.FileUtils;
 import io.kommunicate.commons.json.GsonUtils;
+import io.kommunicate.ui.kommunicate.utils.KmThemeHelper;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -61,18 +62,30 @@ public class FullScreenImageActivity extends KmBaseActivity {
     ImageView gifImageView;
     private Message message;
     private ConnectivityReceiver connectivityReceiver;
+    private CustomizationSettings customizationSettings;
     private static final int HEIGHT = 1600;
     private static final int WIDTH = 1600;
 
     protected void onCreate(Bundle savedInstanceState) {
 
         super.onCreate(savedInstanceState);
-        setupEdgeToEdge(true);
+        String jsonString = FileUtils.loadSettingsJsonFile(getApplicationContext());
+        if (!TextUtils.isEmpty(jsonString)) {
+            customizationSettings = (CustomizationSettings) GsonUtils.getObjectFromJson(jsonString, CustomizationSettings.class);
+        } else {
+            customizationSettings = new CustomizationSettings();
+        }
+
+        setupEdgeToEdge(customizationSettings);
         setContentView(R.layout.image_full_screen);
         configureSentryWithKommunicateUI(this, "");
         Toolbar toolbar = (Toolbar) findViewById(R.id.my_toolbar);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+
+        KmThemeHelper themeHelper = KmThemeHelper.getInstance(this, customizationSettings);
+        int toolbarColor = themeHelper.getStatusBarColor();
+        getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().show();
         showUi();

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
@@ -107,13 +107,11 @@ public class MobicomLocationActivity extends KmBaseActivity implements OnMapRead
                 }
                 MobicomLocationActivity.this.customizationSettings = customizationSettings;
                 progressBar.setVisibility(View.GONE);
-                setupEdgeToEdge(customizationSettings);
+                setupEdgeToEdge(customizationSettings, shouldUseLightSystemBars(customizationSettings), themeHelper.getStatusBarColor());
                 configureSentryWithKommunicateUI(MobicomLocationActivity.this, customizationSettings.toString());
                 themeHelper = KmThemeHelper.getInstance(MobicomLocationActivity.this, customizationSettings);
-
                 toolbar.setBackgroundColor(themeHelper.getToolbarColor());
                 toolbar.setTitleTextColor(themeHelper.getToolbarTitleColor());
-                KmUtils.setStatusBarColor(MobicomLocationActivity.this, themeHelper.getStatusBarColor());
                 getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
                 int iconColor = themeHelper.parseColorWithDefault(customizationSettings.getAttachmentIconsBackgroundColor().get(themeHelper.isDarkModeEnabledForSDK() ? 1 : 0),
@@ -176,10 +174,12 @@ public class MobicomLocationActivity extends KmBaseActivity implements OnMapRead
             googleMap.getUiSettings().setZoomGesturesEnabled(true);
             googleMap.setOnMarkerDragListener(new GoogleMap.OnMarkerDragListener() {
                 @Override
-                public void onMarkerDragStart(Marker marker) { }
+                public void onMarkerDragStart(Marker marker) {
+                }
 
                 @Override
-                public void onMarkerDrag(Marker marker) { }
+                public void onMarkerDrag(Marker marker) {
+                }
 
                 @Override
                 public void onMarkerDragEnd(Marker marker) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
@@ -107,9 +107,9 @@ public class MobicomLocationActivity extends KmBaseActivity implements OnMapRead
                 }
                 MobicomLocationActivity.this.customizationSettings = customizationSettings;
                 progressBar.setVisibility(View.GONE);
+                themeHelper = KmThemeHelper.getInstance(MobicomLocationActivity.this, customizationSettings);
                 setupEdgeToEdge(customizationSettings, shouldUseLightSystemBars(customizationSettings), themeHelper.getStatusBarColor());
                 configureSentryWithKommunicateUI(MobicomLocationActivity.this, customizationSettings.toString());
-                themeHelper = KmThemeHelper.getInstance(MobicomLocationActivity.this, customizationSettings);
                 toolbar.setBackgroundColor(themeHelper.getToolbarColor());
                 toolbar.setTitleTextColor(themeHelper.getToolbarTitleColor());
                 getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -448,7 +448,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
 
     protected Message lastUserMessage;
     private static final String[] WHATSAPP_SOURCE = {"WHATSAPPCLOUDAPI", "WHATSAPPTWILIO", "WHATSAPPDIALOG360"};
-    ;
+
     private static final String CONVERSATION_SOURCE = "source";
 
     private LinearLayout messageListLinearLayout;

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComQuickConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComQuickConversationFragment.java
@@ -687,12 +687,15 @@ public class MobiComQuickConversationFragment extends Fragment implements Search
                         return;
                     }
                     if (loadMore && !loading && (visibleItemCount + pastVisiblesItems) >= totalItemCount) {
-                        DownloadConversation downloadConversation = new DownloadConversation(getContext(), false, listIndex);
-                        downloadConversation.setTextViewWeakReference(emptyTextView);
-                        downloadConversation.setSwipeRefreshLayoutWeakReference(swipeLayout);
-                        downloadConversation.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
                         loading = true;
                         loadMore = false;
+
+                        recyclerView.post(() -> {
+                            DownloadConversation downloadConversation = new DownloadConversation(getContext(), false, listIndex);
+                            downloadConversation.setTextViewWeakReference(emptyTextView);
+                            downloadConversation.setSwipeRefreshLayoutWeakReference(swipeLayout);
+                            downloadConversation.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                        });
                     }
                 }
             }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -84,7 +84,6 @@ public class KmWebViewActivity extends KmBaseActivity {
         } else {
             customizationSettings = new CustomizationSettings();
         }
-        setupEdgeToEdge(customizationSettings);
         setContentView(R.layout.km_activity_payment);
         configureSentryWithKommunicateUI(this, customizationSettings.toString());
 
@@ -92,12 +91,16 @@ public class KmWebViewActivity extends KmBaseActivity {
         webViewContainer = findViewById(R.id.webViewContainer);
         setSupportActionBar(toolbar);
         KmThemeHelper themeHelper = KmThemeHelper.getInstance(this, customizationSettings);
+        setupEdgeToEdge(
+                customizationSettings,
+                shouldUseLightSystemBars(customizationSettings),
+                themeHelper.getStatusBarColor()
+        );
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(themeHelper.getPrimaryColor()));
         getSupportActionBar().setTitle("");
         getSupportActionBar().setDisplayHomeAsUpEnabled(customizationSettings.isShowBackButtonOnFaqPage());
         getSupportActionBar().show();
         toolbar.setBackgroundColor(themeHelper.getToolbarColor());
-        KmUtils.setStatusBarColor(this, themeHelper.getStatusBarColor());
 
         webView = findViewById(R.id.paymentWebView);
         loadingProgressBar = findViewById(R.id.loadingProgress);

--- a/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/activities/LeadCollectionActivity.java
@@ -1,6 +1,7 @@
 package io.kommunicate.ui.kommunicate.activities;
 
 import static io.kommunicate.ui.utils.SentryUtils.configureSentryWithKommunicateUI;
+import static io.sentry.android.core.ContextUtils.getApplicationContext;
 
 import android.app.ProgressDialog;
 import android.os.ResultReceiver;
@@ -17,6 +18,7 @@ import android.widget.TextView;
 
 import io.kommunicate.ui.CustomizationSettings;
 import io.kommunicate.ui.R;
+import io.kommunicate.ui.activities.KmBaseActivity;
 import io.kommunicate.ui.kommunicate.adapters.KmPrechatInputAdapter;
 
 import io.kommunicate.Kommunicate;
@@ -38,7 +40,7 @@ import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
 import io.kommunicate.utils.KmUtils;
 
-public class LeadCollectionActivity extends AppCompatActivity implements View.OnClickListener {
+public class LeadCollectionActivity extends KmBaseActivity implements View.OnClickListener {
     public static final String EMAIL_VALIDATION_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
     public static final String PHONE_NUMBER_VALIDATION_REGEX = "^\\d{10}$";
     public static final String NUMBER_VALIDATION_REGEX = "[0-9]+";
@@ -63,7 +65,12 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             customizationSettings = new CustomizationSettings();
         }
         configureSentryWithKommunicateUI(this, customizationSettings.toString());
-        KmUtils.setStatusBarColor(this, KmThemeHelper.getInstance(this, customizationSettings).getStatusBarColor());
+        KmThemeHelper themeHelper = KmThemeHelper.getInstance(this, customizationSettings);
+        setupEdgeToEdge(
+                customizationSettings,
+                shouldUseLightSystemBars(customizationSettings),
+                themeHelper.getStatusBarColor()
+        );
         if (getIntent() != null) {
             prechatReceiver = getIntent().getParcelableExtra(KmConstants.PRECHAT_RESULT_RECEIVER);
             returnDataMap = getIntent().getBooleanExtra(KmConstants.PRECHAT_RETURN_DATA_MAP, false);
@@ -71,7 +78,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
             if (!TextUtils.isEmpty(preChatModelListJson)) {
                 inputModelList = Arrays.asList((KmPrechatInputModel[]) GsonUtils.getObjectFromJson(preChatModelListJson, KmPrechatInputModel[].class));
                 for (KmPrechatInputModel model : inputModelList) {
-                    if(!TextUtils.isEmpty(model.getField())) {
+                    if (!TextUtils.isEmpty(model.getField())) {
                         if (model.getField().equals(getString(R.string.emailEt))) {
                             model.setValidationRegex(EMAIL_VALIDATION_REGEX);
                         } else if (model.getField().equals(getString(R.string.phoneNumberEt))) {
@@ -115,7 +122,7 @@ public class LeadCollectionActivity extends AppCompatActivity implements View.On
     @Override
     public void onClick(View v) {
         if (prechatInputAdapter != null && prechatInputAdapter.areFieldsValid()) {
-            if(returnDataMap) {
+            if (returnDataMap) {
                 sendPrechatData(prechatInputAdapter.getDataMap());
                 return;
             }

--- a/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/utils/KmThemeHelper.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/utils/KmThemeHelper.java
@@ -175,10 +175,6 @@ public class KmThemeHelper implements KmCallback {
         return toolbarColor;
     }
 
-    /**
-     * @deprecated Deprecated due to Android 15 edge-to-edge migration.
-     */
-    @Deprecated
     public int getStatusBarColor() {
         String colorStr = isDarkModeEnabledForSDK() ? customizationSettings.getStatusBarColor().get(1) : customizationSettings.getStatusBarColor().get(0);
         statusBarColor = parseColorWithDefault(colorStr, getToolbarColor());


### PR DESCRIPTION
## Summary

* Fixed the `NullPointerException` in `MobicomLocationActivity`.
* Initialized `KmThemeHelper` before accessing it during edge-to-edge setup.
* Prevented the location screen from crashing while loading customization settings.

## Root Cause

`themeHelper.getStatusBarColor()` was being called before `KmThemeHelper` was initialized, resulting in a `NullPointerException` when opening the location screen.

## Changes

* Moved `KmThemeHelper` initialization before `setupEdgeToEdge()`.
* Updated the initialization order to ensure `themeHelper` is available before use.

## Testing

* Built and installed the latest debug APK.
* Verified that the location screen no longer crashes.
* Observed a Google Maps authorization issue, which is related to the local Maps API key/SHA configuration and is independent of this SDK fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved edge-to-edge display and status bar theming across conversations, web views, location, lead collection, and full-screen media.
  - Enhanced full-screen image viewing and sharing compatibility.
  - Updated camera and video capture permission handling.

- **Bug Fixes**
  - Improved conversation pagination behavior.
  - Strengthened conversation data filtering and URI permission handling.

- **Chores**
  - Updated Android SDK support to API 35.
  - Released version 2.16.3 with refreshed SDK components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->