### PR TITLE
Ensure exactly-once conversation callbacks

### DIFF
--- a/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
+++ b/kommunicate/src/main/java/io/kommunicate/KmConversationHelper.java
@@ -640,32 +640,32 @@ public class KmConversationHelper {
         return new KmStartConversationHandler() {
             @Override
             public void onSuccess(Channel channel, Context context) {
+                if (resultReceiver != null) {
+                    resultReceiver.send(KmConstants.PRECHAT_RESULT_CODE, null);
+                }
+                if (callback != null && channel == null) {
+                    callback.onFailure(new IllegalStateException("Conversation response did not produce a local channel"));
+                    return;
+                }
+
                 try {
-                    if (resultReceiver != null) {
-                        resultReceiver.send(KmConstants.PRECHAT_RESULT_CODE, null);
-                    }
                     if (isSkipConversationList) {
                         SettingsSharedPreference.getInstance(context).hideChatListOnNotification();
                     }
-                    if (callback != null) {
-                        if (channel == null) {
-                            callback.onFailure(new IllegalStateException("Conversation response did not produce a local channel"));
-                            return;
-                        }
-                        if (launchConversation) {
-                            openParticularConversation(context, isSkipConversationList, channel.getKey(), preFilledMessage, callback);
-                        } else {
-                            callback.onSuccess(channel.getKey());
-                        }
+                    if (callback != null && launchConversation) {
+                        openParticularConversation(context, isSkipConversationList, channel.getKey(), preFilledMessage, callback);
+                        return;
                     }
                 } catch (Exception e) {
                     e.printStackTrace();
-                    if (resultReceiver != null) {
-                        resultReceiver.send(KmConstants.PRECHAT_RESULT_CODE, null);
-                    }
                     if (callback != null) {
                         callback.onFailure(e);
                     }
+                    return;
+                }
+
+                if (callback != null) {
+                    callback.onSuccess(channel.getKey());
                 }
             }
 

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -118,17 +118,27 @@ public class Kommunicate {
     private static final Object LOGIN_LOCK = new Object();
     private static final Map<String, PendingLogin> PENDING_LOGINS = new HashMap<>();
 
+    private static final class PendingLoginCallback {
+        private final KMLoginHandler handler;
+        private final Context context;
+
+        private PendingLoginCallback(KMLoginHandler handler, Context context) {
+            this.handler = handler;
+            this.context = context;
+        }
+    }
+
     private static final class PendingLogin {
-        private final List<KMLoginHandler> handlers = new ArrayList<>();
+        private final List<PendingLoginCallback> callbacks = new ArrayList<>();
         private boolean registerForPush;
 
-        private PendingLogin(KMLoginHandler handler, boolean registerForPush) {
-            add(handler, registerForPush);
+        private PendingLogin(KMLoginHandler handler, Context context, boolean registerForPush) {
+            add(handler, context, registerForPush);
         }
 
-        private void add(KMLoginHandler handler, boolean registerForPush) {
+        private void add(KMLoginHandler handler, Context context, boolean registerForPush) {
             if (handler != null) {
-                handlers.add(handler);
+                callbacks.add(new PendingLoginCallback(handler, context));
             }
             this.registerForPush |= registerForPush;
         }
@@ -217,11 +227,11 @@ public class Kommunicate {
         synchronized (LOGIN_LOCK) {
             PendingLogin pendingLogin = PENDING_LOGINS.get(loginKey);
             if (pendingLogin != null) {
-                pendingLogin.add(handler, registerForPush);
+                pendingLogin.add(handler, context, registerForPush);
                 Utils.printLog(context, TAG, "Login already in progress for the requested user; joining existing request.");
                 return;
             }
-            PENDING_LOGINS.put(loginKey, new PendingLogin(handler, registerForPush));
+            PENDING_LOGINS.put(loginKey, new PendingLogin(handler, context, registerForPush));
         }
 
         KMUserLoginUseCase.Companion.executeWithExecutor(context, kmUser, false, prechatReceiver, new KMLoginHandler() {
@@ -231,11 +241,11 @@ public class Kommunicate {
                 if (pendingLogin == null) {
                     return;
                 }
-                for (KMLoginHandler pendingHandler : pendingLogin.handlers) {
+                for (PendingLoginCallback pendingCallback : pendingLogin.callbacks) {
                     try {
-                        pendingHandler.onSuccess(registrationResponse, callbackContext);
+                        pendingCallback.handler.onSuccess(registrationResponse, pendingCallback.context);
                     } catch (Exception callbackException) {
-                        Utils.printLog(callbackContext, TAG, "Login success callback failed: " + callbackException);
+                        Utils.printLog(pendingCallback.context, TAG, "Login success callback failed: " + callbackException);
                     }
                 }
                 if (pendingLogin.registerForPush) {
@@ -249,11 +259,11 @@ public class Kommunicate {
                 if (pendingLogin == null) {
                     return;
                 }
-                for (KMLoginHandler pendingHandler : pendingLogin.handlers) {
+                for (PendingLoginCallback pendingCallback : pendingLogin.callbacks) {
                     try {
-                        pendingHandler.onFailure(registrationResponse, exception);
+                        pendingCallback.handler.onFailure(registrationResponse, exception);
                     } catch (Exception callbackException) {
-                        Utils.printLog(context, TAG, "Login failure callback failed: " + callbackException);
+                        Utils.printLog(pendingCallback.context, TAG, "Login failure callback failed: " + callbackException);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Follow-up fixes for PR review comments:

- Narrowed the SDK `try/catch` scope.
- Prevented client `onSuccess()` exceptions from triggering `onFailure()`.
- Ensured exactly-once callback delivery.
- Prevented duplicate `ResultReceiver` delivery.
- Preserved each queued login handler’s original `Context`.
- Ensured joined login callbacks receive the context supplied by their respective callers.

## Testing

- Verified compilation successfully.
- Confirmed existing conversation success and failure handling remains intact.
- Confirmed concurrent login callback handling continues to work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation-start callback handling to provide more consistent success and failure results.
  * Fixed in-progress login requests so each callback receives the correct associated context.
  * Improved error reporting when multiple login callbacks are completed together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->