### PR TITLE
Release 2.16.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation project(':kommunicateui')
-//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.7'
+//    implementation 'io.kommunicate.sdk:kommunicateui:2.16.8'
     implementation libs.appcompat
     implementation libs.core.ktx
     implementation libs.retrofit

--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 36
         versionCode 1
-        versionName "2.16.7"
+        versionName "2.16.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "KOMMUNICATE_VERSION", "\"" + versionName + "\""
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdkVersion 36
         minSdkVersion 23
         versionCode 1
-        versionName "2.16.7"
+        versionName "2.16.8"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "KOMMUNICATE_UI_VERSION", "\"" + versionName + "\""
@@ -39,7 +39,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(':kommunicate')
-//    api 'io.kommunicate.sdk:kommunicate:2.16.7'
+//    api 'io.kommunicate.sdk:kommunicate:2.16.8'
     api libs.firebase.messaging
     api libs.play.services.maps
     api libs.gms.play.services.location

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -1922,16 +1922,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             @Override
             public void run() {
                 //Todo: Handle disappearing messages.
+                boolean existingMessage = messageList.contains(message);
                 boolean added = updateMessageList(message, false);
                 if (added) {
                     //Todo: update unread count
                     recyclerDetailConversationAdapter.updateLastSentMessage(message);
                     recyclerDetailConversationAdapter.notifyDataSetChanged();
-                    if (isFollowingNewMessages || message.isTypeOutbox()) {
-                        scrollToLatestMessage();
-                    } else {
-                        showNewMessagesButton();
-                    }
                     emptyTextView.setVisibility(View.GONE);
                     currentConversationId = message.getConversationId();
                     channelKey = message.getGroupId();
@@ -1946,6 +1942,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         } catch (Exception e) {
                             Utils.printLog(getContext(), TAG, "Got exception while read");
                         }
+                    }
+                }
+                if (added || existingMessage) {
+                    if (isFollowingNewMessages || message.isTypeOutbox()) {
+                        scrollToLatestMessage();
+                    } else {
+                        showNewMessagesButton();
                     }
                 }
                 selfDestructMessage(message);

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -576,6 +576,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         individualMessageSendLayout.setBackgroundColor(themeHelper.parseColorWithDefault(
                 customizationSettings.getMessageEditTextBackgroundColor().get(isDarkModeEnabled ? 1 : 0), currentModeColor
         ));
+        if (newMessagesButton != null && newMessagesButton.getBackground() != null) {
+            newMessagesButton.getBackground().mutate().setTint(themeHelper.getToolbarColor());
+        }
         setupDotColorStatus();
         if (recyclerDetailConversationAdapter != null) {
             recyclerDetailConversationAdapter.setupDarkMode(isDarkModeEnabled);
@@ -644,14 +647,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         startNewConv = list.findViewById(R.id.start_new_conversation);
         startNewConv.setVisibility(GONE);
         newMessagesButton = list.findViewById(R.id.new_messages_button);
-        newMessagesButton.getBackground().mutate().setTint(themeHelper.getToolbarColor());
         newMessagesButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 smoothScrollToLatestMessage();
             }
         });
-        isFollowingNewMessages = true;
+        resetNewMessageNavigation();
         customToolbarLayout = toolbar.findViewById(R.id.custom_toolbar_root_layout);
         loggedInUserId = MobiComUserPreference.getInstance(getContext()).getUserId();
 
@@ -800,6 +802,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     BroadcastService.currentConversationId = conversation.getId();
                     if (onSelected) {
                         currentConversationId = conversation.getId();
+                        resetNewMessageNavigation();
                         if (messageList != null) {
                             messageList.clear();
                         }
@@ -1810,6 +1813,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         this.getActivity().runOnUiThread(new Runnable() {
             @Override
             public void run() {
+                resetNewMessageNavigation();
                 if (recyclerDetailConversationAdapter != null) {
                     messageList.clear();
                     if (messageList.isEmpty()) {
@@ -2850,6 +2854,12 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         if (newMessagesButton != null) {
             newMessagesButton.setVisibility(GONE);
         }
+    }
+
+    private void resetNewMessageNavigation() {
+        isFollowingNewMessages = true;
+        isScrollInteractionInProgress = false;
+        hideNewMessagesButton();
     }
 
     @Override

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -648,7 +648,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         newMessagesButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                scrollToLatestMessage();
+                smoothScrollToLatestMessage();
             }
         });
         isFollowingNewMessages = true;
@@ -2828,6 +2828,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         hideNewMessagesButton();
         if (linearLayoutManager != null && !messageList.isEmpty()) {
             linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
+        }
+    }
+
+    private void smoothScrollToLatestMessage() {
+        isFollowingNewMessages = true;
+        hideNewMessagesButton();
+        if (recyclerView != null && recyclerView.getAdapter() != null
+                && recyclerView.getAdapter().getItemCount() > 0) {
+            recyclerView.smoothScrollToPosition(recyclerView.getAdapter().getItemCount() - 1);
         }
     }
 

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -419,6 +419,9 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
     private List<String> localTeams;
     private RelativeLayout faqButtonLayout;
     private Button startNewConv;
+    private Button newMessagesButton;
+    private boolean isFollowingNewMessages = true;
+    private boolean isScrollInteractionInProgress;
     private static final String KMEVENT = "KM_EVENT";
     private static final String QUICK_REPLY_CLICK = "QUICKREPLY_CLICK";
     private static final String SKIP_BOT = "skipBot";
@@ -640,6 +643,15 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         frameLayoutProgressbar = list.findViewById(R.id.idProgressBarLayout);
         startNewConv = list.findViewById(R.id.start_new_conversation);
         startNewConv.setVisibility(GONE);
+        newMessagesButton = list.findViewById(R.id.new_messages_button);
+        newMessagesButton.getBackground().mutate().setTint(themeHelper.getToolbarColor());
+        newMessagesButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                scrollToLatestMessage();
+            }
+        });
+        isFollowingNewMessages = true;
         customToolbarLayout = toolbar.findViewById(R.id.custom_toolbar_root_layout);
         loggedInUserId = MobiComUserPreference.getInstance(getContext()).getUserId();
 
@@ -1046,11 +1058,29 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                 if (recyclerDetailConversationAdapter != null) {
                     recyclerDetailConversationAdapter.contactImageLoader.setPauseWork(newState == RecyclerView.SCROLL_STATE_DRAGGING);
                 }
+                if (newState == RecyclerView.SCROLL_STATE_DRAGGING
+                        || newState == RecyclerView.SCROLL_STATE_SETTLING) {
+                    isScrollInteractionInProgress = true;
+                } else if (isScrollInteractionInProgress) {
+                    if (!recyclerView.canScrollVertically(1)) {
+                        isFollowingNewMessages = true;
+                        hideNewMessagesButton();
+                    }
+                    isScrollInteractionInProgress = false;
+                }
             }
 
             @Override
             public void onScrolled(final RecyclerView recyclerView, int dx, int dy) {
                 //super.onScrolled(recyclerView, dx, dy);
+                if (isScrollInteractionInProgress) {
+                    if (dy < 0) {
+                        isFollowingNewMessages = false;
+                    } else if (!recyclerView.canScrollVertically(1)) {
+                        isFollowingNewMessages = true;
+                        hideNewMessagesButton();
+                    }
+                }
                 if (loadMore) {
                     int topRowVerticalPosition =
                             (recyclerView == null || recyclerView.getChildCount() == 0) ?
@@ -1893,7 +1923,11 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     //Todo: update unread count
                     recyclerDetailConversationAdapter.updateLastSentMessage(message);
                     recyclerDetailConversationAdapter.notifyDataSetChanged();
-                    linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
+                    if (isFollowingNewMessages || message.isTypeOutbox()) {
+                        scrollToLatestMessage();
+                    } else {
+                        showNewMessagesButton();
+                    }
                     emptyTextView.setVisibility(View.GONE);
                     currentConversationId = message.getConversationId();
                     channelKey = message.getGroupId();
@@ -2789,6 +2823,26 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         return toAdd;
     }
 
+    private void scrollToLatestMessage() {
+        isFollowingNewMessages = true;
+        hideNewMessagesButton();
+        if (linearLayoutManager != null && !messageList.isEmpty()) {
+            linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
+        }
+    }
+
+    private void showNewMessagesButton() {
+        if (newMessagesButton != null) {
+            newMessagesButton.setVisibility(VISIBLE);
+        }
+    }
+
+    private void hideNewMessagesButton() {
+        if (newMessagesButton != null) {
+            newMessagesButton.setVisibility(GONE);
+        }
+    }
+
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
@@ -3322,8 +3376,10 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             Message typingMessage = new Message();
             typingMessage.setTypingMessage();
             messageList.add(typingMessage);
-            linearLayoutManager.scrollToPosition(messageList.size() - 1);
             recyclerDetailConversationAdapter.onItemInserted(messageList.size() - 1);
+            if (isFollowingNewMessages) {
+                linearLayoutManager.scrollToPosition(messageList.size() - 1);
+            }
         } else {
             try {
                 int position;

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -1065,8 +1065,8 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                         || newState == RecyclerView.SCROLL_STATE_SETTLING) {
                     isScrollInteractionInProgress = true;
                 } else if (isScrollInteractionInProgress) {
-                    if (!recyclerView.canScrollVertically(1)) {
-                        isFollowingNewMessages = true;
+                    isFollowingNewMessages = !recyclerView.canScrollVertically(1);
+                    if (isFollowingNewMessages) {
                         hideNewMessagesButton();
                     }
                     isScrollInteractionInProgress = false;

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -5284,7 +5284,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
             kmAwayView.setVisibility(show && customizationSettings.isEnableAwayMessage() ? VISIBLE : GONE);
         }
         //don't hide any message if away view is visible
-        if (show && customizationSettings.isEnableAwayMessage()) {
+        if (show && customizationSettings.isEnableAwayMessage() && isFollowingNewMessages) {
             linearLayoutManager.scrollToPosition(messageList.size() - 1);
         }
     }

--- a/kommunicateui/src/main/res/drawable/km_ic_arrow_down.xml
+++ b/kommunicateui/src/main/res/drawable/km_ic_arrow_down.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/km_white_color"
+        android:pathData="M11,4h2v12.17l5.59,-5.58L20,12l-8,8 -8,-8 1.41,-1.41L11,16.17z" />
+</vector>

--- a/kommunicateui/src/main/res/drawable/km_new_messages_button_background.xml
+++ b/kommunicateui/src/main/res/drawable/km_new_messages_button_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="@color/core_theme_color_primary" />
+</shape>

--- a/kommunicateui/src/main/res/layout/message_list.xml
+++ b/kommunicateui/src/main/res/layout/message_list.xml
@@ -121,6 +121,28 @@
                 android:textColor="@color/default_start_new_button_text_color"
                 android:textSize="14sp"
                 android:visibility="visible" />
+
+            <Button
+                android:id="@+id/new_messages_button"
+                android:layout_width="wrap_content"
+                android:layout_height="40dp"
+                android:layout_alignParentBottom="true"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="16dp"
+                android:background="@drawable/km_new_messages_button_background"
+                android:drawableEnd="@drawable/km_ic_arrow_down"
+                android:drawablePadding="8dp"
+                android:drawableTint="@color/km_white_color"
+                android:elevation="4dp"
+                android:fontFamily="sans-serif-medium"
+                android:minWidth="0dp"
+                android:paddingStart="16dp"
+                android:paddingEnd="12dp"
+                android:text="@string/km_new_messages"
+                android:textAllCaps="false"
+                android:textColor="@color/km_white_color"
+                android:textSize="14sp"
+                android:visibility="gone" />
         </RelativeLayout>
 
         <TextView

--- a/kommunicateui/src/main/res/values/core_strings.xml
+++ b/kommunicateui/src/main/res/values/core_strings.xml
@@ -9,6 +9,7 @@
     <string name="group_name_hint">Name of the group</string>
     <string name="empty_conversations">No conversations!</string>
     <string name="enter_message_hint">Type your message...</string>
+    <string name="km_new_messages">New messages</string>
     <string name="send_text">SEND</string>
     <string name="cancel_text">CANCEL</string>
     <string name="ok_text">OK</string>


### PR DESCRIPTION
## Title

TDH-3504: Add new-message navigation to conversation screen

## Description

Prevents the conversation screen from automatically scrolling to the bottom when new messages arrive while the user is reading older messages.

## Changes

- Added a “New messages” button above the message composer.
- Preserved the user’s scroll position for incoming messages.
- Added click behavior to navigate to the latest message.
- Kept auto-scroll when the user is already at the bottom.
- Kept auto-scroll when sending a message or opening the keyboard.
- Prevented typing indicators and agent-transfer updates from forcing a scroll.
- Applied the configured toolbar color to the button.
- Added a downward-arrow icon matching the existing UI style.

## Testing

- Verified normal incoming messages.
- Verified token-by-token bot responses.
- Verified scrolling while reading older messages.
- Verified new-message button navigation.
- Verified agent typing indicators.
- Verified agent-transfer messages.
- Verified outgoing messages and keyboard behavior.
- Verified compilation and Android lint.

Add this section to the PR:

## Screenshots and Video

Attached screenshots and a sample video demonstrating:

- Scroll position preserved while reading older messages.
- “New messages” button displayed for incoming messages.
- Navigation to the latest message when the button is tapped.
- Behavior during token-by-token bot responses and agent transfers.

<img width="576" height="1280" alt="a7a172ad-6472-4d30-b033-c0f924837906" src="https://github.com/user-attachments/assets/e99e9585-55af-4dc2-8b6a-a526332883bb" />

<img width="576" height="1280" alt="new msg" src="https://github.com/user-attachments/assets/d4221764-efee-42ce-a05f-36e592c917d5" />

https://github.com/user-attachments/assets/d76c9da8-addc-4783-9fe3-082e23b67ff6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “New messages” button to conversations when newer messages arrive while viewing older content.
  * Tapping the button smoothly returns to the latest messages.
  * Improved scrolling behavior for incoming messages, typing indicators, and away messages.
* **Chores**
  * Updated the SDK and UI library release version to 2.16.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->