### PR TITLE
TDH-4091 Fix concurrent duplicate login requests

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -648,6 +648,10 @@ public class KmConversationHelper {
                         SettingsSharedPreference.getInstance(context).hideChatListOnNotification();
                     }
                     if (callback != null) {
+                        if (channel == null) {
+                            callback.onFailure(new IllegalStateException("Conversation response did not produce a local channel"));
+                            return;
+                        }
                         if (launchConversation) {
                             openParticularConversation(context, isSkipConversationList, channel.getKey(), preFilledMessage, callback);
                         } else {
@@ -660,7 +664,7 @@ public class KmConversationHelper {
                         resultReceiver.send(KmConstants.PRECHAT_RESULT_CODE, null);
                     }
                     if (callback != null) {
-                        callback.onFailure(e.getMessage());
+                        callback.onFailure(e);
                     }
                 }
             }

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -115,6 +115,24 @@ public class Kommunicate {
     private static final String KM_CHAT_BUILDER_CANTBE_NULL = "KmChatBuilder cannot be null";
     private static final String NEEDS_ACTIVITY_CONTEXT = "This method needs Activity context";
     private static final String LAUNCHED_CHAT_LIST = "Successfully launched chat list";
+    private static final Object LOGIN_LOCK = new Object();
+    private static final Map<String, PendingLogin> PENDING_LOGINS = new HashMap<>();
+
+    private static final class PendingLogin {
+        private final List<KMLoginHandler> handlers = new ArrayList<>();
+        private boolean registerForPush;
+
+        private PendingLogin(KMLoginHandler handler, boolean registerForPush) {
+            add(handler, registerForPush);
+        }
+
+        private void add(KMLoginHandler handler, boolean registerForPush) {
+            if (handler != null) {
+                handlers.add(handler);
+            }
+            this.registerForPush |= registerForPush;
+        }
+    }
 
     public static void setFaqPageName(String faqPageName) {
         Kommunicate.faqPageName = faqPageName;
@@ -169,7 +187,7 @@ public class Kommunicate {
                 logout(context, new KMLogoutHandler() {
                     @Override
                     public void onSuccess(Context context) {
-                        login(context, kmUser, getKmLoginHandlerWithPush(handler), null);
+                        startLogin(context, kmUser, handler, null, true);
                     }
 
                     @Override
@@ -180,46 +198,92 @@ public class Kommunicate {
             }
         } else {
 
-            login(context, kmUser, getKmLoginHandlerWithPush(handler), null);
+            startLogin(context, kmUser, handler, null, true);
         }
     }
 
-    private static KMLoginHandler getKmLoginHandlerWithPush(final KMLoginHandler handler) {
-        return new KMLoginHandler() {
-            @Override
-            public void onSuccess(RegistrationResponse registrationResponse, final Context context) {
-                if (handler != null) {
-                    handler.onSuccess(registrationResponse, context);
-                }
-                Kommunicate.registerForPushNotification(context, new KmPushNotificationHandler() {
-                    @Override
-                    public void onSuccess(RegistrationResponse registrationResponse) {
-                        Utils.printLog(context, TAG, "Registered for push notifications : " + registrationResponse);
-                    }
-
-                    @Override
-                    public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-                        Utils.printLog(context, TAG, "Failed to register for push notifications : " + registrationResponse + " \n\n " + exception);
-                    }
-                });
-            }
-
-            @Override
-            public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
-                if (handler != null) {
-                    handler.onFailure(registrationResponse, exception);
-                }
-            }
-        };
+    public static void login(final Context context, final KMUser kmUser, final KMLoginHandler handler, ResultReceiver prechatReceiver) {
+        startLogin(context, kmUser, handler, prechatReceiver, false);
     }
 
-    public static void login(final Context context, final KMUser kmUser, final KMLoginHandler handler, ResultReceiver prechatReceiver) {
+    private static void startLogin(final Context context, final KMUser kmUser, final KMLoginHandler handler,
+                                   ResultReceiver prechatReceiver, boolean registerForPush) {
         if (kmUser != null) {
             kmUser.setHideActionMessages(true);
             kmUser.setSkipDeletedGroups(true);
         }
 
-        KMUserLoginUseCase.Companion.executeWithExecutor(context, kmUser, false, prechatReceiver, handler);
+        final String loginKey = getLoginKey(context, kmUser);
+        synchronized (LOGIN_LOCK) {
+            PendingLogin pendingLogin = PENDING_LOGINS.get(loginKey);
+            if (pendingLogin != null) {
+                pendingLogin.add(handler, registerForPush);
+                Utils.printLog(context, TAG, "Login already in progress for the requested user; joining existing request.");
+                return;
+            }
+            PENDING_LOGINS.put(loginKey, new PendingLogin(handler, registerForPush));
+        }
+
+        KMUserLoginUseCase.Companion.executeWithExecutor(context, kmUser, false, prechatReceiver, new KMLoginHandler() {
+            @Override
+            public void onSuccess(RegistrationResponse registrationResponse, Context callbackContext) {
+                PendingLogin pendingLogin = removePendingLogin(loginKey);
+                if (pendingLogin == null) {
+                    return;
+                }
+                for (KMLoginHandler pendingHandler : pendingLogin.handlers) {
+                    try {
+                        pendingHandler.onSuccess(registrationResponse, callbackContext);
+                    } catch (Exception callbackException) {
+                        Utils.printLog(callbackContext, TAG, "Login success callback failed: " + callbackException);
+                    }
+                }
+                if (pendingLogin.registerForPush) {
+                    registerPushAfterLogin(callbackContext);
+                }
+            }
+
+            @Override
+            public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
+                PendingLogin pendingLogin = removePendingLogin(loginKey);
+                if (pendingLogin == null) {
+                    return;
+                }
+                for (KMLoginHandler pendingHandler : pendingLogin.handlers) {
+                    try {
+                        pendingHandler.onFailure(registrationResponse, exception);
+                    } catch (Exception callbackException) {
+                        Utils.printLog(context, TAG, "Login failure callback failed: " + callbackException);
+                    }
+                }
+            }
+        });
+    }
+
+    private static String getLoginKey(Context context, KMUser kmUser) {
+        String applicationKey = KommunicateSettings.getInstance(context).getApplicationKey();
+        String userId = kmUser != null ? kmUser.getUserId() : null;
+        return String.valueOf(applicationKey) + '\u0000' + String.valueOf(userId);
+    }
+
+    private static PendingLogin removePendingLogin(String loginKey) {
+        synchronized (LOGIN_LOCK) {
+            return PENDING_LOGINS.remove(loginKey);
+        }
+    }
+
+    private static void registerPushAfterLogin(final Context context) {
+        Kommunicate.registerForPushNotification(context, new KmPushNotificationHandler() {
+            @Override
+            public void onSuccess(RegistrationResponse registrationResponse) {
+                Utils.printLog(context, TAG, "Registered for push notifications : " + registrationResponse);
+            }
+
+            @Override
+            public void onFailure(RegistrationResponse registrationResponse, Exception exception) {
+                Utils.printLog(context, TAG, "Failed to register for push notifications : " + registrationResponse + " \n\n " + exception);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Fix concurrent duplicate login requests

### Summary

- Added thread-safe single-flight handling for concurrent login calls.
- Simultaneous login calls for the same application and user now share one server request.
- All waiting callers receive the same success or failure result.
- Pending login state is cleared after both success and failure.
- Push registration runs only once.
- Improved conversation failure handling to prevent null errors.

### Root cause

Multiple login calls could execute before the first login completed. Each call observed that the user was logged out and sent an independent registration request. This created duplicate backend user records and later caused conversation creation to fail with `NonUniqueResultException`.

### Testing

- Reproduced the issue by sending three simultaneous login calls.
- Confirmed three duplicate backend records were created.
- Confirmed conversation creation returned HTTP 500 with `NonUniqueResultException`.
- Enabled the fix and repeated the test.
- Verified only one login request reached the backend.
- Verified all three callers received callbacks.
- Verified no `NonUniqueResultException` occurred.
- Verified conversation creation succeeded.
- Confirmed the project builds successfully.

### Compatibility

No client implementation changes are required. Existing `Kommunicate.login(...)` APIs and callbacks remain unchanged.

### Backend follow-up

Existing duplicate user records must be cleaned separately. Backend uniqueness and idempotency protection is also recommended.