### PR TITLE
Release 2.16.9

### DIFF
--- a/kommunicate/build.gradle
+++ b/kommunicate/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 36
         versionCode 1
-        versionName "2.16.8"
+        versionName "2.16.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField "String", "KOMMUNICATE_VERSION", "\"" + versionName + "\""
         buildConfigField "String", "CHAT_SERVER_URL", '"https://chat.kommunicate.io"'

--- a/kommunicateui/build.gradle
+++ b/kommunicateui/build.gradle
@@ -15,7 +15,7 @@ android {
         targetSdkVersion 36
         minSdkVersion 23
         versionCode 1
-        versionName "2.16.8"
+        versionName "2.16.9"
         consumerProguardFiles 'proguard-rules.txt'
         vectorDrawables.useSupportLibrary = true
         buildConfigField "String", "KOMMUNICATE_UI_VERSION", "\"" + versionName + "\""
@@ -58,6 +58,7 @@ dependencies {
     implementation "io.noties.markwon:core:4.6.2"
     implementation "io.noties.markwon:html:4.6.2"
     implementation "io.noties.markwon:ext-strikethrough:4.6.2"
+    testImplementation libs.junit
 }
 
 task sourcesJar(type: Jar) {

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -647,12 +647,14 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
         startNewConv = list.findViewById(R.id.start_new_conversation);
         startNewConv.setVisibility(GONE);
         newMessagesButton = list.findViewById(R.id.new_messages_button);
-        newMessagesButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                smoothScrollToLatestMessage();
-            }
-        });
+        if (newMessagesButton != null) {
+            newMessagesButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    smoothScrollToLatestMessage();
+                }
+            });
+        }
         resetNewMessageNavigation();
         customToolbarLayout = toolbar.findViewById(R.id.custom_toolbar_root_layout);
         loggedInUserId = MobiComUserPreference.getInstance(getContext()).getUserId();

--- a/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
+++ b/kommunicateui/src/main/java/io/kommunicate/ui/conversation/fragment/MobiComConversationFragment.java
@@ -1947,7 +1947,7 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                     }
                 }
                 if (added || existingMessage) {
-                    if (isFollowingNewMessages || message.isTypeOutbox()) {
+                    if (isFollowingNewMessages) {
                         scrollToLatestMessage();
                     } else {
                         showNewMessagesButton();
@@ -2740,9 +2740,13 @@ public abstract class MobiComConversationFragment extends Fragment implements Vi
                             }
                         } else if (!message.isVideoNotificationMessage() && !message.isHidden()) {
                             messageList.add(message);
-                            linearLayoutManager.scrollToPositionWithOffset(messageList.size() - 1, 0);
                             emptyTextView.setVisibility(View.GONE);
                             recyclerDetailConversationAdapter.notifyDataSetChanged();
+                            if (isFollowingNewMessages) {
+                                scrollToLatestMessage();
+                            } else {
+                                showNewMessagesButton();
+                            }
                         }
                     } catch (Exception ex) {
                         Utils.printLog(getContext(), TAG, "Exception while updating delivery status in UI.");


### PR DESCRIPTION
## Summary

- Prevent a crash when the new-message button is unavailable in a custom layout.
- Preserve the user’s scroll position when new messages arrive.
- Show the new-message button when the user is viewing older messages.
- Auto-scroll only when the user is already following the latest messages.
- Bump the SDK and UI versions to `2.16.9`.

## Testing

- Verified conversation navigation with incoming and outgoing messages.
- Verified custom layouts without the new-message button do not crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scrolling to avoid unexpectedly moving users away from their current position.
  * New incoming messages now display a notification button when users aren’t following the latest messages.
  * Prevented potential issues when interacting with the new messages control.

* **Release**
  * Updated the Android library version to 2.16.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->