### PR TITLE
TDH-4187 Enforce SSL pinning for Kommunicate domains

### DIFF
--- a/app/src/release/res/xml/network_security_config.xml
+++ b/app/src/release/res/xml/network_security_config.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">gY8gSDmi6lg/wV1MbM3FzNMYrcX6EKseYfJg7QnA02A=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">cqN64LYMqSbYAlnj5gqix01wTHc4f+IFGOe68iV7LHY=</pin>
+            <pin digest="SHA-256">LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-in.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">1zJGg1EdjGEFdxqpA0bNZoXNomD9oXfxci/SmbWp7e0=</pin>
+            <pin digest="SHA-256">brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">MpB2iHEUO7nmKSdp/YuWdkjSP9hp7Ax7P/9c9jeGQO4=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">eWPDImElk5nVbsn19Uz9VXDUVfPispeX5ZlINItM/7c=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">w/h1ivN8L5msp4gPmxqFr2qqqb+dvxG+XGd8XDatx+s=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>

--- a/docs/SSL_PIN_ROTATION.md
+++ b/docs/SSL_PIN_ROTATION.md
@@ -1,0 +1,73 @@
+# SSL public-key pin rotation
+
+The Android SDK enforces SPKI SHA-256 pins for the explicitly inventoried Kommunicate API and chat hosts in release builds. Android's normal CA, certificate-validity, and hostname checks run before the additional pin check. Unlisted hosts, external attachments, customer overrides, Google, and AWS URLs are not assigned Kommunicate pins and continue to use platform TLS validation.
+
+Release-only Network Security Configuration files repeat the same exact-host inventory so Android-managed HTTP stacks, including Glide and WebView requests that honor the application configuration, receive the same pins. Debug builds retain the unpinned system-CA-only configuration. Consuming applications that replace `android:networkSecurityConfig` must merge these domain pin sets into their own release configuration.
+
+## Pin roles
+
+- Each entry in `pinsByHost` in `SSLPinningConfig.kt` contains the currently deployed leaf public-key pin and that host's issuer backup pin.
+- Issuer backup pins allow a leaf certificate to be renewed or replaced under the same approved issuer without disabling supported app versions.
+- A pin is a public identifier, not a private key or secret. Never add certificate private keys to this repository.
+
+## Verified host inventory
+
+Verification was performed from the TLS chains served on 2026-08-26. Expiry timestamps are UTC.
+
+| Host | Role | Certificate subject | Certificate expiry | SPKI SHA-256 |
+| --- | --- | --- | --- | --- |
+| `api.kommunicate.io` | Primary | `CN=api.kommunicate.io` | 2026-10-18 13:41:48 | `TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY=` |
+| `api.kommunicate.io` | Backup | `CN=WR3, O=Google Trust Services, C=US` | 2029-02-20 14:00:00 | `OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=` |
+| `api-test.kommunicate.io` | Primary | `CN=api-test.kommunicate.io` | 2026-10-18 15:14:06 | `gY8gSDmi6lg/wV1MbM3FzNMYrcX6EKseYfJg7QnA02A=` |
+| `api-test.kommunicate.io` | Backup | `CN=WR3, O=Google Trust Services, C=US` | 2029-02-20 14:00:00 | `OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=` |
+| `api-eu.kommunicate.io` | Primary | `CN=api-eu.kommunicate.io` | 2026-10-21 15:01:26 | `cqN64LYMqSbYAlnj5gqix01wTHc4f+IFGOe68iV7LHY=` |
+| `api-eu.kommunicate.io` | Backup | `CN=YR1, O=Let's Encrypt, C=US` | 2028-09-02 23:59:59 | `LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w=` |
+| `api-in.kommunicate.io` | Primary | `CN=api-in.kommunicate.io` | 2026-10-20 13:45:53 | `1zJGg1EdjGEFdxqpA0bNZoXNomD9oXfxci/SmbWp7e0=` |
+| `api-in.kommunicate.io` | Backup | `CN=YE1, O=Let's Encrypt, C=US` | 2028-09-02 23:59:59 | `brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=` |
+| `chat.kommunicate.io` | Primary | `CN=chat.kommunicate.io` | 2026-10-10 01:19:47 | `MpB2iHEUO7nmKSdp/YuWdkjSP9hp7Ax7P/9c9jeGQO4=` |
+| `chat.kommunicate.io` | Backup | `CN=WR3, O=Google Trust Services, C=US` | 2029-02-20 14:00:00 | `OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=` |
+| `chat-test.kommunicate.io` | Primary | `CN=chat-test.kommunicate.io` | 2026-10-07 08:18:46 | `eWPDImElk5nVbsn19Uz9VXDUVfPispeX5ZlINItM/7c=` |
+| `chat-test.kommunicate.io` | Backup | `CN=WR3, O=Google Trust Services, C=US` | 2029-02-20 14:00:00 | `OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=` |
+| `chat-eu.kommunicate.io` | Primary | `CN=chat-eu.kommunicate.io` | 2026-10-10 15:29:14 | `w/h1ivN8L5msp4gPmxqFr2qqqb+dvxG+XGd8XDatx+s=` |
+| `chat-eu.kommunicate.io` | Backup | `CN=WR3, O=Google Trust Services, C=US` | 2029-02-20 14:00:00 | `OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=` |
+
+### Retired Canada endpoint
+
+`api-ca.kommunicate.io` is officially retired from this SDK. On 2026-08-26 it returned authoritative NXDOMAIN responses from both Google Public DNS and Cloudflare DNS, and the public SDK server configuration supports only the default and EU environments. The legacy API, dashboard, and Help Center CA entries were removed from `km_urls.xml`. `api-ca.kommunicate.io` remains in the programmatic `retiredHosts` denylist so an application carrying an old manual configuration fails closed instead of making an unpinned connection.
+
+Do not re-enable the Canada endpoint until Infrastructure provides a supported resolving hostname, its served certificate chain is verified, and both primary and backup pins are added to this inventory, `pinsByHost`, and every release Network Security Configuration.
+
+## Planned rotation
+
+1. At least one SDK release before changing the server key or issuer, obtain the new certificate chain from Infrastructure.
+2. Calculate the SHA-256 hash of the DER-encoded SubjectPublicKeyInfo for the new leaf and issuer keys.
+3. Add the new values to the relevant host's `PinSet` in `pinsByHost` and to every release Network Security Configuration, retaining the currently deployed values.
+4. Run the pinning unit tests and the release MITM test described below, then publish the SDK.
+5. Wait until the agreed minimum supported SDK adoption threshold is reached.
+6. Deploy the new server certificate and verify login, conversations, uploads, downloads, and notification media with both the previous and latest supported SDK releases.
+7. Remove obsolete leaf pins only in a later SDK release. Always retain at least one separately managed rotation pin.
+
+Do not deploy a certificate chain for which no SPKI in a supported app's pin set is present. If an emergency rotation cannot use a pre-shipped pin, restore the previous certificate while a compatible SDK release is distributed; do not add a remote or release-mode pinning bypass.
+
+## Generate and verify a pin
+
+For each hostname, save every certificate in the served chain separately and calculate:
+
+```shell
+openssl x509 -in certificate.pem -pubkey -noout \
+  | openssl pkey -pubin -outform DER \
+  | openssl dgst -sha256 -binary \
+  | openssl base64 -A
+```
+
+Record the hostname, certificate subject, expiry, pin role, verification date, and Infrastructure owner in the rotation ticket. Review pins before certificate expiry and whenever the CDN, load balancer, CA, or regional endpoint changes.
+
+## Release verification
+
+1. Build the release variant and inspect its merged manifest. It must use `network_security_config`, disallow cleartext traffic, trust only system CAs, and contain no debug override or user CA.
+2. On a non-rooted test device, install a normal user CA from an HTTPS interception proxy.
+3. Confirm login and Kommunicate API requests fail with a generic connection error while interception is active.
+4. Remove the proxy and confirm login, conversations, message send/receive, attachment upload/download, thumbnails, and notification media succeed.
+5. Confirm customer-controlled and presigned storage URLs still work through normal platform TLS validation.
+
+Rooted-device/runtime-instrumentation tools can bypass client-side checks. This control increases resistance and does not claim to prevent every bypass on a compromised device.

--- a/docs/SSL_PIN_ROTATION.md
+++ b/docs/SSL_PIN_ROTATION.md
@@ -7,8 +7,15 @@ Release-only Network Security Configuration files repeat the same exact-host inv
 ## Pin roles
 
 - Each entry in `pinsByHost` in `SSLPinningConfig.kt` contains the currently deployed leaf public-key pin and that host's issuer backup pin.
-- Issuer backup pins allow a leaf certificate to be renewed or replaced under the same approved issuer without disabling supported app versions.
+- Every backup pin was verified against the issuer/intermediate certificate in the host's served chain on 2026-08-26. It allows the server to deploy a renewed or re-keyed leaf certificate without an app release only while the new chain continues to include that pinned issuer key.
+- These are issuer fallback pins, not dormant Kommunicate-controlled leaf keys. Changing CA or intermediate requires the replacement leaf or issuer pin to be shipped in an SDK release before the server chain changes.
 - A pin is a public identifier, not a private key or secret. Never add certificate private keys to this repository.
+
+## Pin expiration policy
+
+The release pin sets intentionally do not declare an expiration date. Android disables pinning after that date, which avoids stranding an old app but also makes pinning fail open. This SDK applies the same pin inventory through both Network Security Configuration and programmatic verification, so an XML-only expiration would provide inconsistent behavior and would not prevent programmatic connections from failing.
+
+The selected policy is to fail closed and preserve the VAPT control. Availability is handled through the verified issuer fallback pins and the staged rotation procedure below. Before changing an issuer/intermediate, Infrastructure must provide the new chain and a compatible SDK must be released and adopted. If the organization later chooses a fail-open expiration policy, the same reviewed deadline must be implemented in both enforcement paths and covered by release tests.
 
 ## Verified host inventory
 
@@ -45,7 +52,7 @@ Do not re-enable the Canada endpoint until Infrastructure provides a supported r
 4. Run the pinning unit tests and the release MITM test described below, then publish the SDK.
 5. Wait until the agreed minimum supported SDK adoption threshold is reached.
 6. Deploy the new server certificate and verify login, conversations, uploads, downloads, and notification media with both the previous and latest supported SDK releases.
-7. Remove obsolete leaf pins only in a later SDK release. Always retain at least one separately managed rotation pin.
+7. Remove obsolete pins only in a later SDK release, while retaining a verified fallback for the next approved certificate chain.
 
 Do not deploy a certificate chain for which no SPKI in a supported app's pin set is present. If an emergency rotation cannot use a pre-shipped pin, restore the previous certificate while a compatible SDK release is distributed; do not add a remote or release-mode pinning bypass.
 

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -31,7 +31,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField "boolean", "SSL_PINNING_ENFORCED", "false"
+        }
         release {
+            buildConfigField "boolean", "SSL_PINNING_ENFORCED", "true"
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
@@ -42,6 +46,12 @@ android {
     }
     buildFeatures {
         buildConfig true
+    }
+}
+
+androidComponents {
+    beforeVariants(selector().withBuildType("release")) { variantBuilder ->
+        variantBuilder.enableUnitTest = true
     }
 }
 
@@ -59,6 +69,9 @@ dependencies {
     api libs.gson
     api libs.silicompressor
     api libs.sentry.android
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation "org.mockito:mockito-core:5.12.0"
     api(libs.isoparser) {
         exclude(
                 group : "org.aspectj",

--- a/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
+++ b/kommunicate/src/main/java/io/kommunicate/Kommunicate.java
@@ -166,6 +166,10 @@ public class Kommunicate {
         init(context, applicationKey, true);
     }
 
+    /**
+     * Release builds always enforce SSL pinning. This setting is retained for debug builds.
+     */
+    @Deprecated
     public static void enableSSLPinning(boolean isEnable) {
         KmAppSettingPreferences.setSSLPinningEnabled(isEnable);
     }

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/HttpRequestUtils.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/HttpRequestUtils.java
@@ -112,7 +112,7 @@ public class HttpRequestUtils {
             }
             url = new URL(urlString);
             connection = (HttpsURLConnection) url.openConnection();
-            connection.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+            SSLPinningConfig.configure(connection);
             connection.setRequestMethod(isPatchRequest ? PATCH : POST);
             connection.setDoInput(true);
             connection.setDoOutput(true);
@@ -186,7 +186,7 @@ public class HttpRequestUtils {
         try {
             url = new URL(urlString);
             connection = (HttpsURLConnection) url.openConnection();
-            connection.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+            SSLPinningConfig.configure(connection);
             connection.setInstanceFollowRedirects(true);
             connection.setRequestMethod("GET");
             connection.setUseCaches(false);

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/MobiComKitClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/MobiComKitClientService.java
@@ -127,7 +127,7 @@ public class MobiComKitClientService {
             throw new IOException(NOT_HTTP_CONN);
 
         try {
-            conn.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+            SSLPinningConfig.configure(conn);
             conn.setAllowUserInteraction(false);
             conn.setInstanceFollowRedirects(true);
             conn.setRequestMethod("GET");

--- a/kommunicate/src/main/java/io/kommunicate/devkit/api/attachment/MultipartUtility.java
+++ b/kommunicate/src/main/java/io/kommunicate/devkit/api/attachment/MultipartUtility.java
@@ -47,7 +47,7 @@ public class MultipartUtility {
 
         URL url = new URL(requestURL);
         httpConn = (HttpsURLConnection) url.openConnection();
-        httpConn.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+        SSLPinningConfig.configure(httpConn);
         httpConn.setUseCaches(false);
         httpConn.setDoOutput(true);
         httpConn.setDoInput(true);
@@ -63,7 +63,7 @@ public class MultipartUtility {
         isUploadOveridden = true;
         URL url = new URL(requestURL);
         httpConn = (HttpsURLConnection) url.openConnection();
-        httpConn.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+        SSLPinningConfig.configure(httpConn);
         httpConn.setUseCaches(false);
         httpConn.setDoOutput(true);
         httpConn.setDoInput(true);

--- a/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
+++ b/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
@@ -128,4 +128,7 @@ object SSLPinningConfig {
     @JvmStatic
     internal fun hasBackupPin(hostname: String, pin: String): Boolean =
         pinsForHost(hostname)?.backup == pin
+
+    internal fun pinInventory(): Map<String, Set<String>> =
+        pinsByHost.mapValues { (_, pinSet) -> pinSet.all }
 }

--- a/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
+++ b/kommunicate/src/main/java/io/kommunicate/network/SSLPinningConfig.kt
@@ -1,88 +1,131 @@
 package io.kommunicate.network
 
-import android.annotation.SuppressLint
 import android.util.Base64
 import io.kommunicate.BuildConfig
 import io.kommunicate.utils.KmAppSettingPreferences
-import io.kommunicate.utils.KmUtils
-import java.security.KeyManagementException
 import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
-import java.security.cert.CertificateException
+import java.security.PublicKey
 import java.security.cert.X509Certificate
-import javax.net.ssl.SSLContext
-import javax.net.ssl.SSLSocketFactory
-import javax.net.ssl.TrustManager
-import javax.net.ssl.X509TrustManager
+import javax.net.ssl.HttpsURLConnection
+import javax.net.ssl.HostnameVerifier
 
+/** Configures public-key pinning without replacing Android's platform trust manager. */
 object SSLPinningConfig {
 
-    @JvmStatic
-    @Synchronized
-    fun createPinnedSSLSocketFactory(): SSLSocketFactory {
-        if(KmUtils.isDeviceRooted) {
-            throw CertificateException("Unable to Establish Connection, Device is rooted.")
-        }
-
-        val expectedPublicKeyHash = arrayOf(
-            BuildConfig.apiKommunicateIo,
-            BuildConfig.apiEuKommunicateIo,
-            BuildConfig.apiCaKommunicateIo,
-            BuildConfig.apiTestKommuncateIo,
-            BuildConfig.kommunicateIo,
-            BuildConfig.apiInKommunicateIo,
-            BuildConfig.kommunicateAWS
-        )
-
-        val trustManager: TrustManager = @SuppressLint("CustomX509TrustManager")
-        object : X509TrustManager {
-            @Throws(CertificateException::class)
-            override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
-                // No client side authentication implemented
-            }
-
-            @Throws(CertificateException::class)
-            override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
-                if (chain.isEmpty()) {
-                    throw CertificateException("Certificate chain is empty")
-                }
-
-                val certificate = chain[0]
-                val publicKeyBytes = certificate.publicKey.encoded
-
-                val md: MessageDigest = try {
-                    MessageDigest.getInstance("SHA-256")
-                } catch (e: NoSuchAlgorithmException) {
-                    e.printStackTrace()
-                    throw RuntimeException(e)
-                }
-
-                val publicKeyHash = md.digest(publicKeyBytes)
-                val publicKeyHashBase64 = Base64.encodeToString(publicKeyHash, Base64.NO_WRAP)
-
-                val isSSLPinningEnabled = KmAppSettingPreferences.isSSLPinningEnabled
-                if (isSSLPinningEnabled && !expectedPublicKeyHash.contains(publicKeyHashBase64)) {
-                    throw CertificateException("Public key pinning failure")
-                }
-            }
-
-            override fun getAcceptedIssuers(): Array<X509Certificate?> {
-                return arrayOfNulls(0)
-            }
-        }
-
-        var sslContext: SSLContext? = null
-        try {
-            sslContext = SSLContext.getInstance("TLS")
-            sslContext.init(null, arrayOf(trustManager), null)
-        } catch (e: NoSuchAlgorithmException) {
-            e.printStackTrace()
-            throw RuntimeException(e)
-        } catch (e: KeyManagementException) {
-            e.printStackTrace()
-            throw RuntimeException(e)
-        }
-
-        return sslContext.socketFactory
+    internal data class PinSet(val primary: String, val backup: String) {
+        val all = setOf(primary, backup)
     }
+
+    /* Verified 2026-08-26. See docs/SSL_PIN_ROTATION.md for certificate metadata. */
+    private val pinsByHost = mapOf(
+        "api.kommunicate.io" to PinSet(
+            "TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY=",
+            "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+        ),
+        "api-test.kommunicate.io" to PinSet(
+            "gY8gSDmi6lg/wV1MbM3FzNMYrcX6EKseYfJg7QnA02A=",
+            "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+        ),
+        "api-eu.kommunicate.io" to PinSet(
+            "cqN64LYMqSbYAlnj5gqix01wTHc4f+IFGOe68iV7LHY=",
+            "LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w="
+        ),
+        "api-in.kommunicate.io" to PinSet(
+            "1zJGg1EdjGEFdxqpA0bNZoXNomD9oXfxci/SmbWp7e0=",
+            "brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4="
+        ),
+        "chat.kommunicate.io" to PinSet(
+            "MpB2iHEUO7nmKSdp/YuWdkjSP9hp7Ax7P/9c9jeGQO4=",
+            "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+        ),
+        "chat-test.kommunicate.io" to PinSet(
+            "eWPDImElk5nVbsn19Uz9VXDUVfPispeX5ZlINItM/7c=",
+            "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+        ),
+        "chat-eu.kommunicate.io" to PinSet(
+            "w/h1ivN8L5msp4gPmxqFr2qqqb+dvxG+XGd8XDatx+s=",
+            "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+        )
+    )
+
+    /* Retired legacy endpoints remain denied so old manual configurations fail closed. */
+    private val retiredHosts = setOf("api-ca.kommunicate.io")
+
+    /**
+     * Platform CA/validity checks still run because the default socket factory is retained.
+     * The wrapped hostname verifier first performs Android's hostname check and then pinning.
+     */
+    @JvmStatic
+    fun configure(connection: HttpsURLConnection) {
+        if (!isPinningEnabled()) return
+
+        connection.hostnameVerifier = createHostnameVerifier(
+            HttpsURLConnection.getDefaultHostnameVerifier()
+        )
+    }
+
+    internal fun createHostnameVerifier(
+        platformHostnameVerifier: HostnameVerifier,
+        hostPins: Map<String, PinSet> = pinsByHost,
+        blockedHosts: Set<String> = retiredHosts
+    ): HostnameVerifier {
+        return HostnameVerifier { hostname, session ->
+            if (!platformHostnameVerifier.verify(hostname, session)) {
+                return@HostnameVerifier false
+            }
+            val normalizedHost = normalizeHost(hostname)
+            if (normalizedHost in blockedHosts) {
+                return@HostnameVerifier false
+            }
+            val pins = hostPins[normalizedHost]
+            if (pins == null) {
+                return@HostnameVerifier true
+            }
+
+            try {
+                session.peerCertificates
+                    .filterIsInstance<X509Certificate>()
+                    .any { certificate -> publicKeyPin(certificate) in pins.all }
+            } catch (_: Exception) {
+                false
+            }
+        }
+    }
+
+    @JvmStatic
+    internal fun isPinnedHost(hostname: String): Boolean {
+        return pinsForHost(hostname) != null
+    }
+
+    @JvmStatic
+    internal fun isRetiredHost(hostname: String): Boolean =
+        normalizeHost(hostname) in retiredHosts
+
+    private fun pinsForHost(hostname: String): PinSet? =
+        pinsByHost[normalizeHost(hostname)]
+
+    private fun normalizeHost(hostname: String): String = hostname.lowercase().trimEnd('.')
+
+    internal fun isPinningEnabled(): Boolean {
+        return BuildConfig.SSL_PINNING_ENFORCED || KmAppSettingPreferences.isSSLPinningEnabled
+    }
+
+    @JvmStatic
+    internal fun publicKeyPin(certificate: X509Certificate): String {
+        return publicKeyPin(certificate.publicKey)
+    }
+
+    @JvmStatic
+    internal fun publicKeyPin(publicKey: PublicKey): String {
+        val hash = MessageDigest.getInstance("SHA-256").digest(publicKey.encoded)
+        return Base64.encodeToString(hash, Base64.NO_WRAP)
+    }
+
+    @JvmStatic
+    internal fun hasPrimaryPin(hostname: String, pin: String): Boolean =
+        pinsForHost(hostname)?.primary == pin
+
+    @JvmStatic
+    internal fun hasBackupPin(hostname: String, pin: String): Boolean =
+        pinsForHost(hostname)?.backup == pin
 }

--- a/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmClientService.java
@@ -131,9 +131,14 @@ public class KmClientService extends MobiComKitClientService {
             return null;
         }
 
-        return context.getResources()
-                .getStringArray(context.getResources()
-                        .getIdentifier(urlMapper, "array", context.getPackageName()))[baseUrlList.indexOf(getKmBaseUrl())];
+        int baseUrlIndex = baseUrlList.indexOf(getKmBaseUrl());
+        int mappedUrlResource = context.getResources().getIdentifier(urlMapper, "array", context.getPackageName());
+        if (baseUrlIndex < 0 || mappedUrlResource == 0) {
+            return null;
+        }
+
+        String[] mappedUrls = context.getResources().getStringArray(mappedUrlResource);
+        return baseUrlIndex < mappedUrls.length ? mappedUrls[baseUrlIndex] : null;
     }
 
     /**

--- a/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmHttpClient.java
@@ -45,7 +45,7 @@ public class KmHttpClient {
             }
             url = new URL(urlString);
             connection = (HttpsURLConnection) url.openConnection();
-            connection.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+            SSLPinningConfig.configure(connection);
             connection.setRequestMethod(POST);
             connection.setDoInput(true);
             connection.setDoOutput(true);
@@ -112,7 +112,7 @@ public class KmHttpClient {
         try {
             url = new URL(urlString);
             connection = (HttpsURLConnection) url.openConnection();
-            connection.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+            SSLPinningConfig.configure(connection);
             connection.setInstanceFollowRedirects(true);
             connection.setRequestMethod(GET);
             connection.setUseCaches(false);

--- a/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
+++ b/kommunicate/src/main/java/io/kommunicate/services/KmUserClientService.java
@@ -513,7 +513,7 @@ public class KmUserClientService extends UserClientService {
     private HttpURLConnection createAndGetConnectionObjectForMethodGet(String urlString, String contentType, String accept) throws Exception {
         URL url = new URL(urlString);
         HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-        connection.setSSLSocketFactory(SSLPinningConfig.createPinnedSSLSocketFactory());
+        SSLPinningConfig.configure(connection);
         connection.setInstanceFollowRedirects(true);
         connection.setRequestMethod(GET);
         connection.setUseCaches(false);

--- a/kommunicate/src/main/res/values/km_urls.xml
+++ b/kommunicate/src/main/res/values/km_urls.xml
@@ -4,19 +4,16 @@
     <string-array name="km_base_url">
         <item>https://api.kommunicate.io</item>
         <item>https://api-test.kommunicate.io</item>
-        <item>https://api-ca.kommunicate.io</item>
     </string-array>
 
     <string-array name="km_dashboard_url">
         <item>https://dashboard.kommunicate.io</item>
         <item>https://dashboard-test.kommunicate.io</item>
-        <item>https://dashboard-ca.kommunicate.io</item>
     </string-array>
 
     <string-array name="km_helpcenter_url">
         <item>https://helpcenter.kommunicate.io</item>
         <item>https://helpcenter-test.kommunicate.io</item>
-        <item>https://helpcenter-ca.kommunicate.io</item>
     </string-array>
     <string-array name="km_skip_encryption_endpoints">
         <item>/rest/ws/register/client</item>

--- a/kommunicate/src/main/res/values/km_urls.xml
+++ b/kommunicate/src/main/res/values/km_urls.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-   //Note: Adding any new url array , Follow the same order.
+    <!-- These arrays are index-aligned. Add every supported API base URL to all three. -->
     <string-array name="km_base_url">
         <item>https://api.kommunicate.io</item>
         <item>https://api-test.kommunicate.io</item>
+        <item>https://api-eu.kommunicate.io</item>
+        <item>https://api-in.kommunicate.io</item>
     </string-array>
 
     <string-array name="km_dashboard_url">
         <item>https://dashboard.kommunicate.io</item>
         <item>https://dashboard-test.kommunicate.io</item>
+        <item>https://dashboard.kommunicate.io</item>
+        <item>https://dashboard.kommunicate.io</item>
     </string-array>
 
     <string-array name="km_helpcenter_url">
         <item>https://helpcenter.kommunicate.io</item>
         <item>https://helpcenter-test.kommunicate.io</item>
+        <item>https://helpcenter.kommunicate.io</item>
+        <item>https://helpcenter.kommunicate.io</item>
     </string-array>
     <string-array name="km_skip_encryption_endpoints">
         <item>/rest/ws/register/client</item>

--- a/kommunicate/src/release/res/xml/network_security_config.xml
+++ b/kommunicate/src/release/res/xml/network_security_config.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">gY8gSDmi6lg/wV1MbM3FzNMYrcX6EKseYfJg7QnA02A=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">cqN64LYMqSbYAlnj5gqix01wTHc4f+IFGOe68iV7LHY=</pin>
+            <pin digest="SHA-256">LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-in.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">1zJGg1EdjGEFdxqpA0bNZoXNomD9oXfxci/SmbWp7e0=</pin>
+            <pin digest="SHA-256">brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">MpB2iHEUO7nmKSdp/YuWdkjSP9hp7Ax7P/9c9jeGQO4=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">eWPDImElk5nVbsn19Uz9VXDUVfPispeX5ZlINItM/7c=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">w/h1ivN8L5msp4gPmxqFr2qqqb+dvxG+XGd8XDatx+s=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>

--- a/kommunicate/src/test/java/io/kommunicate/network/SSLPinningConfigTest.kt
+++ b/kommunicate/src/test/java/io/kommunicate/network/SSLPinningConfigTest.kt
@@ -1,0 +1,133 @@
+package io.kommunicate.network
+
+import android.util.Base64
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.robolectric.RobolectricTestRunner
+import java.security.KeyPairGenerator
+import java.security.MessageDigest
+import java.security.PublicKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLSession
+
+@RunWith(RobolectricTestRunner::class)
+class SSLPinningConfigTest {
+
+    @Test
+    fun pinsOnlyKommunicateControlledHosts() {
+        assertTrue(SSLPinningConfig.isPinnedHost("api.kommunicate.io"))
+        assertTrue(SSLPinningConfig.isPinnedHost("CHAT-EU.KOMMUNICATE.IO."))
+        assertFalse(SSLPinningConfig.isPinnedHost("api-ca.kommunicate.io"))
+        assertTrue(SSLPinningConfig.isRetiredHost("API-CA.KOMMUNICATE.IO."))
+        assertFalse(SSLPinningConfig.isPinnedHost("unknown.kommunicate.io"))
+        assertFalse(SSLPinningConfig.isPinnedHost("kommunicate.io.attacker.example"))
+        assertFalse(SSLPinningConfig.isPinnedHost("storage.googleapis.com"))
+        assertFalse(SSLPinningConfig.isPinnedHost("s3.amazonaws.com"))
+    }
+
+    @Test
+    fun primaryAndBackupPinsAreDistinct() {
+        val primary = "TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY="
+        val backup = "OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE="
+
+        assertTrue(SSLPinningConfig.hasPrimaryPin("api.kommunicate.io", primary))
+        assertFalse(SSLPinningConfig.hasBackupPin("api.kommunicate.io", primary))
+        assertTrue(SSLPinningConfig.hasBackupPin("api.kommunicate.io", backup))
+        assertFalse(SSLPinningConfig.hasPrimaryPin("api.kommunicate.io", backup))
+        assertFalse(SSLPinningConfig.hasPrimaryPin("api-test.kommunicate.io", primary))
+    }
+
+    @Test
+    fun createsSha256SpkiPinFromPublicKey() {
+        val publicKey = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }
+            .generateKeyPair().public
+        val expected = Base64.encodeToString(
+            MessageDigest.getInstance("SHA-256").digest(publicKey.encoded),
+            Base64.NO_WRAP
+        )
+
+        assertEquals(expected, SSLPinningConfig.publicKeyPin(publicKey))
+    }
+
+    @Test
+    fun verifierAcceptsPrimaryPin() {
+        val fixture = verifierFixture()
+
+        assertTrue(fixture.verifier.verify(fixture.hostname, sessionWith(fixture.primaryKey)))
+    }
+
+    @Test
+    fun verifierAcceptsBackupPin() {
+        val fixture = verifierFixture()
+
+        assertTrue(fixture.verifier.verify(fixture.hostname, sessionWith(fixture.backupKey)))
+    }
+
+    @Test
+    fun verifierRejectsUnknownPin() {
+        val fixture = verifierFixture()
+        val unknownKey = generatePublicKey()
+
+        assertFalse(fixture.verifier.verify(fixture.hostname, sessionWith(unknownKey)))
+    }
+
+    @Test
+    fun verifierUsesPlatformValidationForNonKommunicateHost() {
+        val fixture = verifierFixture()
+        val unknownKey = generatePublicKey()
+
+        assertTrue(fixture.verifier.verify("storage.googleapis.com", sessionWith(unknownKey)))
+
+        val rejectingPlatformVerifier = HostnameVerifier { _, _ -> false }
+        val verifier = SSLPinningConfig.createHostnameVerifier(
+            rejectingPlatformVerifier,
+            fixture.hostPins,
+            emptySet()
+        )
+        assertFalse(verifier.verify("storage.googleapis.com", sessionWith(unknownKey)))
+    }
+
+    private fun verifierFixture(): VerifierFixture {
+        val hostname = "api.kommunicate.io"
+        val primaryKey = generatePublicKey()
+        val backupKey = generatePublicKey()
+        val hostPins = mapOf(
+            hostname to SSLPinningConfig.PinSet(
+                SSLPinningConfig.publicKeyPin(primaryKey),
+                SSLPinningConfig.publicKeyPin(backupKey)
+            )
+        )
+        val verifier = SSLPinningConfig.createHostnameVerifier(
+            HostnameVerifier { _, _ -> true },
+            hostPins,
+            emptySet()
+        )
+        return VerifierFixture(hostname, primaryKey, backupKey, hostPins, verifier)
+    }
+
+    private fun sessionWith(publicKey: PublicKey): SSLSession {
+        val certificate = mock(X509Certificate::class.java)
+        `when`(certificate.publicKey).thenReturn(publicKey)
+        val session = mock(SSLSession::class.java)
+        `when`(session.peerCertificates).thenReturn(arrayOf(certificate))
+        return session
+    }
+
+    private fun generatePublicKey(): PublicKey =
+        KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }
+            .generateKeyPair().public
+
+    private data class VerifierFixture(
+        val hostname: String,
+        val primaryKey: PublicKey,
+        val backupKey: PublicKey,
+        val hostPins: Map<String, SSLPinningConfig.PinSet>,
+        val verifier: HostnameVerifier
+    )
+}

--- a/kommunicate/src/test/java/io/kommunicate/services/KmClientServiceTest.kt
+++ b/kommunicate/src/test/java/io/kommunicate/services/KmClientServiceTest.kt
@@ -1,0 +1,57 @@
+package io.kommunicate.services
+
+import io.kommunicate.BuildConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class KmClientServiceTest {
+
+    @Test
+    fun regionalApiHostsMapToValidDashboardAndHelpCenterUrls() {
+        val arrays = readUrlArrays()
+        val apiUrls = arrays.getValue("km_base_url")
+        val dashboardUrls = arrays.getValue("km_dashboard_url")
+        val helpCenterUrls = arrays.getValue("km_helpcenter_url")
+
+        assertEquals(apiUrls.size, dashboardUrls.size)
+        assertEquals(apiUrls.size, helpCenterUrls.size)
+
+        listOf(BuildConfig.EU_API_SERVER_URL, "https://api-in.kommunicate.io").forEach { apiUrl ->
+            val index = apiUrls.indexOf(apiUrl)
+            assertTrue("Missing regional API mapping for $apiUrl", index >= 0)
+            assertEquals("https://dashboard.kommunicate.io", dashboardUrls[index])
+            assertEquals("https://helpcenter.kommunicate.io", helpCenterUrls[index])
+        }
+    }
+
+    private fun readUrlArrays(): Map<String, List<String>> {
+        val workingDirectory = System.getProperty("user.dir")
+            ?: error("Unable to determine working directory")
+        val root = generateSequence(File(workingDirectory).canonicalFile) {
+            it.parentFile
+        }.firstOrNull { File(it, "settings.gradle").isFile }
+            ?: error("Unable to locate repository root")
+        val source = File(root, "kommunicate/src/main/res/values/km_urls.xml")
+
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            isXIncludeAware = false
+            isExpandEntityReferences = false
+        }
+        val arrays = factory.newDocumentBuilder().parse(source).getElementsByTagName("string-array")
+
+        return (0 until arrays.length).associate { index ->
+            val array = arrays.item(index) as Element
+            val items = array.getElementsByTagName("item")
+            array.getAttribute("name") to (0 until items.length).map { itemIndex ->
+                items.item(itemIndex).textContent.trim()
+            }
+        }
+    }
+}

--- a/kommunicate/src/testRelease/java/io/kommunicate/network/SSLPinningPinInventoryTest.kt
+++ b/kommunicate/src/testRelease/java/io/kommunicate/network/SSLPinningPinInventoryTest.kt
@@ -1,0 +1,64 @@
+package io.kommunicate.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class SSLPinningPinInventoryTest {
+
+    @Test
+    fun kotlinAndReleaseXmlPinInventoriesMatch() {
+        val kotlinInventory = SSLPinningConfig.pinInventory()
+
+        releaseNetworkSecurityConfigs().forEach { config ->
+            val xmlInventory = parsePinInventory(config)
+            assertEquals("Host or pin mismatch in ${config.path}", kotlinInventory, xmlInventory)
+            assertTrue(
+                "Every host must have distinct primary and backup pins in ${config.path}",
+                xmlInventory.values.all { pins -> pins.size == 2 }
+            )
+        }
+    }
+
+    private fun releaseNetworkSecurityConfigs(): List<File> {
+        val workingDirectory = System.getProperty("user.dir")
+            ?: error("Unable to determine working directory")
+        val root = generateSequence(File(workingDirectory).canonicalFile) {
+            it.parentFile
+        }.firstOrNull { File(it, "settings.gradle").isFile }
+            ?: error("Unable to locate repository root")
+
+        return listOf("app", "kommunicate", "kommunicateui").map { module ->
+            File(root, "$module/src/release/res/xml/network_security_config.xml").also {
+                check(it.isFile) { "Missing release network security config: ${it.path}" }
+            }
+        }
+    }
+
+    private fun parsePinInventory(config: File): Map<String, Set<String>> {
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            setFeature("http://xml.org/sax/features/external-general-entities", false)
+            setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            isXIncludeAware = false
+            isExpandEntityReferences = false
+        }
+        val document = factory.newDocumentBuilder().parse(config)
+        val domainConfigs = document.getElementsByTagName("domain-config")
+
+        return (0 until domainConfigs.length).associate { index ->
+            val domainConfig = domainConfigs.item(index) as Element
+            val domains = domainConfig.getElementsByTagName("domain")
+            check(domains.length == 1) { "Expected one exact domain in ${config.path}" }
+            val host = domains.item(0).textContent.trim()
+            val pinNodes = domainConfig.getElementsByTagName("pin")
+            val pins = (0 until pinNodes.length)
+                .map { pinIndex -> pinNodes.item(pinIndex).textContent.trim() }
+                .toSet()
+            host to pins
+        }
+    }
+}

--- a/kommunicate/src/testRelease/java/io/kommunicate/network/SSLPinningReleaseEnforcementTest.kt
+++ b/kommunicate/src/testRelease/java/io/kommunicate/network/SSLPinningReleaseEnforcementTest.kt
@@ -1,0 +1,12 @@
+package io.kommunicate.network
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SSLPinningReleaseEnforcementTest {
+
+    @Test
+    fun releaseBuildAlwaysEnforcesPinning() {
+        assertTrue(SSLPinningConfig.isPinningEnabled())
+    }
+}

--- a/kommunicateui/src/release/res/xml/network_security_config.xml
+++ b/kommunicateui/src/release/res/xml/network_security_config.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">TVBTCkZ55/FSdN5KDEWeF6aQMEsf4tmuHbQy92W4OuY=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">gY8gSDmi6lg/wV1MbM3FzNMYrcX6EKseYfJg7QnA02A=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">cqN64LYMqSbYAlnj5gqix01wTHc4f+IFGOe68iV7LHY=</pin>
+            <pin digest="SHA-256">LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">api-in.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">1zJGg1EdjGEFdxqpA0bNZoXNomD9oXfxci/SmbWp7e0=</pin>
+            <pin digest="SHA-256">brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">MpB2iHEUO7nmKSdp/YuWdkjSP9hp7Ax7P/9c9jeGQO4=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-test.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">eWPDImElk5nVbsn19Uz9VXDUVfPispeX5ZlINItM/7c=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">chat-eu.kommunicate.io</domain>
+        <pin-set>
+            <pin digest="SHA-256">w/h1ivN8L5msp4gPmxqFr2qqqb+dvxG+XGd8XDatx+s=</pin>
+            <pin digest="SHA-256">OdSlmQD9NWJh4EbcOHBxkhygPwNSwA9Q91eounfbcoE=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION

## Description

This PR strengthens HTTPS certificate validation in response to the VAPT SSL pinning finding (CWE-295).

## Changes

- Added host-specific SPKI pinning for supported Kommunicate API and chat domains.
- Added primary and backup pins for certificate rotation.
- Retained Android’s normal certificate and hostname validation.
- Made pinning mandatory in release builds.
- Applied pinning to API, conversation, upload and download connections.
- Added release-only Network Security Configuration pin sets.
- Deprecated `Kommunicate.enableSSLPinning()`.
- Retired the non-resolving `api-ca.kommunicate.io` endpoint.
- Added enforcement tests and certificate-rotation documentation.

## Validation

- Passed debug and release unit tests.
- Built the Kommunicate release AAR successfully.
- Built and linted the minified sample release successfully.
- Verified unknown pins are rejected and primary/backup pins are accepted.

## Known Limitation

Frida on a rooted device can bypass many client-side protections. This change blocks normal user-installed CA interception and increases resistance but does not claim pinning is impossible to bypass.

Applications overriding `android:networkSecurityConfig` must merge the Kommunicate release pin sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened Android network security by disabling cleartext traffic and enforcing certificate pinning for supported production and regional services.
  * Preserved standard platform TLS validation for external and unlisted hosts.
  * Release builds now always enforce SSL pinning; debug behavior remains configurable.

* **Bug Fixes**
  * Prevented invalid or unmapped service URLs from causing runtime indexing errors.
  * Removed retired Canada-specific service endpoints.

* **Documentation**
  * Added guidance for certificate rotation, verification, and release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->