### PR TITLE
Fix NPE in MobicomLocationActivity"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api project(':kommunicateui')
-//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.2'
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.3'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/MobicomLocationActivity.java
@@ -107,9 +107,9 @@ public class MobicomLocationActivity extends KmBaseActivity implements OnMapRead
                 }
                 MobicomLocationActivity.this.customizationSettings = customizationSettings;
                 progressBar.setVisibility(View.GONE);
+                themeHelper = KmThemeHelper.getInstance(MobicomLocationActivity.this, customizationSettings);
                 setupEdgeToEdge(customizationSettings, shouldUseLightSystemBars(customizationSettings), themeHelper.getStatusBarColor());
                 configureSentryWithKommunicateUI(MobicomLocationActivity.this, customizationSettings.toString());
-                themeHelper = KmThemeHelper.getInstance(MobicomLocationActivity.this, customizationSettings);
                 toolbar.setBackgroundColor(themeHelper.getToolbarColor());
                 toolbar.setTitleTextColor(themeHelper.getToolbarTitleColor());
                 getSupportActionBar().setDisplayHomeAsUpEnabled(true);


### PR DESCRIPTION
## Summary

* Fixed the `NullPointerException` in `MobicomLocationActivity`.
* Initialized `KmThemeHelper` before accessing it during edge-to-edge setup.
* Prevented the location screen from crashing while loading customization settings.

## Root Cause

`themeHelper.getStatusBarColor()` was being called before `KmThemeHelper` was initialized, resulting in a `NullPointerException` when opening the location screen.

## Changes

* Moved `KmThemeHelper` initialization before `setupEdgeToEdge()`.
* Updated the initialization order to ensure `themeHelper` is available before use.

## Testing

* Built and installed the latest debug APK.
* Verified that the location screen no longer crashes.
* Observed a Google Maps authorization issue, which is related to the local Maps API key/SHA configuration and is independent of this SDK fix.
