### PR TITLE
TDH-4222 Fixes conversation-screen crashes and improves new-message navigation behavior.

### DIFF
--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -647,12 +647,14 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         startNewConv = list.findViewById(R.id.start_new_conversation);
         startNewConv.setVisibility(GONE);
         newMessagesButton = list.findViewById(R.id.new_messages_button);
-        newMessagesButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                smoothScrollToLatestMessage();
-            }
-        });
+        if (newMessagesButton != null) {
+            newMessagesButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    smoothScrollToLatestMessage();
+                }
+            });
+        }
         resetNewMessageNavigation();
         customToolbarLayout = toolbar.findViewById(R.id.custom_toolbar_root_layout);
         loggedInUserId = MobiComUserPreference.getInstance(getContext()).getUserId();

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -1947,7 +1947,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     }
                 }
                 if (added || existingMessage) {
-                    if (isFollowingNewMessages || message.isTypeOutbox()) {
+                    if (isFollowingNewMessages) {
                         scrollToLatestMessage();
                     } else {
                         showNewMessagesButton();
@@ -2740,9 +2740,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                             }
                         } else if (!message.isVideoNotificationMessage() && !message.isHidden()) {
                             messageList.add(message);
-                            linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
                             emptyTextView.setVisibility(View.GONE);
                             recyclerDetailConversationAdapter.notifyDataSetChanged();
+                            if (isFollowingNewMessages) {
+                                scrollToLatestMessage();
+                            } else {
+                                showNewMessagesButton();
+                            }
                         }
                     } catch (Exception ex) {
                         Utils.printLog(getContext(), TAG, "Exception while updating delivery status in UI.");


### PR DESCRIPTION
## Summary

Fixes conversation-screen crashes and improves new-message navigation behavior.

## Changes

- Added a null check for `new_messages_button` to support custom or older conversation layouts.
- Prevented message updates from automatically scrolling users to the bottom.
- Shows the new-message button when the user is viewing older messages.

## Testing

- Tested conversation flow in the Agent App.
- Verified custom layouts without `new_messages_button` no longer crash.
- Verified new-message scrolling and navigation behavior.
- Confirmed `kommunicateui` compiles successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scrolling behavior when new messages arrive.
  * Outgoing messages no longer force the conversation to scroll to the latest message.
  * The new-messages button is now shown when users are not following the latest messages.
  * Added safeguards to prevent errors when the new-messages button is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->